### PR TITLE
Update auth.go

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -133,7 +133,8 @@ const (
 	Location           = "Location"
 	Upgrade            = "Upgrade"
 	Vary               = "Vary"
-
+	Basic              = "Basic"
+	WWWAuthenticate    = "WWW-Authenticate"
 	//-----------
 	// Protocols
 	//-----------

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -11,11 +11,6 @@ type (
 	BasicValidateFunc func(string, string) bool
 )
 
-const (
-	Basic           = "Basic"
-	WWWAuthenticate = "WWW-Authenticate"
-)
-
 // BasicAuth returns an HTTP basic authentication middleware.
 //
 // For valid credentials it calls the next handler.
@@ -28,10 +23,10 @@ func BasicAuth(fn BasicValidateFunc) echo.HandlerFunc {
 		}
 
 		auth := c.Request().Header.Get(echo.Authorization)
-		l := len(Basic)
+		l := len(echo.Basic)
 		he := echo.NewHTTPError(http.StatusUnauthorized)
 
-		if len(auth) > l+1 && auth[:l] == Basic {
+		if len(auth) > l+1 && auth[:l] == echo.Basic {
 			b, err := base64.StdEncoding.DecodeString(auth[l+1:])
 			if err == nil {
 				cred := string(b)
@@ -46,7 +41,7 @@ func BasicAuth(fn BasicValidateFunc) echo.HandlerFunc {
 			}
 		}
 
-		c.Response().Header().Add(WWWAuthenticate, Basic)
+		c.Response().Header().Add(echo.WWWAuthenticate, echo.Basic)
 		return he
 	}
 }

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -12,7 +12,8 @@ type (
 )
 
 const (
-	Basic = "Basic"
+	Basic           = "Basic"
+	WWWAuthenticate = "WWW-Authenticate"
 )
 
 // BasicAuth returns an HTTP basic authentication middleware.
@@ -44,8 +45,8 @@ func BasicAuth(fn BasicValidateFunc) echo.HandlerFunc {
 				}
 			}
 		}
-		
-		c.Response().Header().Add("WWW-Authenticate", "Basic")
+
+		c.Response().Header().Add(WWWAuthenticate, Basic)
 		return he
 	}
 }

--- a/middleware/auth_test.go
+++ b/middleware/auth_test.go
@@ -40,7 +40,7 @@ func TestBasicAuth(t *testing.T) {
 	// Empty Authorization header
 	req.Header.Set(echo.Authorization, "")
 	he = ba(c).(*echo.HTTPError)
-	assert.Equal(t, http.StatusBadRequest, he.Code())
+	assert.Equal(t, http.StatusUnauthorized, he.Code())
 
 	// Invalid Authorization header
 	auth = base64.StdEncoding.EncodeToString([]byte("invalid"))

--- a/middleware/auth_test.go
+++ b/middleware/auth_test.go
@@ -46,7 +46,7 @@ func TestBasicAuth(t *testing.T) {
 	auth = base64.StdEncoding.EncodeToString([]byte("invalid"))
 	req.Header.Set(echo.Authorization, auth)
 	he = ba(c).(*echo.HTTPError)
-	assert.Equal(t, http.StatusBadRequest, he.Code())
+	assert.Equal(t, http.StatusUnauthorized, he.Code())
 
 	// WebSocket
 	c.Request().Header.Set(echo.Upgrade, echo.WebSocket)

--- a/middleware/auth_test.go
+++ b/middleware/auth_test.go
@@ -23,7 +23,7 @@ func TestBasicAuth(t *testing.T) {
 	ba := BasicAuth(fn)
 
 	// Valid credentials
-	auth := Basic + " " + base64.StdEncoding.EncodeToString([]byte("joe:secret"))
+	auth := echo.Basic + " " + base64.StdEncoding.EncodeToString([]byte("joe:secret"))
 	req.Header.Set(echo.Authorization, auth)
 	assert.NoError(t, ba(c))
 
@@ -32,7 +32,7 @@ func TestBasicAuth(t *testing.T) {
 	//---------------------
 
 	// Incorrect password
-	auth = Basic + " " + base64.StdEncoding.EncodeToString([]byte("joe:password"))
+	auth = echo.Basic + " " + base64.StdEncoding.EncodeToString([]byte("joe:password"))
 	req.Header.Set(echo.Authorization, auth)
 	he := ba(c).(*echo.HTTPError)
 	assert.Equal(t, http.StatusUnauthorized, he.Code())


### PR DESCRIPTION
Add Header WWW-Authenticate and removes http.BadRequest error

Hello guys, I was having a issue where when using the BasicAuth middleware, in the first request when the browser doesn't know that the URI is protected by Basic HTTP Auth scheme I was getting a Bad Request error, and the browser wasn't prompting me to put my User and Password.

So I look at the [RFC 2617](http://tools.ietf.org/html/rfc2617) and made these changes, now the browser knows that he needs to prompt the user asking his User and Password to resubmit the request.
