### PR TITLE
fix index out of bounds if path is empty

### DIFF
--- a/middleware/slash.go
+++ b/middleware/slash.go
@@ -69,7 +69,7 @@ func RemoveTrailingSlashWithConfig(config TrailingSlashConfig) echo.MiddlewareFu
 			path := url.Path()
 			qs := url.QueryString()
 			l := len(path) - 1
-			if path != "/" && path[l] == '/' {
+			if l >= 0 && path != "/" && path[l] == '/' {
 				path = path[:l]
 				uri := path
 				if qs != "" {

--- a/middleware/slash_test.go
+++ b/middleware/slash_test.go
@@ -59,4 +59,15 @@ func TestRemoveTrailingSlash(t *testing.T) {
 	h(c)
 	assert.Equal(t, http.StatusMovedPermanently, rec.Status())
 	assert.Equal(t, "/remove-slash?key=value", rec.Header().Get(echo.HeaderLocation))
+
+	// With bare URL
+	req = test.NewRequest(echo.GET, "http://localhost", nil)
+	rec = test.NewResponseRecorder()
+	c = e.NewContext(req, rec)
+	h = RemoveTrailingSlash()(func(c echo.Context) error {
+		return nil
+	})
+	h(c)
+	assert.Equal(t, "", req.URL().Path())
+	assert.Equal(t, "http://localhost", req.URI())
 }


### PR DESCRIPTION
A url with no path was causing the middleware to panic.