### PR TITLE
gzip flush coverage

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -25,8 +25,8 @@ func (w gzipWriter) Write(b []byte) (int, error) {
 	return w.Writer.Write(b)
 }
 
-func (w gzipWriter) Flush() {
-	w.Writer.(*gzip.Writer).Flush()
+func (w gzipWriter) Flush() error {
+	return w.Writer.(*gzip.Writer).Flush()
 }
 
 func (w gzipWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {


### PR DESCRIPTION
Adding test coverage to `gzip.Flush`.

Also, please note that I added `return` to the `Flush` function to expose any errors that might occur. This is entirely based on the [gzip_test.go](https://golang.org/src/compress/gzip/gzip_test.go#L161) provided by go, but tweaked to use `gzipWriter`