### PR TITLE
http.ResponseWriter.Write() writes headers.

### DIFF
--- a/response.go
+++ b/response.go
@@ -44,6 +44,9 @@ func (r *Response) WriteHeader(code int) {
 }
 
 func (r *Response) Write(b []byte) (n int, err error) {
+	if !r.committed {
+		r.WriteHeader(200)
+	}
 	n, err = r.writer.Write(b)
 	r.size += int64(n)
 	return n, err

--- a/response_test.go
+++ b/response_test.go
@@ -63,3 +63,27 @@ func TestResponse(t *testing.T) {
 	// reset
 	r.reset(httptest.NewRecorder())
 }
+
+func TestResponseWriteCommits(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := NewResponse(w)
+	r.SetWriter(w)
+
+	// write body, it writes header if not committed yet
+	s := "echo"
+	r.Write([]byte(s))
+
+	assert.Equal(t, w.Code, 200)
+	assert.Equal(t, w.Body.String(), s)
+
+	assert.Equal(t, r.Status(), 200)
+	assert.Equal(t, r.Size(), int64(4))
+	assert.True(t, r.Committed())
+
+	// this is ignored with warning
+	r.WriteHeader(400)
+
+	assert.Equal(t, r.Status(), 200)
+	assert.Equal(t, r.Size(), int64(4))
+	assert.True(t, r.Committed())
+}


### PR DESCRIPTION
So should we.

Otherwise call to `Write()` followed by `WriteHeader()` will produce unexpected result.