### PR TITLE
Fix tests methods arguments

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -204,7 +204,7 @@ func TestContext(t *testing.T) {
 	err = c.File("test/fixture/walle.png", "WALLE.PNG", true)
 	if assert.NoError(t, err) {
 		assert.Equal(t, http.StatusOK, rec.Code)
-		assert.Equal(t, rec.Header().Get(ContentDisposition), "attachment; filename=WALLE.PNG")
+		assert.Equal(t, "attachment; filename=WALLE.PNG", rec.Header().Get(ContentDisposition))
 		assert.Equal(t, 219885, rec.Body.Len())
 	}
 
@@ -236,12 +236,12 @@ func TestContextPath(t *testing.T) {
 	r.Add(GET, "/users/:id", nil, e)
 	c := NewContext(nil, nil, e).X()
 	r.Find(GET, "/users/1", c)
-	assert.Equal(t, c.Path(), "/users/:id")
+	assert.Equal(t, "/users/:id", c.Path())
 
 	r.Add(GET, "/users/:uid/files/:fid", nil, e)
 	c = NewContext(nil, nil, e).X()
 	r.Find(GET, "/users/1/files/1", c)
-	assert.Equal(t, c.Path(), "/users/:uid/files/:fid")
+	assert.Equal(t, "/users/:uid/files/:fid", c.Path())
 }
 
 func TestContextQuery(t *testing.T) {

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -118,7 +118,7 @@ func TestGzipCloseNotify(t *testing.T) {
 	case <-time.After(time.Second):
 	}
 
-	assert.Equal(t, closed, true)
+	assert.Equal(t, true, closed)
 }
 
 func BenchmarkGzip(b *testing.B) {


### PR DESCRIPTION
Some tests had confused arguments. For example it should be
```go 
Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{})
```
but somewhere in code it was
```go 
assert.Equal(t, actual, expected)
```

