### PR TITLE
Add echo.Binder() method

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -293,6 +293,11 @@ func (e *Echo) SetBinder(b Binder) {
 	e.binder = b
 }
 
+// Binder returns the binder instance.
+func (e *Echo) Binder() Binder {
+	return e.binder
+}
+
 // SetRenderer registers an HTML template renderer. It's invoked by `Context#Render()`.
 func (e *Echo) SetRenderer(r Renderer) {
 	e.renderer = r

--- a/echo_test.go
+++ b/echo_test.go
@@ -333,3 +333,19 @@ func request(method, path string, e *Echo) (int, string) {
 	e.ServeHTTP(req, rec)
 	return rec.Status(), rec.Body.String()
 }
+
+func TestEchoBinder(t *testing.T) {
+	e := New()
+
+	binder := testBinder{}
+	assert.NotEqual(t, binder, e.Binder())
+
+	e.SetBinder(binder)
+	assert.Equal(t, binder, e.Binder())
+}
+
+type testBinder struct {}
+
+func (_ testBinder) Bind(_ interface{}, _ Context) error {
+	return nil
+}


### PR DESCRIPTION
This method is useful when we call `SetBinder()` but still want to be able to use original default binder.