### PR TITLE
For consistency, added additional header constant for 'Allow' named '…

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -141,6 +141,7 @@ const (
 // Headers
 const (
 	HeaderAcceptEncoding                = "Accept-Encoding"
+	HeaderAllow                         = "Allow"
 	HeaderAuthorization                 = "Authorization"
 	HeaderContentDisposition            = "Content-Disposition"
 	HeaderContentEncoding               = "Content-Encoding"


### PR DESCRIPTION
…HeaderAllow', which is missing when forming responses to OPTIONS method requests