### PR TITLE
adding content-type sniffing

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -110,6 +110,7 @@ const (
 	ContentType        = "Content-Type"
 	Authorization      = "Authorization"
 	Upgrade            = "Upgrade"
+	Vary               = "Vary"
 
 	//-----------
 	// Protocols

--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -44,7 +44,7 @@ func Gzip() echo.MiddlewareFunc {
 
 	return func(h echo.HandlerFunc) echo.HandlerFunc {
 		return func(c *echo.Context) error {
-			c.Response().Header().Add("Vary", "Accept-Encoding")
+			c.Response().Header().Add(echo.Vary, echo.AcceptEncoding)
 			if strings.Contains(c.Request().Header.Get(echo.AcceptEncoding), scheme) {
 				w := gzip.NewWriter(c.Response().Writer())
 				defer w.Close()

--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -44,6 +44,7 @@ func Gzip() echo.MiddlewareFunc {
 
 	return func(h echo.HandlerFunc) echo.HandlerFunc {
 		return func(c *echo.Context) error {
+			c.Response().Header().Add("Vary", "Accept-Encoding")
 			if strings.Contains(c.Request().Header.Get(echo.AcceptEncoding), scheme) {
 				w := gzip.NewWriter(c.Response().Writer())
 				defer w.Close()

--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -1,16 +1,14 @@
 package middleware
 
 import (
+	"bufio"
 	"compress/gzip"
+	"io"
+	"net"
+	"net/http"
 	"strings"
 
-	"net/http"
-
-	"bufio"
-	"net"
-
 	"github.com/labstack/echo"
-	"io"
 )
 
 type (
@@ -21,6 +19,9 @@ type (
 )
 
 func (w gzipWriter) Write(b []byte) (int, error) {
+	if "" == w.Header().Get("Content-Type") {
+		w.Header().Set("Content-Type", http.DetectContentType(b))
+	}
 	return w.Writer.Write(b)
 }
 

--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -19,8 +19,8 @@ type (
 )
 
 func (w gzipWriter) Write(b []byte) (int, error) {
-	if "" == w.Header().Get("Content-Type") {
-		w.Header().Set("Content-Type", http.DetectContentType(b))
+	if "" == w.Header().Get(echo.ContentType) {
+		w.Header().Set(echo.ContentType, http.DetectContentType(b))
 	}
 	return w.Writer.Write(b)
 }


### PR DESCRIPTION
When using `mw.Gzip()` with responses that don't explicitly set `Content-Type`, it's being auto-detected by `gzipWriter` as `Content-Type: application/x-gzip`. This fixes that issue.

You can reproduce this issue with the following example:

```go
package main

import (
    "github.com/labstack/echo"
    mw "github.com/labstack/echo/middleware"
)

func hello(c *echo.Context) error {
    c.Response().Write([]byte("Hello World"))
    return nil
}

func main() {
    e := echo.New()

    e.Use(mw.Logger())
    e.Use(mw.Recover())
    e.Use(mw.Gzip())

    e.Get("/", hello)

    e.Run(":1323")
}
``` 