### PR TITLE
fix issue of #536, build engines failure.

### DIFF
--- a/engine/fasthttp/request.go
+++ b/engine/fasthttp/request.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/engine"
-	"github.com/labstack/gommon/log"
+	"github.com/labstack/echo/log"
 	"github.com/valyala/fasthttp"
 )
 
@@ -19,12 +19,12 @@ type (
 		*fasthttp.RequestCtx
 		header engine.Header
 		url    engine.URL
-		logger *log.Logger
+		logger log.Logger
 	}
 )
 
 // NewRequest returns `Request` instance.
-func NewRequest(c *fasthttp.RequestCtx, l *log.Logger) *Request {
+func NewRequest(c *fasthttp.RequestCtx, l log.Logger) *Request {
 	return &Request{
 		RequestCtx: c,
 		url:        &URL{URI: c.URI()},

--- a/engine/fasthttp/response.go
+++ b/engine/fasthttp/response.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/engine"
-	"github.com/labstack/gommon/log"
+	"github.com/labstack/echo/log"
 	"github.com/valyala/fasthttp"
 )
 
@@ -20,12 +20,12 @@ type (
 		size      int64
 		committed bool
 		writer    io.Writer
-		logger    *log.Logger
+		logger    log.Logger
 	}
 )
 
 // NewResponse returns `Response` instance.
-func NewResponse(c *fasthttp.RequestCtx, l *log.Logger) *Response {
+func NewResponse(c *fasthttp.RequestCtx, l log.Logger) *Response {
 	return &Response{
 		RequestCtx: c,
 		header:     &ResponseHeader{ResponseHeader: &c.Response.Header},

--- a/engine/fasthttp/server.go
+++ b/engine/fasthttp/server.go
@@ -7,8 +7,11 @@ import (
 
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/engine"
-	"github.com/labstack/gommon/log"
+	"github.com/labstack/echo/log"
+
 	"github.com/valyala/fasthttp"
+
+	gommon_log "github.com/labstack/gommon/log"
 )
 
 type (
@@ -17,7 +20,7 @@ type (
 		*fasthttp.Server
 		config  engine.Config
 		handler engine.Handler
-		logger  *log.Logger
+		logger  log.Logger
 		pool    *pool
 	}
 
@@ -81,7 +84,7 @@ func WithConfig(c engine.Config) (s *Server) {
 		handler: engine.HandlerFunc(func(req engine.Request, res engine.Response) {
 			s.logger.Error("handler not set, use `SetHandler()` to set it.")
 		}),
-		logger: log.New("echo"),
+		logger: gommon_log.New("echo"),
 	}
 	s.Handler = s.ServeHTTP
 	return
@@ -93,7 +96,7 @@ func (s *Server) SetHandler(h engine.Handler) {
 }
 
 // SetLogger implements `engine.Server#SetLogger` function.
-func (s *Server) SetLogger(l *log.Logger) {
+func (s *Server) SetLogger(l log.Logger) {
 	s.logger = l
 }
 

--- a/engine/standard/request.go
+++ b/engine/standard/request.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/engine"
-	"github.com/labstack/gommon/log"
+	"github.com/labstack/echo/log"
 )
 
 type (
@@ -18,7 +18,7 @@ type (
 		*http.Request
 		header engine.Header
 		url    engine.URL
-		logger *log.Logger
+		logger log.Logger
 	}
 )
 
@@ -27,7 +27,7 @@ const (
 )
 
 // NewRequest returns `Request` instance.
-func NewRequest(r *http.Request, l *log.Logger) *Request {
+func NewRequest(r *http.Request, l log.Logger) *Request {
 	return &Request{
 		Request: r,
 		url:     &URL{URL: r.URL},

--- a/engine/standard/response.go
+++ b/engine/standard/response.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/engine"
-	"github.com/labstack/gommon/log"
+	"github.com/labstack/echo/log"
 )
 
 type (
@@ -19,7 +19,7 @@ type (
 		size      int64
 		committed bool
 		writer    io.Writer
-		logger    *log.Logger
+		logger    log.Logger
 	}
 
 	responseAdapter struct {
@@ -29,7 +29,7 @@ type (
 )
 
 // NewResponse returns `Response` instance.
-func NewResponse(w http.ResponseWriter, l *log.Logger) *Response {
+func NewResponse(w http.ResponseWriter, l log.Logger) *Response {
 	return &Response{
 		ResponseWriter: w,
 		header:         &Header{Header: w.Header()},

--- a/engine/standard/server.go
+++ b/engine/standard/server.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/engine"
-	"github.com/labstack/gommon/log"
+	"github.com/labstack/echo/log"
+
+	gommon_log "github.com/labstack/gommon/log"
 )
 
 type (
@@ -15,7 +17,7 @@ type (
 		*http.Server
 		config  engine.Config
 		handler engine.Handler
-		logger  *log.Logger
+		logger  log.Logger
 		pool    *pool
 	}
 
@@ -79,7 +81,7 @@ func WithConfig(c engine.Config) (s *Server) {
 		handler: engine.HandlerFunc(func(req engine.Request, res engine.Response) {
 			s.logger.Error("handler not set, use `SetHandler()` to set it.")
 		}),
-		logger: log.New("echo"),
+		logger: gommon_log.New("echo"),
 	}
 	s.Addr = c.Address
 	s.Handler = s
@@ -92,7 +94,7 @@ func (s *Server) SetHandler(h engine.Handler) {
 }
 
 // SetLogger implements `engine.Server#SetLogger` function.
-func (s *Server) SetLogger(l *log.Logger) {
+func (s *Server) SetLogger(l log.Logger) {
 	s.logger = l
 }
 


### PR DESCRIPTION
cannot use standard.New(":1323") (type *standard.Server) as type engine.Server in argument to e.Run: *standard.Server does not implement engine.Server (wrong type for SetLogger method) have SetLogger(*"github.com/labstack/gommon/log".Logger) want SetLogger("github.com/labstack/echo/log".Logger) exit status 2