### PR TITLE
Added printing of registered routes in debug mode.

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -356,6 +356,10 @@ func (e *Echo) add(method, path string, h Handler) {
 		Handler: runtime.FuncForPC(reflect.ValueOf(h).Pointer()).Name(),
 	}
 	e.router.routes = append(e.router.routes, r)
+
+	if e.Debug() {
+		debugPrintRoute(r)
+	}
 }
 
 // Index serves index file.
@@ -634,4 +638,16 @@ func (binder) Bind(r *http.Request, i interface{}) (err error) {
 		err = xml.NewDecoder(r.Body).Decode(i)
 	}
 	return
+}
+
+func debugPrintRoute(route Route) {
+	log.Printf("%-5s %-35s --> %s", route.Method, route.Path, stripPackage(route.Handler.(string)))
+}
+
+func stripPackage(n string) string {
+	slashI := strings.LastIndex(n, "/")
+	if slashI == -1 {
+		slashI = 0
+	}
+	return n[slashI+1:]
 }


### PR DESCRIPTION
Gives the following example output when server is run:

```
2015/09/30 23:40:55 GET   /                          --> web.GetRoot
2015/09/30 23:40:55 GET   /login                     --> web.GetLogin
2015/09/30 23:40:55 POST  /login                     --> web.PostLogin
```

*Useful for debugging*