### PR TITLE
More appropriate behaviour for Context.Redirect on invalid status code

### DIFF
--- a/context.go
+++ b/context.go
@@ -3,6 +3,7 @@ package echo
 import (
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"net/http"
 
 	"fmt"
@@ -26,6 +27,8 @@ type (
 	}
 	store map[string]interface{}
 )
+
+var InvalidRedirectCode  = errors.New("echo ⇒ invalid redirect status code")
 
 // NewContext creates a Context object.
 func NewContext(req *http.Request, res *Response, e *Echo) *Context {
@@ -170,7 +173,12 @@ func (c *Context) NoContent(code int) error {
 }
 
 // Redirect redirects the request using http.Redirect with status code.
-func (c *Context) Redirect(code int, url string) error {
+func (c *Context) Redirect(code int, url string) (err error) {
+	if code < http.StatusMultipleChoices || code > http.StatusTemporaryRedirect {
+		err = InvalidRedirectCode
+		c.response.clear()
+		return
+	}
 	http.Redirect(c.response, c.request, url, code)
 	return nil
 }

--- a/echo.go
+++ b/echo.go
@@ -184,15 +184,15 @@ func New() (e *Echo) {
 		http.Error(c.response, msg, code)
 	}
 	e.SetHTTPErrorHandler(e.defaultHTTPErrorHandler)
-	e.SetBinder(func(r *http.Request, v interface{}) error {
+	e.SetBinder(func(r *http.Request, v interface{}) (err error) {
 		ct := r.Header.Get(ContentType)
-		err := UnsupportedMediaType
+		err = UnsupportedMediaType
 		if strings.HasPrefix(ct, ApplicationJSON) {
 			err = json.NewDecoder(r.Body).Decode(v)
 		} else if strings.HasPrefix(ct, ApplicationXML) {
 			err = xml.NewDecoder(r.Body).Decode(v)
 		}
-		return err
+		return
 	})
 	return
 }


### PR DESCRIPTION
I came across this when responding to #150. Context.Redirect() is currently able to send a non-redirect status code (something outside the 300-307 range). I don't feel that this should be the case, it could potentially create a bug that is hard to track down. This will identify an invalid code in debug mode.