### PR TITLE
Context / Middleware / Appengine

### DIFF
--- a/context.go
+++ b/context.go
@@ -81,12 +81,13 @@ const (
 // NewContext creates a Context object.
 func NewContext(req engine.Request, res engine.Response, e *Echo) Context {
 	return &context{
-		request:  req,
-		response: res,
-		echo:     e,
-		pvalues:  make([]string, *e.maxParam),
-		store:    make(store),
-		handler:  notFoundHandler,
+		netContext: netContext.TODO(),
+		request:    req,
+		response:   res,
+		echo:       e,
+		pvalues:    make([]string, *e.maxParam),
+		store:      make(store),
+		handler:    notFoundHandler,
 	}
 }
 
@@ -367,6 +368,7 @@ func detectContentType(name string) (t string) {
 }
 
 func (c *context) reset(req engine.Request, res engine.Response) {
+	c.netContext = c.echo.contextFunc(req)
 	c.request = req
 	c.response = res
 	c.query = nil

--- a/echo.go
+++ b/echo.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/labstack/echo/engine"
 	"github.com/labstack/gommon/log"
+
+	netContext "golang.org/x/net/context"
 )
 
 type (
@@ -33,6 +35,7 @@ type (
 		debug            bool
 		router           *Router
 		logger           *log.Logger
+		contextFunc      ContextFunc
 	}
 
 	Route struct {
@@ -78,6 +81,8 @@ type (
 	Renderer interface {
 		Render(io.Writer, string, interface{}, Context) error
 	}
+
+	ContextFunc func(req engine.Request) netContext.Context
 )
 
 const (
@@ -203,6 +208,10 @@ func New() (e *Echo) {
 	e.logger = log.New("echo")
 	e.logger.SetLevel(log.FATAL)
 
+	e.contextFunc = func(req engine.Request) netContext.Context {
+		return netContext.Background()
+	}
+
 	return
 }
 
@@ -264,6 +273,11 @@ func (e *Echo) SetHTTPErrorHandler(h HTTPErrorHandler) {
 // SetBinder registers a custom binder. It's invoked by Context.Bind().
 func (e *Echo) SetBinder(b Binder) {
 	e.binder = b
+}
+
+// SetContectFunc registered a custom context factory.
+func (e *Echo) SetContectFunc(fn ContextFunc) {
+	e.contextFunc = fn
 }
 
 // SetRenderer registers an HTML template renderer. It's invoked by Context.Render().

--- a/engine/standard/appengine.go
+++ b/engine/standard/appengine.go
@@ -1,0 +1,21 @@
+// +build appengine
+
+package standard
+
+import (
+	"github.com/labstack/echo"
+	"github.com/labstack/echo/engine"
+
+	"golang.org/x/net/context"
+	"google.golang.org/appengine"
+)
+
+// SetHandler implements `engine.Engine#SetHandler` method.
+func (s *Server) SetHandler(h engine.Handler) {
+	e := h.(*echo.Echo)
+	e.SetContectFunc(func(req engine.Request) context.Context {
+		return appengine.NewContext(req.(*Request).Request)
+	})
+
+	s.handler = h
+}

--- a/engine/standard/server.go
+++ b/engine/standard/server.go
@@ -80,11 +80,6 @@ func NewFromConfig(c engine.Config) (s *Server) {
 	return
 }
 
-// SetHandler implements `engine.Engine#SetHandler` method.
-func (s *Server) SetHandler(h engine.Handler) {
-	s.handler = h
-}
-
 // SetLogger implements `engine.Engine#SetLogger` method.
 func (s *Server) SetLogger(l *log.Logger) {
 	s.logger = l

--- a/engine/standard/standalone.go
+++ b/engine/standard/standalone.go
@@ -1,0 +1,11 @@
+// +build !appengine
+
+package standard
+
+import (
+	"github.com/labstack/echo/engine"
+)
+
+func (s *Server) SetHandler(h engine.Handler) {
+	s.handler = h
+}


### PR DESCRIPTION
(for discussion, don't merge)

AppEngine needs access to the net/context Context and without it available on the echo Context it wasn't settable in middleware and would need to be set in each handler. So, I had already added code to support it before it was available (now rebased).

The other changes I'd made were to wire up the context automatically for app engine or set it to the TODO / Background context as a appropriate.

The discussion about context and middleware https://github.com/labstack/echo/issues/404 makes me wonder if this could be used to also return the request object to set for the context - giving a chance to change the path etc... before the middleware & routing kicks in ?