### PR TITLE
Fix cookies parsing

### DIFF
--- a/engine/fasthttp/request.go
+++ b/engine/fasthttp/request.go
@@ -136,12 +136,12 @@ func (r *Request) MultipartForm() (*multipart.Form, error) {
 // Cookie implements `engine.Request#Cookie` function.
 func (r *Request) Cookie(name string) (engine.Cookie, error) {
 	c := new(fasthttp.Cookie)
-	c.SetKey(name)
 	b := r.Request.Header.Cookie(name)
 	if b == nil {
 		return nil, echo.ErrCookieNotFound
 	}
 	c.ParseBytes(b)
+	c.SetKey(name)
 	return &Cookie{c}, nil
 }
 

--- a/engine/test/test_request.go
+++ b/engine/test/test_request.go
@@ -78,6 +78,7 @@ func RequestTest(t *testing.T, request engine.Request) {
 	}
 
 	if cookie, err := request.Cookie("session"); assert.NoError(t, err) {
+		assert.Equal(t, "session", cookie.Name())
 		assert.Equal(t, "securetoken", cookie.Value())
 	}
 


### PR DESCRIPTION
https://github.com/valyala/fasthttp/blob/master/cookie.go#L261 entirely resets all cookie properties what makes `c.SetKey(name)` useless and cookies are returned with empty names.