### PR TITLE
Let responseAdapter be an http.Hijacker

### DIFF
--- a/engine/standard/response.go
+++ b/engine/standard/response.go
@@ -1,7 +1,10 @@
 package standard
 
 import (
+	"bufio"
+	"errors"
 	"io"
+	"net"
 	"net/http"
 
 	"github.com/labstack/echo/engine"
@@ -85,4 +88,11 @@ func (r *Response) reset(w http.ResponseWriter, h engine.Header) {
 
 func (r *responseAdapter) Write(b []byte) (n int, err error) {
 	return r.writer.Write(b)
+}
+
+func (r *responseAdapter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hj, ok := r.ResponseWriter.(http.Hijacker); ok {
+		return hj.Hijack()
+	}
+	return nil, nil, errors.New("I'm not a Hijacker")
 }


### PR DESCRIPTION
Hi. When I tried to execute the [WebSocket example](https://labstack.com/echo/recipes/websocket/), I've got this panic:

`panic serving [::1]:39932: interface conversion: *standard.responseAdapter is not http.Hijacker: missing method Hijack`

The problem was on this line: https://github.com/labstack/echo/blob/master/engine/standard/server.go#L146

Therefore I fixed this issue, making `responseAdapter` an Hijacker.

After that, WebSocket works well.