### PR TITLE
Add a ParamNames method on Context

### DIFF
--- a/context.go
+++ b/context.go
@@ -58,6 +58,11 @@ func (c *Context) Socket() *websocket.Conn {
 	return c.socket
 }
 
+// ParamNames returns path parameter names.
+func (c *Context) ParamNames() []string {
+	return c.pnames
+}
+
 // Path returns the registered path for the handler.
 func (c *Context) Path() string {
 	return c.path

--- a/context_test.go
+++ b/context_test.go
@@ -51,6 +51,10 @@ func TestContext(t *testing.T) {
 	// Socket
 	assert.Nil(t, c.Socket())
 
+	// ParamNames
+	c.pnames = []string{"user_id", "id"}
+	assert.EqualValues(t, []string{"user_id", "id"}, c.ParamNames())
+
 	// Param by id
 	c.pnames = []string{"id"}
 	c.pvalues = []string{"1"}


### PR DESCRIPTION
Hello,

Currently there is no way to get all matched parameters from the `Context`. While this fully makes senses in the context of a classic webapp where knowledge of which parameters are passed is implied, this doesn't allow to write a dynamic handler that does for example, some forwarding on another transport layer (which requires to aggregate parameter names and values).

Given the methods that are currently available we'd have to rematch the route to infer the parameters but that defeats the purpose of using echo as it's made for speed which is exactly what we're looking for here. 

A single method returning `pnames` appears to be a fair tradeoff to fix our use case without changing too much on your side nor messing with your API design.

Thanks