### PR TITLE
Set AppEngine Context automatically

### DIFF
--- a/appengine.go
+++ b/appengine.go
@@ -1,0 +1,22 @@
+// +build appengine
+
+package echo
+
+import (
+	"golang.org/x/net/context"
+	"google.golang.org/appengine"
+)
+
+type (
+	appengineLogAdapter struct {
+		context.Context
+	}
+)
+
+func init() {
+	RegisterPreRequestHandlerFunc(setupAppEngineContext)
+}
+
+func setupAppEngineContext(c *Context) {
+	c.Context = appengine.NewContext(c.Request())
+}

--- a/echo.go
+++ b/echo.go
@@ -533,6 +533,11 @@ func (e *Echo) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h, e := e.router.Find(r.Method, r.URL.Path, c)
 	c.reset(r, w, e)
 
+	// Execute lifecycle function(s)
+	for i := len(preRequestHandlerFuncs) - 1; i >= 0; i-- {
+		preRequestHandlerFuncs[i](c)
+	}
+
 	// Chain middleware with handler in the end
 	for i := len(e.middleware) - 1; i >= 0; i-- {
 		h = e.middleware[i](h)

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -1,0 +1,13 @@
+package echo
+
+// PreRequestHandlerFunc is a func which will be called before control for
+// the request is passed to the middleware and handler. The purpose is to
+// provide a transparent way for a platform to hook into the process such
+// as Googo AppEngine to setup it's own content and logger
+type PreRequestHandlerFunc func(*Context)
+
+var preRequestHandlerFuncs []PreRequestHandlerFunc
+
+func RegisterPreRequestHandlerFunc(fn PreRequestHandlerFunc) {
+	preRequestHandlerFuncs = append(preRequestHandlerFuncs, fn)
+}


### PR DESCRIPTION
Automatically sets up the AppEngine Content if running on that platform.

Right now this is just a convenience to allow the echo.Content to be used directly with AppEngine packages and automatically available in any middleware or handlers, e.g.

```
package main

import (
	"net/http"

	"github.com/labstack/echo"
	"google.golang.org/appengine/log"
)

func init() {
	e := echo.New()
	e.Get("/", indexHandler)
	http.Handle("/", e)
}

func indexHandler(c *echo.Context) error {
	log.Debugf(c, "test logging on app engine")
	return c.String(http.StatusOK, "test")
}
```

The plan is that this should enable the ability to have some logging methods available off the echo.Context that can be output automatically to the configured logger or the AppEngine logs (again, when running on that platform).