### PR TITLE
Typo in the template documentation

### DIFF
--- a/website/content/guide/response.md
+++ b/website/content/guide/response.md
@@ -19,7 +19,7 @@ Below is an example using Go `html/template`
 - Implement `echo.Render` interface
 
 ```go
-Template struct {
+type Template struct {
     templates *template.Template
 }
 


### PR DESCRIPTION
Just fixing a little typo, tripped me up when playing around with the `echo.Render` stuff.