### PR TITLE
Add context.Stream() and context.Bytes() response methods.

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -116,6 +116,7 @@ const (
 	TextPlain                        = "text/plain"
 	TextPlainCharsetUTF8             = TextPlain + "; " + CharsetUTF8
 	MultipartForm                    = "multipart/form-data"
+	OctetStream                      = "application/octet-stream"
 
 	//---------
 	// Charset


### PR DESCRIPTION
Add 
```go
Stream(data io.Reader, filename string, attachment bool) (err error)
```
 and 
```go
Bytes(data []byte, filename string, attachment bool) (err error)
```
 methods to context for sending dynamically generated binary data.