### PR TITLE
Reorder titles in graceful shutdown recipe

### DIFF
--- a/website/content/recipes/graceful-shutdown.md
+++ b/website/content/recipes/graceful-shutdown.md
@@ -6,13 +6,13 @@ menu:
     weight: 13
 ---
 
-### With [graceful](https://github.com/tylerb/graceful)
+### With [grace](https://github.com/facebookgo/grace)
 
 `server.go`
 
 {{< embed "graceful-shutdown/grace/server.go" >}}
 
-### With [grace](https://github.com/facebookgo/grace)
+### With [graceful](https://github.com/tylerb/graceful)
 
 `server.go`
 


### PR DESCRIPTION
Looks like the titles where switched around in the graceful shutdown recipe, I rearranged them to match the given snippets.