### PR TITLE
Fix for corrupted middleware using Groups

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -411,6 +411,10 @@ func (e *Echo) Group(prefix string, m ...Middleware) *Group {
 	if len(m) > 0 {
 		g.echo.middleware = nil
 		g.Use(m...)
+	} else {
+		mw := make([]MiddlewareFunc, len(g.echo.middleware))
+		copy(mw, g.echo.middleware)
+		g.echo.middleware = mw
 	}
 	return g
 }


### PR DESCRIPTION
This makes a copy of the middleware when creating a group, preventing the cross-group pollination of middleware.