### PR TITLE
Response reset size

### DIFF
--- a/response.go
+++ b/response.go
@@ -76,6 +76,7 @@ func (r *Response) Size() int64 {
 
 func (r *Response) reset(w http.ResponseWriter) {
 	r.writer = w
+	r.size = 0
 	r.status = http.StatusOK
 	r.committed = false
 }

--- a/response_test.go
+++ b/response_test.go
@@ -37,4 +37,10 @@ func TestResponse(t *testing.T) {
 	if r.Size() != int64(len(s)) {
 		t.Errorf("size should be %d", len(s))
 	}
+	
+	// reser
+	r.reset(httptest.NewRecorder())
+	if r.Size() != int64(0) {
+		t.Error("size should be 0")
+	}
 }


### PR DESCRIPTION
Very minor but the logged response size accumulated with each request producing the following for the 'hello world' example (note last column):

```
2015/05/27 20:46:49 GET / 200 0 14
2015/05/27 20:46:49 GET / 200 0 28
2015/05/27 20:46:49 GET / 200 0 42
2015/05/27 20:46:50 GET / 200 0 56
```

Setting the size to 0 when the response is reset produces the expected result:

```
2015/05/27 20:49:13 GET / 200 0 14
2015/05/27 20:49:14 GET / 200 0 14
2015/05/27 20:49:14 GET / 200 0 14
2015/05/27 20:49:14 GET / 200 0 14
```