### PR TITLE
Relax content-type matching

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -59,7 +59,7 @@ func TestContext(t *testing.T) {
 	//------
 
 	// JSON
-	testBind(t, c, "application/json")
+	testBind(t, c, "application/json;charset=UTF-8")
 
 	// XML
 	c.request, _ = http.NewRequest(POST, "/", strings.NewReader(userXML))

--- a/echo.go
+++ b/echo.go
@@ -91,7 +91,9 @@ const (
 	// Media types
 	//-------------
 
+	applicationJSON     = "application/json"
 	ApplicationJSON     = "application/json; charset=utf-8"
+	applicationXML      = "application/xml"
 	ApplicationXML      = "application/xml; charset=utf-8"
 	ApplicationForm     = "application/x-www-form-urlencoded"
 	ApplicationProtobuf = "application/protobuf"
@@ -180,9 +182,9 @@ func New() (e *Echo) {
 	e.SetBinder(func(r *http.Request, v interface{}) error {
 		ct := r.Header.Get(ContentType)
 		err := UnsupportedMediaType
-		if strings.HasPrefix(ApplicationJSON, ct) {
+		if strings.HasPrefix(ct, applicationJSON) {
 			err = json.NewDecoder(r.Body).Decode(v)
-		} else if strings.HasPrefix(ApplicationXML, ct) {
+		} else if strings.HasPrefix(ct, applicationXML) {
 			err = xml.NewDecoder(r.Body).Decode(v)
 		}
 		return err


### PR DESCRIPTION
This relaxes the Content-Type header matching in the context.Bind method.

Angular 1.x sets the header to `application/json;charset=utf-8` (note the lack of any space after the `;`) so checking that the string `application/json; charset=utf-8` starts with that header fails which prevents Angular `$resource` or `$http` etc... being used without extra client work.

I think the match should be the other way round - check if the header starts with simpler `application/json` string instead and ignore anything else.

I added the `applicationJSON` const because `ApplicationJSON` is used for other things as well. It's not a very good name and should probably be called `ApplicationJSONPrefix` or something similar but probably shouldn't be exported. I'm sure there is some official Content-Type parsing / matching rule somewhere though so we should probably follow that.