### PR TITLE
Return an error when the type of the payload is not supported by *contex.Bind()

### DIFF
--- a/context.go
+++ b/context.go
@@ -2,6 +2,7 @@ package echo
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 )
@@ -38,7 +39,8 @@ func (c *Context) Bind(i interface{}) bool {
 		dec := json.NewDecoder(c.Request.Body)
 		err = dec.Decode(i)
 	} else {
-		// TODO:
+		// TODO: add more payload types
+		err = errors.New("Unsupported payload type")
 	}
 	if err != nil {
 		c.echo.internalServerErrorHandler(c)


### PR DESCRIPTION
Instead of returning like everything is normal, the Bind() method returns an error when the `Content-Type` of the request payload is not supported. Just a better way to manage unsupported cases. 