### PR TITLE
Enforce `LF` newlines

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# EditorConfig coding styles definitions. For more information about the
+# properties used in this file, please see the EditorConfig documentation:
+# http://editorconfig.org/
+
+# indicate this is the root of the project
+root = true
+
+[*]
+charset = utf-8
+
+end_of_line = LF
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.go]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,10 +2,9 @@
 # http://git-scm.com/docs/gitattributes#_end_of_line_conversion
 * text=auto
 
-# For the following file types, normalize line endings to LF on
-# checkin and prevent conversion to CRLF when they are checked out
-# (this is required in order to prevent newline related issues like,
-# for example, after the build script is run)
+# For the following file types, normalize line endings to LF on checking and
+# prevent conversion to CRLF when they are checked out (this is required in
+# order to prevent newline related issues)
 .*      text eol=lf
 *.go    text eol=lf
 *.yml   text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+# Automatically normalize line endings for all text-based files
+# http://git-scm.com/docs/gitattributes#_end_of_line_conversion
+* text=auto
+
+# For the following file types, normalize line endings to LF on
+# checkin and prevent conversion to CRLF when they are checked out
+# (this is required in order to prevent newline related issues like,
+# for example, after the build script is run)
+.*      text eol=lf
+*.go    text eol=lf
+*.yml   text eol=lf
+*.html  text eol=lf
+*.css   text eol=lf
+*.js    text eol=lf
+*.json  text eol=lf
+LICENSE text eol=lf
+
+# Exclude `website` and `examples` from Github's language statistics
+# https://github.com/github/linguist#using-gitattributes
+examples/* linguist-documentation
+website/* linguist-documentation


### PR DESCRIPTION
I know you prefer issues to be created before opening pull requests, but hopefully you'll see value in this.

* Prevents potential [newline](http://en.wikipedia.org/wiki/Newline) related problems with Windows.
* Removes `examples` and `website` from Github's language statistics count

This also adds an `.editorconfig` for those people who standardize around it for ease-of-coding standards (although `gofmt` should take care of this most of the time, other files like HTML and such aren't taken into account without it)