### PR TITLE
Adding Response.Committed Getter

### DIFF
--- a/response.go
+++ b/response.go
@@ -74,6 +74,10 @@ func (r *Response) Size() int64 {
 	return r.size
 }
 
+func (r *Response) Committed() bool {
+	return r.committed
+}
+
 func (r *Response) reset(w http.ResponseWriter) {
 	r.writer = w
 	r.size = 0

--- a/response_test.go
+++ b/response_test.go
@@ -1,10 +1,11 @@
 package echo
 
 import (
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestResponse(t *testing.T) {
@@ -45,6 +46,9 @@ func TestResponse(t *testing.T) {
 
 	// Size
 	assert.EqualValues(t, len(s), r.Size())
+
+	// Committed
+	assert.Equal(t, true, r.Committed())
 
 	// Hijack
 	assert.Panics(t, func() {


### PR DESCRIPTION
Was doing a 100% export of the `defaultHTTPErrorHandler` (specifically to remove the `Println` for my own purposes), and ended up not being able to get the `r.committed` boolean.

Here's the working code, for anyone that might want:

```go
func HTTPErrorHandler(err error, c *echo.Context) {
	code := http.StatusInternalServerError
	msg := http.StatusText(code)

	if he, ok := err.(*echo.HTTPError); ok {
		code = he.Code()
		msg = he.Error()
	}

	if viper.GetBool("app.debug") == true {
		msg = err.Error()
	}

	if !c.Response().Committed() {
		http.Error(c.Response(), msg, code)
	}
}
```

Not a huge deal, but it's nice for people to completely overwrite the handler with an identically functioning one.