### PR TITLE
spelling mistake fix on readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ func getUser(c echo.Context) error {
 func show(c echo.Context) error {
 	// Get team and member from the query string
 	team := c.QueryParam("team")
-	member := c.QueryParam("team")
+	member := c.QueryParam("member")
 }
 ```
 


### PR DESCRIPTION
Spelling mistake fix for 
// Get team and member from the query string
