### PR TITLE
Context.Redirect now returns an error

### DIFF
--- a/context.go
+++ b/context.go
@@ -170,8 +170,9 @@ func (c *Context) NoContent(code int) error {
 }
 
 // Redirect redirects the request using http.Redirect with status code.
-func (c *Context) Redirect(code int, url string) {
+func (c *Context) Redirect(code int, url string) error {
 	http.Redirect(c.response, c.request, url, code)
+  return nil
 }
 
 // Error invokes the registered HTTP error handler. Generally used by middleware.

--- a/context_test.go
+++ b/context_test.go
@@ -139,7 +139,7 @@ func TestContext(t *testing.T) {
 	// Redirect
 	rec = httptest.NewRecorder()
 	c = NewContext(req, NewResponse(rec), New())
-	c.Redirect(http.StatusMovedPermanently, "http://labstack.github.io/echo")
+	assert.Equal(t, nil, c.Redirect(http.StatusMovedPermanently, "http://labstack.github.io/echo"))
 
 	// Error
 	rec = httptest.NewRecorder()


### PR DESCRIPTION
  Context.Redirect will now return nil allowing users to do:
```go
    return context.Redirect(...)
```
  rather that having to return nil everytime Redirect is used, ie:
```go
    context.Redirect(...)
    return nil
```

Note: This is a backwards compatible change. It should not break any existing code.