### PR TITLE
Add MiddlewareFunc type support to echo.wrapM

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -392,6 +392,8 @@ func wrapM(m Middleware) MiddlewareFunc {
 				return h(c)
 			}
 		}
+	case MiddlewareFunc:
+		return m
 	default:
 		panic("echo: unknown middleware")
 	}

--- a/echo_test.go
+++ b/echo_test.go
@@ -102,6 +102,16 @@ func TestEchoMiddleware(t *testing.T) {
 		return nil
 	})
 
+	// echo.MiddlewareFunc
+	e.Use((func(i string) MiddlewareFunc {
+		return func(h HandlerFunc) HandlerFunc {
+			return func(c *Context) error {
+				b.WriteString(i)
+				return h(c)
+			}
+		}
+	})("i"))
+
 	// Route
 	e.Get("/hello", func(c *Context) {
 		c.String(http.StatusOK, "world")
@@ -110,8 +120,8 @@ func TestEchoMiddleware(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(GET, "/hello", nil)
 	e.ServeHTTP(w, r)
-	if b.String() != "abcdefgh" {
-		t.Errorf("buffer should be abcdefgh, found %s", b.String())
+	if b.String() != "abcdefghi" {
+		t.Errorf("buffer should be abcdefghi, found %s", b.String())
 	}
 	if w.Body.String() != "world" {
 		t.Error("body should be world")


### PR DESCRIPTION
I ran into a scenario where I wanted to create middleware like so:
```go
func Authenticate(ignorePaths []string) echo.MiddlewareFunc {
    return func(h echo.HandlerFunc) echo.HandlerFunc {
        // do stuff here
    }
}
```

Instead I needed to write:
```go
func Authenticate(ignorePaths []string) func(echo.HandlerFunc) echo.HandlerFunc {
    return func(h echo.HandlerFunc) echo.HandlerFunc {
        // do stuff here
    }
}
```

This is obviously not a big deal, but since there's an `echo.MiddlewareFunc` type, it'd be great to provide that type as middleware to echo.