### PR TITLE
Fix HTTP status and content length of wrapped handlers

### DIFF
--- a/engine/fasthttp/server.go
+++ b/engine/fasthttp/server.go
@@ -151,6 +151,8 @@ func WrapHandler(h fasthttp.RequestHandler) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		ctx := c.Request().(*Request).RequestCtx
 		h(ctx)
+		c.Response().(*Response).status = ctx.Response.StatusCode()
+		c.Response().(*Response).size = int64(ctx.Response.Header.ContentLength())
 		return nil
 	}
 }

--- a/engine/standard/response.go
+++ b/engine/standard/response.go
@@ -24,7 +24,9 @@ type (
 
 	responseAdapter struct {
 		http.ResponseWriter
-		writer io.Writer
+		writer   io.Writer
+		response *Response
+		code     int
 	}
 )
 
@@ -110,6 +112,10 @@ func (r *Response) reset(w http.ResponseWriter, h engine.Header) {
 
 func (r *responseAdapter) Write(b []byte) (n int, err error) {
 	return r.writer.Write(b)
+}
+
+func (r *responseAdapter) WriteHeader(code int) {
+	r.response.WriteHeader(code)
 }
 
 func (r *responseAdapter) Flush() {

--- a/engine/standard/server.go
+++ b/engine/standard/server.go
@@ -140,6 +140,7 @@ func WrapHandler(h http.Handler) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		w := &responseAdapter{
 			ResponseWriter: c.Response().(*Response).ResponseWriter,
+			response:       c.Response().(*Response),
 			writer:         c.Response(),
 		}
 		r := c.Request().(*Request).Request


### PR DESCRIPTION
Hi @vishr,
 
I tried to integrate static HTTP file servers of different implementations and I noticed in access logs that HTTP statuses are lost and returned implicitly as HTTP 200 OK (standard and fasthttp implementations). Fasthttp wrapped handler log entries suffered from empty content length.

`2016/03/27 20:01:30 server 127.0.0.1 GET /file.txt 200 432.539µs 0
2016/03/27 20:01:30 server 127.0.0.1 GET /file.txt 200 1.714813ms 0
2016/03/27 20:01:30 server 127.0.0.1 GET /file.txt 200 383.486µs 0
2016/03/27 20:01:30 server 127.0.0.1 GET /file.txt 200 304.048µs 0
2016/03/27 20:01:34 server 127.0.0.1 GET /file.txt 304 358.484µs 0
2016/03/27 20:01:35 server 127.0.0.1 GET /file.txt 304 370.593µs 0
2016/03/27 20:01:35 server 127.0.0.1 GET /file.txt 304 428.715µs 0
2016/03/27 20:01:39 server 127.0.0.1 GET /file.txt 304 464.595µs 0
2016/03/27 20:01:44 server 127.0.0.1 GET /file.txt 200 443.278µs 0`

Code snippet of handlers I tried to integrate:
`fasthttp.WrapHandler(fileServer.NewRequestHandler())
standard.WrapHandler(http.FileServer(http.Dir(staticPath)))`