### PR TITLE
Allow for nested grouping.

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -147,7 +147,7 @@ func New() (e *Echo) {
 // the parent. Passing middleware overrides parent middleware.
 func (e *Echo) Group(pfx string, m ...Middleware) *Echo {
 	g := *e
-	g.prefix = pfx
+	g.prefix = g.prefix + pfx
 	if len(m) > 0 {
 		g.middleware = nil
 		g.Use(m...)

--- a/echo_test.go
+++ b/echo_test.go
@@ -218,6 +218,19 @@ func TestEchoGroup(t *testing.T) {
 	if b.String() != "3" {
 		t.Errorf("should execute middleware 3, executed %s", b.String())
 	}
+
+	// Nested Group
+	g3 := e.Group("/group3")
+	g4 := g3.Group("/group4")
+	g4.Get("/test", func(c *Context) {
+		c.String(http.StatusOK, "okay")
+	})
+	w = httptest.NewRecorder()
+	r, _ = http.NewRequest(GET, "/group3/group4/test", nil)
+	e.ServeHTTP(w, r)
+	if w.Body.String() != "okay" {
+		t.Error("body should be okay")
+	}
 }
 
 func TestEchoMethod(t *testing.T) {


### PR DESCRIPTION
Hey I was having trouble structuring because I wanted to nest my groups but it wasnt working. Here is an example of what I wanted to do.

```go
	test_group := e.Group("/test")
	id_group := test_group.Group("/:id")
	id_group.Get("/foo.json", func(c *echo.Context) error {
		return c.JSON(200, map[string]string{"test": c.Param("id")})
	})
```
I was hoping to have the path "/test/other/test.json" but instead only "/other/test.json" worked. My pull request might be naive but it seems to all work this way(including with path variables) and I thought it would help more than just an open issue.
