### PR TITLE
Implement context with exported composed types

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -46,12 +46,12 @@ func TestContext(t *testing.T) {
 	assert.NotNil(t, c.Response())
 
 	// ParamNames
-	c.Object().pnames = []string{"uid", "fid"}
+	c.(*context).pnames = []string{"uid", "fid"}
 	assert.EqualValues(t, []string{"uid", "fid"}, c.ParamNames())
 
 	// Param by id
-	c.Object().pnames = []string{"id"}
-	c.Object().pvalues = []string{"1"}
+	c.(*context).pnames = []string{"id"}
+	c.(*context).pvalues = []string{"1"}
 	assert.Equal(t, "1", c.P(0))
 
 	// Param by name
@@ -67,13 +67,13 @@ func TestContext(t *testing.T) {
 
 	// JSON
 	testBindOk(t, c, MIMEApplicationJSON)
-	c.Object().request = test.NewRequest(POST, "/", strings.NewReader(invalidContent))
+	c.(*context).RequestReader.Req = test.NewRequest(POST, "/", strings.NewReader(invalidContent))
 	testBindError(t, c, MIMEApplicationJSON)
 
 	// XML
-	c.Object().request = test.NewRequest(POST, "/", strings.NewReader(userXML))
+	c.(*context).RequestReader.Req = test.NewRequest(POST, "/", strings.NewReader(userXML))
 	testBindOk(t, c, MIMEApplicationXML)
-	c.Object().request = test.NewRequest(POST, "/", strings.NewReader(invalidContent))
+	c.(*context).RequestReader.Req = test.NewRequest(POST, "/", strings.NewReader(invalidContent))
 	testBindError(t, c, MIMEApplicationXML)
 
 	// Unsupported
@@ -86,14 +86,14 @@ func TestContext(t *testing.T) {
 	tpl := &Template{
 		templates: template.Must(template.New("hello").Parse("Hello, {{.}}!")),
 	}
-	c.Object().echo.SetRenderer(tpl)
+	c.(*context).echo.SetRenderer(tpl)
 	err := c.Render(http.StatusOK, "hello", "Joe")
 	if assert.NoError(t, err) {
 		assert.Equal(t, http.StatusOK, rec.Status())
 		assert.Equal(t, "Hello, Joe!", rec.Body.String())
 	}
 
-	c.Object().echo.renderer = nil
+	c.(*context).echo.renderer = nil
 	err = c.Render(http.StatusOK, "hello", "Joe")
 	assert.Error(t, err)
 
@@ -193,7 +193,7 @@ func TestContext(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rec.Status())
 
 	// Reset
-	c.Object().Reset(rq, test.NewResponseRecorder())
+	c.(*context).Reset(rq, test.NewResponseRecorder())
 }
 
 func TestContextPath(t *testing.T) {

--- a/map_store.go
+++ b/map_store.go
@@ -1,0 +1,19 @@
+package echo
+
+// MapStore is a string -> arbitrary value store with Get/Set methods.
+type MapStore map[string]interface{}
+
+// Set sets a key value into the store.
+func (m MapStore) Set(key string, val interface{}) {
+	m[key] = val
+}
+
+// Get retrieves a key from the store (may be nil)
+func (m MapStore) Get(key string) interface{} {
+	return m[key]
+}
+
+// Del removes a key from the store
+func (m MapStore) Del(key string) {
+	delete(m, key)
+}

--- a/net_context_embedder.go
+++ b/net_context_embedder.go
@@ -1,0 +1,42 @@
+package echo
+
+import (
+	"time"
+
+	netContext "golang.org/x/net/context"
+)
+
+// NetContextEmbedder elevates enables embedding of net.Context operations.
+type NetContextEmbedder struct {
+	Ctx netContext.Context
+}
+
+// SetNetContext sets the context
+func (n *NetContextEmbedder) SetNetContext(ctx netContext.Context) {
+	n.Ctx = ctx
+}
+
+// NetContext retrieves the context
+func (n *NetContextEmbedder) NetContext() netContext.Context {
+	return n.Ctx
+}
+
+// Deadline sets a deadline on the context
+func (n *NetContextEmbedder) Deadline() (deadline time.Time, ok bool) {
+	return n.Ctx.Deadline()
+}
+
+// Done gets the done channel for this request
+func (n *NetContextEmbedder) Done() <-chan struct{} {
+	return n.Ctx.Done()
+}
+
+// Err returns the error in the context
+func (n *NetContextEmbedder) Err() error {
+	return n.Ctx.Err()
+}
+
+// Value retrieves a value from the context
+func (n *NetContextEmbedder) Value(key interface{}) interface{} {
+	return n.Ctx.Value(key)
+}

--- a/request_reader.go
+++ b/request_reader.go
@@ -1,0 +1,50 @@
+package echo
+
+import (
+	"mime/multipart"
+
+	"github.com/labstack/echo/engine"
+)
+
+// RequestReader implements helpers around reading requests.
+type RequestReader struct {
+	Req engine.Request
+}
+
+// Request gets the underlying engine.Request
+func (r RequestReader) Request() engine.Request {
+	return r.Req
+}
+
+// QueryParam returns the query param for the provided name. It is an alias
+// for `engine.URL#QueryParam()`.
+func (r RequestReader) QueryParam(name string) string {
+	return r.Req.URL().QueryParam(name)
+}
+
+// QueryParams returns the query parameters as map. It is an alias for `engine.URL#QueryParams()`.
+func (r RequestReader) QueryParams() map[string][]string {
+	return r.Req.URL().QueryParams()
+}
+
+// FormValue returns the form field value for the provided name. It is an
+// alias for `engine.Request#FormValue()`.
+func (r RequestReader) FormValue(name string) string {
+	return r.Req.FormValue(name)
+}
+
+// FormParams returns the form parameters as map. It is an alias for `engine.Request#FormParams()`.
+func (r RequestReader) FormParams() map[string][]string {
+	return r.Req.FormParams()
+}
+
+// FormFile returns the multipart form file for the provided name. It is an
+// alias for `engine.Request#FormFile()`.
+func (r RequestReader) FormFile(name string) (*multipart.FileHeader, error) {
+	return r.Req.FormFile(name)
+}
+
+// MultipartForm returns the multipart form. It is an alias for `engine.Request#MultipartForm()`.
+func (r RequestReader) MultipartForm() (*multipart.Form, error) {
+	return r.Req.MultipartForm()
+}

--- a/response_writer.go
+++ b/response_writer.go
@@ -1,0 +1,173 @@
+package echo
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/labstack/echo/engine"
+)
+
+// ResponseWriter can write bodies to the underlying response
+type ResponseWriter struct {
+	Res engine.Response
+}
+
+// Response returns the inner engine response
+func (r ResponseWriter) Response() engine.Response {
+	return r.Res
+}
+
+// HTML writes html out to the response with proper Content-Type.
+func (r ResponseWriter) HTML(code int, html string) (err error) {
+	r.Res.Header().Set(HeaderContentType, MIMETextHTMLCharsetUTF8)
+	r.Res.WriteHeader(code)
+	_, err = r.Res.Write([]byte(html))
+	return
+}
+
+// String writes plain text to the response with proper Content-Type.
+func (r ResponseWriter) String(code int, s string) (err error) {
+	r.Res.Header().Set(HeaderContentType, MIMETextPlainCharsetUTF8)
+	r.Res.WriteHeader(code)
+	_, err = r.Res.Write([]byte(s))
+	return
+}
+
+// JSON marshals the object passed in and renders a code as well.
+func (r ResponseWriter) JSON(code int, i interface{}) error {
+	var byt []byte
+	var err error
+
+	byt, err = json.Marshal(i)
+	if err != nil {
+		return err
+	}
+
+	return r.JSONBlob(code, byt)
+}
+
+// JSONBlob writes out a JSON blob directly to the response and sets
+// the correct Content-Type.
+func (r ResponseWriter) JSONBlob(code int, blob []byte) (err error) {
+	r.Res.Header().Set(HeaderContentType, MIMEApplicationJSONCharsetUTF8)
+	r.Res.WriteHeader(code)
+	_, err = r.Res.Write(blob)
+	return err
+}
+
+// JSONP sends a JSONP response with status code. It uses `callback` to construct
+// the JSONP payload.
+func (r ResponseWriter) JSONP(code int, callback string, i interface{}) error {
+	byt, err := json.Marshal(i)
+	if err != nil {
+		return err
+	}
+	r.Res.Header().Set(HeaderContentType, MIMEApplicationJavaScriptCharsetUTF8)
+	r.Res.WriteHeader(code)
+
+	// TODO(aarondl): Is this better than what was there before?
+	_, err = fmt.Fprintf(r.Res, "%s(%s);", callback, byt)
+	return err
+}
+
+// XML encode i and send it to the response with a proper Content-Type.
+func (r ResponseWriter) XML(code int, i interface{}) error {
+	byt, err := xml.Marshal(i)
+	if err != nil {
+		return err
+	}
+	return r.XMLBlob(code, byt)
+}
+
+// XMLBlob writes a blob of XML to the response with proper Content-Type.
+func (r ResponseWriter) XMLBlob(code int, blob []byte) (err error) {
+	r.Res.Header().Set(HeaderContentType, MIMEApplicationXMLCharsetUTF8)
+	r.Res.WriteHeader(code)
+	if _, err = r.Res.Write([]byte(xml.Header)); err != nil {
+		return
+	}
+	_, err = r.Res.Write(blob)
+	return
+}
+
+// File sends a response with the content of the file.
+func (r ResponseWriter) File(request engine.Request, file string) error {
+	f, err := os.Open(file)
+	if err != nil {
+		return ErrNotFound
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	// TODO(aarondl): Validate why there was no error checking here
+	if err != nil {
+		return err
+	}
+
+	if fi.IsDir() {
+		file = filepath.Join(file, "index.html")
+		f, err = os.Open(file)
+		if err != nil {
+			return ErrNotFound
+		}
+		defer f.Close() //TODO(aarondl): Validate this close
+		if fi, err = f.Stat(); err != nil {
+			return err
+		}
+	}
+
+	return ServeContent(request, r.Res, f, fi.Name(), fi.ModTime())
+}
+
+// Attachment sends a response from `io.ReaderSeeker` as attachment, prompting
+// client to save the file.
+func (r ResponseWriter) Attachment(seeker io.ReadSeeker, name string) (err error) {
+	r.Res.Header().Set(HeaderContentType, ContentTypeByExtension(name))
+	r.Res.Header().Set(HeaderContentDisposition, "attachment; filename="+name)
+	r.Res.WriteHeader(http.StatusOK)
+	// TODO(aarondl): Why is this not using ServeContent?
+	_, err = io.Copy(r.Res, seeker)
+	return
+}
+
+// NoContent renders out an http status code.
+func (r ResponseWriter) NoContent(code int) error {
+	r.Res.WriteHeader(code)
+	return nil
+}
+
+// Redirect the client to a different URL. The code must be a valid redirect
+// code in the range of 300 to 307 or an error is returned.
+func (r ResponseWriter) Redirect(code int, url string) error {
+	if code < http.StatusMultipleChoices || code > http.StatusTemporaryRedirect {
+		return ErrInvalidRedirectCode
+	}
+	r.Res.Header().Set(HeaderLocation, url)
+	r.Res.WriteHeader(code)
+	return nil
+}
+
+// ServeContent intelligently serves content (like a file) to a client.
+// It handles caching as well as setting headers.
+//
+// TODO: It does not currently handle resuming a file like this because
+// it doesn't listen to the headers. It should probably use http.ServeContent
+func ServeContent(rq engine.Request, rs engine.Response, content io.ReadSeeker, name string, modtime time.Time) error {
+	if t, err := time.Parse(http.TimeFormat, rq.Header().Get(HeaderIfModifiedSince)); err == nil && modtime.Before(t.Add(1*time.Second)) {
+		rs.Header().Del(HeaderContentType)
+		rs.Header().Del(HeaderContentLength)
+		rs.WriteHeader(http.StatusNotModified)
+	}
+
+	rs.Header().Set(HeaderContentType, ContentTypeByExtension(name))
+	rs.Header().Set(HeaderLastModified, modtime.UTC().Format(http.TimeFormat))
+	rs.WriteHeader(http.StatusOK)
+	_, err := io.Copy(rs, content)
+	return err
+}

--- a/router.go
+++ b/router.go
@@ -286,8 +286,8 @@ func (n *node) checkMethodNotAllowed() HandlerFunc {
 // - Get context from `Echo#GetContext()`
 // - Reset it `Context#Reset()`
 // - Return it `Echo#PutContext()`.
-func (r *Router) Find(method, path string, context Context) {
-	ctx := context.Object()
+func (r *Router) Find(method, path string, ctx Context) {
+	context := ctx.(*context)
 	cn := r.tree // Current node as root
 
 	var (
@@ -356,7 +356,7 @@ func (r *Router) Find(method, path string, context Context) {
 	Param:
 		if c = cn.findChildByKind(pkind); c != nil {
 			// Issue #378
-			if len(ctx.pvalues) == n {
+			if len(context.pvalues) == n {
 				continue
 			}
 
@@ -371,7 +371,7 @@ func (r *Router) Find(method, path string, context Context) {
 			i, l := 0, len(search)
 			for ; i < l && search[i] != '/'; i++ {
 			}
-			ctx.pvalues[n] = search[:i]
+			context.pvalues[n] = search[:i]
 			n++
 			search = search[i:]
 			continue
@@ -393,30 +393,30 @@ func (r *Router) Find(method, path string, context Context) {
 			// Not found
 			return
 		}
-		ctx.pvalues[len(cn.pnames)-1] = search
+		context.pvalues[len(cn.pnames)-1] = search
 		goto End
 	}
 
 End:
-	ctx.handler = cn.findHandler(method)
-	ctx.path = cn.ppath
-	ctx.pnames = cn.pnames
+	context.handler = cn.findHandler(method)
+	context.path = cn.ppath
+	context.pnames = cn.pnames
 
 	// NOTE: Slow zone...
-	if ctx.handler == nil {
-		ctx.handler = cn.checkMethodNotAllowed()
+	if context.handler == nil {
+		context.handler = cn.checkMethodNotAllowed()
 
 		// Dig further for any, might have an empty value for *, e.g.
 		// serving a directory. Issue #207.
 		if cn = cn.findChildByKind(akind); cn == nil {
 			return
 		}
-		if ctx.handler = cn.findHandler(method); ctx.handler == nil {
-			ctx.handler = cn.checkMethodNotAllowed()
+		if context.handler = cn.findHandler(method); context.handler == nil {
+			context.handler = cn.checkMethodNotAllowed()
 		}
-		ctx.path = cn.ppath
-		ctx.pnames = cn.pnames
-		ctx.pvalues[len(cn.pnames)-1] = ""
+		context.path = cn.ppath
+		context.pnames = cn.pnames
+		context.pvalues[len(cn.pnames)-1] = ""
 	}
 
 	return

--- a/router_test.go
+++ b/router_test.go
@@ -281,7 +281,7 @@ func TestRouterStatic(t *testing.T) {
 		c.Set("path", path)
 		return nil
 	}, e)
-	c := NewContext(nil, nil, e).Object()
+	c := NewContext(nil, nil, e).(*context)
 	r.Find(GET, path, c)
 	c.handler(c)
 	assert.Equal(t, path, c.Get("path"))
@@ -377,7 +377,7 @@ func TestRouterMixParamMatchAny(t *testing.T) {
 	r.Add(GET, "/users/:id/*", func(c Context) error {
 		return nil
 	}, e)
-	c := NewContext(nil, nil, e).Object()
+	c := NewContext(nil, nil, e).(*context)
 
 	r.Find(GET, "/users/joe/comments", c)
 	c.handler(c)
@@ -396,7 +396,7 @@ func TestRouterMultiRoute(t *testing.T) {
 	r.Add(GET, "/users/:id", func(c Context) error {
 		return nil
 	}, e)
-	c := NewContext(nil, nil, e).Object()
+	c := NewContext(nil, nil, e).(*context)
 
 	// Route > /users
 	r.Find(GET, "/users", c)
@@ -408,7 +408,7 @@ func TestRouterMultiRoute(t *testing.T) {
 	assert.Equal(t, "1", c.P(0))
 
 	// Route > /user
-	c = NewContext(nil, nil, e).Object()
+	c = NewContext(nil, nil, e).(*context)
 	r.Find(GET, "/user", c)
 	he := c.handler(c).(*HTTPError)
 	assert.Equal(t, http.StatusNotFound, he.Code)
@@ -447,7 +447,7 @@ func TestRouterPriority(t *testing.T) {
 		c.Set("g", 7)
 		return nil
 	}, e)
-	c := NewContext(nil, nil, e).Object()
+	c := NewContext(nil, nil, e).(*context)
 
 	// Route > /users
 	r.Find(GET, "/users", c)
@@ -490,7 +490,7 @@ func TestRouterPriority(t *testing.T) {
 func TestRouterPriorityNotFound(t *testing.T) {
 	e := New()
 	r := e.router
-	c := NewContext(nil, nil, e).Object()
+	c := NewContext(nil, nil, e).(*context)
 
 	// Add
 	r.Add(GET, "/a/foo", func(c Context) error {
@@ -511,7 +511,7 @@ func TestRouterPriorityNotFound(t *testing.T) {
 	c.handler(c)
 	assert.Equal(t, 2, c.Get("b"))
 
-	c = NewContext(nil, nil, e).Object()
+	c = NewContext(nil, nil, e).(*context)
 	r.Find(GET, "/abc/def", c)
 	he := c.handler(c).(*HTTPError)
 	assert.Equal(t, http.StatusNotFound, he.Code)
@@ -532,7 +532,7 @@ func TestRouterParamNames(t *testing.T) {
 	r.Add(GET, "/users/:uid/files/:fid", func(c Context) error {
 		return nil
 	}, e)
-	c := NewContext(nil, nil, e).Object()
+	c := NewContext(nil, nil, e).(*context)
 
 	// Route > /users
 	r.Find(GET, "/users", c)
@@ -541,14 +541,14 @@ func TestRouterParamNames(t *testing.T) {
 
 	// Route > /users/:id
 	r.Find(GET, "/users/1", c)
-	assert.Equal(t, "id", c.Object().pnames[0])
+	assert.Equal(t, "id", c.pnames[0])
 	assert.Equal(t, "1", c.P(0))
 
 	// Route > /users/:uid/files/:fid
 	r.Find(GET, "/users/1/files/1", c)
-	assert.Equal(t, "uid", c.Object().pnames[0])
+	assert.Equal(t, "uid", c.pnames[0])
 	assert.Equal(t, "1", c.P(0))
-	assert.Equal(t, "fid", c.Object().pnames[1])
+	assert.Equal(t, "fid", c.pnames[1])
 	assert.Equal(t, "1", c.P(1))
 }
 
@@ -564,7 +564,7 @@ func TestRouterAPI(t *testing.T) {
 	c := NewContext(nil, nil, e)
 	for _, route := range api {
 		r.Find(route.Method, route.Path, c)
-		for i, n := range c.Object().pnames {
+		for i, n := range c.(*context).pnames {
 			if assert.NotEmpty(t, n) {
 				assert.Equal(t, ":"+n, c.P(i))
 			}


### PR DESCRIPTION
Work in progress. There's several TODO's to verify with the echo authors. As well as this is kind of the beginning of this work not the end. There's still potential to remove quite a few methods from *context into chunks that others can easily implement.

Commit message follows:

This change allows for "easier" creation of implementations
of a Context type. Because it's composed of many different
exported types that are based on simple types. Out of 36
methods on the Context interface, 28 of them can be implemented
by simply embedding a few structs into your mock type.

These new types are:
- echo.RequestReader
- echo.ResponseWriter
- echo.MapStore
- echo.NetContextEmbedder

This means the only methods that are required for Context
implementation is:
- Path
- P
- Param
- ParamNames
- Bind
- Render
- File
- Error
- Echo
- Handler
- Logger
- ServeContent
- Reset

Changes to Context()'s public interface:
- Delete the Object() method from the interface
  which made it impossible to implement this interface since
  it returned an exported type.
- Add a Del() to be able to delete things stored in "store".