### PR TITLE
Added Type HandlerFunc to wrapH

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -398,6 +398,8 @@ func wrapM(m Middleware) MiddlewareFunc {
 // wraps Handler
 func wrapH(h Handler) HandlerFunc {
 	switch h := h.(type) {
+	case HandlerFunc:
+		return h
 	case func(*Context):
 		return func(c *Context) error {
 			h(c)


### PR DESCRIPTION
This was done so that middleware can easily be used in the normal add context. This helps chaining middleware on single calls.  Here is a simple example of what I mean:

```go
func UserAuth(h echo.HandlerFunc) echo.HandlerFunc {
	return func(c *echo.Context) error {
                //do auth here
		return h(c)
	}
}

func ActionThatRequiresAuth(c *echo.Context) error {
	return c.JSON(200, map[string]string{})
}

func main(){
        e := echo.New()
	e.Get("/test", UserAuth(ActionThatRequiresAuth))
}
```

Through the typing of Handlerfunc we are sure that we don't need to wrap the handler, but it also makes a few things simpler to use. You could even chain multiple middleware like this:

```go
        e := echo.New()
	e.Get("/test", GetUser(UserAuth(GetBlogPost(ActionThatRequiresManyThings))))
```

Just this simple change could be very useful for code reuse.