### PR TITLE
Add an All() func to the Header interface

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -239,6 +239,16 @@ func TestContextNetContext(t *testing.T) {
 	// assert.Equal(t, "val", c.Value("key"))
 }
 
+func TestHeaderAll(t *testing.T) {
+	req := test.NewRequest(GET, "/", strings.NewReader(""))
+	req.Header().Add(ContentLength, "123")
+	req.Header().Add(ContentType, TextPlain)
+	all := req.Header().All()
+	assert.Equal(t, 2, len(all))
+	assert.Contains(t, all, ContentType)
+	assert.Contains(t, all, ContentLength)
+}
+
 func testBindOk(t *testing.T, c Context, ct string) {
 	c.Request().Header().Set(ContentType, ct)
 	u := new(user)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -57,6 +57,7 @@ type (
 		Del(string)
 		Set(string, string)
 		Get(string) string
+		All() []string
 	}
 
 	// URL defines the interface for HTTP request url.

--- a/engine/fasthttp/header.go
+++ b/engine/fasthttp/header.go
@@ -36,6 +36,16 @@ func (h *RequestHeader) Get(key string) string {
 	return string(h.Peek(key))
 }
 
+func (h *RequestHeader) All() []string {
+	hdrs := make([]string, h.Len())
+	idx := 0
+	h.VisitAll(func(k, v []byte) {
+		hdrs[idx] = string(k)
+		idx++
+	})
+	return hdrs
+}
+
 func (h *RequestHeader) reset(hdr *fasthttp.RequestHeader) {
 	h.RequestHeader = hdr
 }
@@ -59,6 +69,16 @@ func (h *ResponseHeader) Get(key string) string {
 // Set implements `engine.Header#Set` method.
 func (h *ResponseHeader) Set(key, val string) {
 	h.ResponseHeader.Set(key, val)
+}
+
+func (h *ResponseHeader) All() []string {
+	hdrs := make([]string, h.Len())
+	idx := 0
+	h.VisitAll(func(k, v []byte) {
+		hdrs[idx] = string(k)
+		idx++
+	})
+	return hdrs
 }
 
 func (h *ResponseHeader) reset(hdr *fasthttp.ResponseHeader) {

--- a/engine/standard/header.go
+++ b/engine/standard/header.go
@@ -29,6 +29,16 @@ func (h *Header) Get(key string) string {
 	return h.Header.Get(key)
 }
 
+func (h *Header) All() []string {
+	headers := make([]string, len(h.Header))
+	idx := 0
+	for header, _ := range h.Header {
+		headers[idx] = header
+		idx++
+	}
+	return headers
+}
+
 func (h *Header) reset(hdr http.Header) {
 	h.Header = hdr
 }

--- a/test/header.go
+++ b/test/header.go
@@ -24,6 +24,16 @@ func (h *Header) Set(key, val string) {
 	h.header.Set(key, val)
 }
 
+func (h *Header) All() []string {
+	headers := make([]string, len(h.header))
+	idx := 0
+	for header, _ := range h.header {
+		headers[idx] = header
+		idx++
+	}
+	return headers
+}
+
 func (h *Header) Object() interface{} {
 	return h.header
 }


### PR DESCRIPTION
We have a few usecases that require us to walk over all HTTP headers of a request and act differently depending on whether they exist or not. The recent change that made the Headers an interface makes this a bit awkward and requires a typecast to the type of the implementation in use (standard http or fasthttp):

```go
h := c.Header().(*standard.Header)
for header, _ := range h.Header {
    c.Header.Get(header)
}
```

A convenience method would be nice:

```go
for _, header := range c.Header().All() {
    c.Header.Get(header)
}
```

This PR will do just that. 