### PR TITLE
Added tests to `TestEchoURL()` test to show that the `URL()` and `URI()`...

### DIFF
--- a/echo_test.go
+++ b/echo_test.go
@@ -239,9 +239,15 @@ func TestEchoURL(t *testing.T) {
 	static := func(*Context) {}
 	getUser := func(*Context) {}
 	getFile := func(*Context) {}
+	getGroups := func(*Context) {}a
+	getGroup := func(*Context) {}
+
 	e.Get("/static/file", static)
 	e.Get("/users/:id", getUser)
 	e.Get("/users/:uid/files/:fid", getFile)
+
+	eg := e.Group("/groups")
+	eg.Get("/:id", getGroup)
 
 	if e.URL(static) != "/static/file" {
 		t.Error("uri should be /static/file")
@@ -260,6 +266,12 @@ func TestEchoURL(t *testing.T) {
 	}
 	if e.URI(getFile, "1", "1") != "/users/1/files/1" {
 		t.Error("uri should be /users/1/files/1")
+	}
+	if e.URI(getGroups) != "/groups" {
+		t.Error("uri should be /groups")
+	}
+	if e.URI(getGroup, "1") != "/groups/1" {
+		t.Error("uri should be /groups/1")
 	}
 }
 


### PR DESCRIPTION
This is related to labstack/echo#12.

I created two new tests in the `TestEchoURL()` method

1. The first test used `URI()` without passing any additional arguments aside from the handler.
2. The second test uses `URI()` with passing a single argument.

Both tests fail and show that when you pass a hander into the `URI()` method that was used in a `Group()`, it does not show the full path of the group path + handler path.