### PR TITLE
Properly disable colors in Logger middleware

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -113,11 +113,11 @@ func LoggerWithConfig(config LoggerConfig) echo.MiddlewareFunc {
 					s := config.color.Green(n)
 					switch {
 					case n >= 500:
-						s = color.Red(n)
+						s = config.color.Red(n)
 					case n >= 400:
-						s = color.Yellow(n)
+						s = config.color.Yellow(n)
 					case n >= 300:
-						s = color.Cyan(n)
+						s = config.color.Cyan(n)
 					}
 					return w.Write([]byte(s))
 				case "response_time":

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -70,7 +70,7 @@ func LoggerWithConfig(config LoggerConfig) echo.MiddlewareFunc {
 
 	config.template = fasttemplate.New(config.Format, "${", "}")
 	config.color = color.New()
-	if w, ok := config.Output.(*os.File); ok && !isatty.IsTerminal(w.Fd()) {
+	if w, ok := config.Output.(*os.File); !ok || !isatty.IsTerminal(w.Fd()) {
 		config.color.Disable()
 	}
 
@@ -110,7 +110,7 @@ func LoggerWithConfig(config LoggerConfig) echo.MiddlewareFunc {
 					return w.Write([]byte(p))
 				case "status":
 					n := rs.Status()
-					s := color.Green(n)
+					s := config.color.Green(n)
 					switch {
 					case n >= 500:
 						s = color.Red(n)


### PR DESCRIPTION
Hello!

This pull request fixes a minor bug in `Logger` middleware when colours are enabled if non-`os.File` writer is used as output `io.Writer`.