### PR TITLE
Fixed bug where IP address wasn't showing up in log files.

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -15,13 +15,15 @@ func Logger() echo.MiddlewareFunc {
 			req := c.Request()
 			res := c.Response()
 
-			remoteAddr := req.RemoteAddr
+			var remoteAddr string
 			if ip := req.Header.Get(echo.XRealIP); ip != "" {
 				remoteAddr = ip
 			} else if ip = req.Header.Get(echo.XForwardedFor); ip != "" {
 				remoteAddr = ip
+			} else {
+				remoteAddr = req.RemoteAddr
+				remoteAddr, _, _ = net.SplitHostPort(remoteAddr)
 			}
-			remoteAddr, _, _ = net.SplitHostPort(remoteAddr)
 
 			start := time.Now()
 			if err := h(c); err != nil {

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -1,12 +1,15 @@
 package middleware
 
 import (
+	"bytes"
 	"errors"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/labstack/echo"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLogger(t *testing.T) {
@@ -16,23 +19,8 @@ func TestLogger(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := echo.NewContext(req, echo.NewResponse(rec), e)
 
-	// With X-Real-IP
-	req.Header.Add(echo.XRealIP, "127.0.0.1")
-	h := func(c *echo.Context) error {
-		return c.String(http.StatusOK, "test")
-	}
-	Logger()(h)(c)
-
-	// With X-Forwarded-For
-	req.Header.Del(echo.XRealIP)
-	req.Header.Add(echo.XForwardedFor, "127.0.0.1")
-	h = func(c *echo.Context) error {
-		return c.String(http.StatusOK, "test")
-	}
-	Logger()(h)(c)
-
 	// Status 2xx
-	h = func(c *echo.Context) error {
+	h := func(c *echo.Context) error {
 		return c.String(http.StatusOK, "test")
 	}
 	Logger()(h)(c)
@@ -61,4 +49,38 @@ func TestLogger(t *testing.T) {
 		return errors.New("error")
 	}
 	Logger()(h)(c)
+}
+
+func TestLogger_IPAddress(t *testing.T) {
+	buf := &bytes.Buffer{}
+	log.SetOutput(buf)
+
+	ip := "127.0.0.1"
+
+	e := echo.New()
+	req, _ := http.NewRequest(echo.GET, "/", nil)
+	rec := httptest.NewRecorder()
+	c := echo.NewContext(req, echo.NewResponse(rec), e)
+	h := func(c *echo.Context) error {
+		return c.String(http.StatusOK, "test")
+	}
+
+	mw := Logger()
+
+	// With X-Real-IP
+	req.Header.Add(echo.XRealIP, ip)
+	mw(h)(c)
+	assert.Contains(t, buf.String(), ip)
+
+	// With X-Forwarded-For
+	buf.Reset()
+	req.Header.Del(echo.XRealIP)
+	req.Header.Add(echo.XForwardedFor, ip)
+	mw(h)(c)
+	assert.Contains(t, buf.String(), ip)
+
+	// with req.RemoteAddr
+	buf.Reset()
+	mw(h)(c)
+	assert.Contains(t, buf.String(), ip)
 }


### PR DESCRIPTION
There was a bug in `middleware.Logger` that was preventing the IP Address from showing up in the log files.

If the IP was found via either `echo.XRealIP` or `echo.XForwardedFor` it would throw an error when using `net.SplitHostPort` because there wasn't a port. Since the error was never checked this went unnoticed.

I also added some tests to check to make sure the IP address is showing up properly in the log.