### PR TITLE
Fix missing response size

### DIFF
--- a/engine/fasthttp/response.go
+++ b/engine/fasthttp/response.go
@@ -41,8 +41,10 @@ func (r *Response) WriteHeader(code int) {
 }
 
 // Write implements `engine.Response#Write` method.
-func (r *Response) Write(b []byte) (int, error) {
-	return r.writer.Write(b)
+func (r *Response) Write(b []byte) (n int, err error) {
+	n, err = r.writer.Write(b)
+	r.size += int64(n)
+	return
 }
 
 // Status implements `engine.Response#Status` method.


### PR DESCRIPTION
Hi,

when you look at log entries of running fasthttp HTTP server you will see a bunch of:

`2016/03/16 18:49:22 internal ::1 GET /healthcheck 500 724.955µs 0
2016/03/16 18:49:23 internal ::1 GET /healthcheck 500 882.135µs 0
2016/03/16 18:49:23 internal ::1 GET /healthcheck 500 328.629µs 0`

... entries with missing response size. The given pull request repairs it.

Kind regards,
Marcin