### PR TITLE
Allow blank Origin header in CORS middleware

### DIFF
--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -115,7 +115,6 @@ func CORSWithConfig(config CORSConfig) echo.MiddlewareFunc {
 				if exposeHeaders != "" {
 					res.Header().Set(echo.HeaderAccessControlExposeHeaders, exposeHeaders)
 				}
-				fmt.Println(res.Header().Keys())
 				return next(c)
 			}
 
@@ -128,7 +127,6 @@ func CORSWithConfig(config CORSConfig) echo.MiddlewareFunc {
 			}
 			res.Header().Set(echo.HeaderAccessControlAllowOrigin, allowedOrigin)
 			res.Header().Set(echo.HeaderAccessControlAllowMethods, allowMethods)
-			fmt.Println(res.Header().Keys())
 			if config.AllowCredentials {
 				res.Header().Set(echo.HeaderAccessControlAllowCredentials, "true")
 			}

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"fmt"
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/engine"
 	"net/http"

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -1,11 +1,12 @@
 package middleware
 
 import (
+	"fmt"
+	"github.com/labstack/echo"
+	"github.com/labstack/echo/engine"
 	"net/http"
 	"strconv"
 	"strings"
-
-	"github.com/labstack/echo"
 )
 
 type (
@@ -58,6 +59,19 @@ func CORS() echo.MiddlewareFunc {
 	return CORSWithConfig(DefaultCORSConfig)
 }
 
+//getOrigin returns the origin header, or a nil pointer if it is not set
+func getOrigin(req engine.Request) *string {
+	var origin string
+
+	for _, k := range req.Header().Keys() {
+		if strings.ToLower(k) == "origin" {
+			origin = req.Header().Get(echo.HeaderOrigin)
+			return &origin
+		}
+	}
+	return nil
+}
+
 // CORSWithConfig returns a CORS middleware from config.
 // See: `CORS()`.
 func CORSWithConfig(config CORSConfig) echo.MiddlewareFunc {
@@ -77,12 +91,12 @@ func CORSWithConfig(config CORSConfig) echo.MiddlewareFunc {
 		return func(c echo.Context) error {
 			req := c.Request()
 			res := c.Response()
-			origin := req.Header().Get(echo.HeaderOrigin)
+			origin := getOrigin(req)
 
 			// Check allowed origins
 			allowedOrigin := ""
 			for _, o := range config.AllowOrigins {
-				if o == "*" || o == origin {
+				if o == "*" || o == *origin {
 					allowedOrigin = o
 					break
 				}
@@ -91,7 +105,7 @@ func CORSWithConfig(config CORSConfig) echo.MiddlewareFunc {
 			// Simple request
 			if req.Method() != echo.OPTIONS {
 				res.Header().Add(echo.HeaderVary, echo.HeaderOrigin)
-				if origin == "" || allowedOrigin == "" {
+				if origin == nil || allowedOrigin == "" {
 					return next(c)
 				}
 				res.Header().Set(echo.HeaderAccessControlAllowOrigin, allowedOrigin)
@@ -101,6 +115,7 @@ func CORSWithConfig(config CORSConfig) echo.MiddlewareFunc {
 				if exposeHeaders != "" {
 					res.Header().Set(echo.HeaderAccessControlExposeHeaders, exposeHeaders)
 				}
+				fmt.Println(res.Header().Keys())
 				return next(c)
 			}
 
@@ -108,11 +123,12 @@ func CORSWithConfig(config CORSConfig) echo.MiddlewareFunc {
 			res.Header().Add(echo.HeaderVary, echo.HeaderOrigin)
 			res.Header().Add(echo.HeaderVary, echo.HeaderAccessControlRequestMethod)
 			res.Header().Add(echo.HeaderVary, echo.HeaderAccessControlRequestHeaders)
-			if origin == "" || allowedOrigin == "" {
+			if origin == nil || allowedOrigin == "" {
 				return next(c)
 			}
 			res.Header().Set(echo.HeaderAccessControlAllowOrigin, allowedOrigin)
 			res.Header().Set(echo.HeaderAccessControlAllowMethods, allowMethods)
+			fmt.Println(res.Header().Keys())
 			if config.AllowCredentials {
 				res.Header().Set(echo.HeaderAccessControlAllowCredentials, "true")
 			}

--- a/middleware/cors_test.go
+++ b/middleware/cors_test.go
@@ -25,6 +25,14 @@ func TestCORS(t *testing.T) {
 	h(c)
 	assert.Equal(t, "", rec.Header().Get(echo.HeaderAccessControlAllowOrigin))
 
+	// Blank origin header
+	req = test.NewRequest(echo.GET, "/", nil)
+	rec = test.NewResponseRecorder()
+	c = e.NewContext(req, rec)
+	req.Header().Set(echo.HeaderOrigin, "")
+	h(c)
+	assert.Equal(t, "*", rec.Header().Get(echo.HeaderAccessControlAllowOrigin))
+
 	// Wildcard origin
 	req = test.NewRequest(echo.GET, "/", nil)
 	rec = test.NewResponseRecorder()


### PR DESCRIPTION
As reported in #517, the Access-Control-Allow-Origin header is not being sent in the following case:

* The "Origin" header is set in the request but it is blank
* The allowed origins configuration setting is "*"

As a blank "Origin" header is not invalid (see eg. [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Origin)), I think that the Access-Control-Allow-Origin header should be sent back with "*" in this case. 

This pull request corrects that while preserving the current behaviour that if the "Origin" header is not present, then the Access-Control-Allow-Origin header will *not* be sent. 