### PR TITLE
Context.MatchedRoute() added

### DIFF
--- a/context.go
+++ b/context.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 
 	"bytes"
+
 	"golang.org/x/net/websocket"
 )
 
@@ -18,14 +19,15 @@ type (
 	// Context represents context for the current request. It holds request and
 	// response objects, path parameters, data and registered handler.
 	Context struct {
-		request  *http.Request
-		response *Response
-		socket   *websocket.Conn
-		pnames   []string
-		pvalues  []string
-		query    url.Values
-		store    store
-		echo     *Echo
+		request      *http.Request
+		response     *Response
+		socket       *websocket.Conn
+		matchedRoute string
+		pnames       []string
+		pvalues      []string
+		query        url.Values
+		store        store
+		echo         *Echo
 	}
 	store map[string]interface{}
 )
@@ -39,6 +41,10 @@ func NewContext(req *http.Request, res *Response, e *Echo) *Context {
 		pvalues:  make([]string, *e.maxParam),
 		store:    make(store),
 	}
+}
+
+func (c *Context) MatchedRoute() string {
+	return c.matchedRoute
 }
 
 // Request returns *http.Request.
@@ -227,7 +233,8 @@ func (c *Context) Error(err error) {
 	c.echo.httpErrorHandler(err, c)
 }
 
-func (c *Context) reset(r *http.Request, w http.ResponseWriter, e *Echo) {
+func (c *Context) reset(r *http.Request, w http.ResponseWriter, e *Echo, rp string) {
+	c.matchedRoute = rp
 	c.request = r
 	c.response.reset(w)
 	c.query = nil

--- a/context_test.go
+++ b/context_test.go
@@ -175,7 +175,7 @@ func TestContext(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, c.response.status)
 
 	// reset
-	c.reset(req, NewResponse(httptest.NewRecorder()), New())
+	c.reset(req, NewResponse(httptest.NewRecorder()), New(), "")
 }
 
 func TestContextQuery(t *testing.T) {

--- a/echo.go
+++ b/echo.go
@@ -463,8 +463,8 @@ func (e *Echo) Routes() []Route {
 // ServeHTTP implements `http.Handler` interface, which serves HTTP requests.
 func (e *Echo) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	c := e.pool.Get().(*Context)
-	h, e := e.router.Find(r.Method, r.URL.Path, c)
-	c.reset(r, w, e)
+	h, e, rp := e.router.Find(r.Method, r.URL.Path, c)
+	c.reset(r, w, e, rp)
 
 	// Chain middleware with handler in the end
 	for i := len(e.middleware) - 1; i >= 0; i-- {


### PR DESCRIPTION
New context field contains route's path without interpolated path
params, as passed to Router.Add. This can be used for logging purposes.

Look #203 for previous discussion.
This is a POC for now, it works and passes tests, but I'm not sure about zero allocations per request. This needs to be checked.