### PR TITLE
Improved error handling of multipart requests

### DIFF
--- a/engine/standard/request.go
+++ b/engine/standard/request.go
@@ -100,8 +100,8 @@ func (r *Request) FormFile(name string) (*multipart.FileHeader, error) {
 
 // MultipartForm implements `engine.Request#MultipartForm` method.
 func (r *Request) MultipartForm() (*multipart.Form, error) {
-	r.Request.ParseMultipartForm(32 << 20) // 32 MB
-	return r.Request.MultipartForm, nil
+	err := r.Request.ParseMultipartForm(32 << 20) // 32 MB
+	return r.Request.MultipartForm, err
 }
 
 func (r *Request) reset(req *http.Request, h engine.Header, u engine.URL) {

--- a/test/request.go
+++ b/test/request.go
@@ -94,8 +94,8 @@ func (r *Request) FormFile(name string) (*multipart.FileHeader, error) {
 }
 
 func (r *Request) MultipartForm() (*multipart.Form, error) {
-	m := r.request.MultipartForm
-	return m, nil
+	err := r.request.ParseMultipartForm(32 << 20) // 32 MB
+	return r.request.MultipartForm, err
 }
 
 func (r *Request) reset(req *http.Request, h engine.Header, u engine.URL) {


### PR DESCRIPTION
standard/request: return the error of the http request multipart parsing
call
test/request: similar functionality as the standard/request