### PR TITLE
Sub-Directory Index Support

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -338,7 +338,7 @@ func serveFile(dir, file string, c *Context) error {
 
 	fi, _ := f.Stat()
 	if fi.IsDir() {
-		f, err = fs.Open("index.html")
+		f, err = fs.Open(file + "/index.html")
 		if err != nil {
 			return NewHTTPError(http.StatusForbidden)
 		}

--- a/echo_test.go
+++ b/echo_test.go
@@ -78,8 +78,14 @@ func TestEchoStatic(t *testing.T) {
 
 	// Directory with index.html
 	e.Static("/", "examples/website/public")
-	c, _ = request(GET, "/", e)
+	c, r := request(GET, "/", e)
 	assert.Equal(t, http.StatusOK, c)
+	assert.Equal(t, true, strings.HasPrefix(r, "<!doctype html>"))
+
+	// Sub-directory with index.html
+	c, r = request(GET, "/folder", e)
+	assert.Equal(t, http.StatusOK, c)
+	assert.Equal(t, "sub directory", r)
 }
 
 func TestEchoMiddleware(t *testing.T) {

--- a/examples/website/public/folder/index.html
+++ b/examples/website/public/folder/index.html
@@ -1,0 +1,1 @@
+sub directory


### PR DESCRIPTION
Added the ability for sub-directories to have their `index.html` files referenced by default, and also removes the bug where sub-directories will render the root `index.html`

See issue #100 for more context. 