### PR TITLE
Added fix for instance of Echo that have a prefix (created with `Group()...

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -251,7 +251,7 @@ func (e *Echo) URI(h Handler, params ...string) string {
 			}
 		}
 	}
-	return uri.String()
+	return e.prefix + uri.String()
 }
 
 // URL is an alias for URI

--- a/echo_test.go
+++ b/echo_test.go
@@ -239,9 +239,15 @@ func TestEchoURL(t *testing.T) {
 	static := func(*Context) {}
 	getUser := func(*Context) {}
 	getFile := func(*Context) {}
+	getGroups := func(*Context) {}
+	getGroup := func(*Context) {}
+
 	e.Get("/static/file", static)
 	e.Get("/users/:id", getUser)
 	e.Get("/users/:uid/files/:fid", getFile)
+
+	eg := e.Group("/groups")
+	eg.Get("/:id", getGroup)
 
 	if e.URL(static) != "/static/file" {
 		t.Error("uri should be /static/file")
@@ -260,6 +266,18 @@ func TestEchoURL(t *testing.T) {
 	}
 	if e.URI(getFile, "1", "1") != "/users/1/files/1" {
 		t.Error("uri should be /users/1/files/1")
+	}
+	if e.URI(getGroups) != "/groups" {
+		t.Error("uri should be /groups")
+	}
+	if e.URI(getGroup, "1") != "/groups/1" {
+		t.Error("uri should be /groups/1")
+	}
+	if eg.URI(getGroups) != "/groups" {
+		t.Error("uri should be /groups")
+	}
+	if eg.URI(getGroup, "1") != "/groups/1" {
+		t.Error("uri should be /groups/1")
 	}
 }
 


### PR DESCRIPTION
Added fix for instance of Echo that have a prefix (created with `Group() method). The `URI()` method should return prefix plus the calculated string.

This is related to labstack/echo/pull/36, I closed that pull request because this one contains a fix. This is also relates to labstack/echo#12
