### PR TITLE
convert limit type from int to int64

### DIFF
--- a/middleware/body_limit.go
+++ b/middleware/body_limit.go
@@ -45,7 +45,7 @@ func BodyLimitWithConfig(config BodyLimitConfig) echo.MiddlewareFunc {
 	if err != nil {
 		panic(fmt.Errorf("invalid body-limit=%s", config.Limit))
 	}
-	config.limit = limit
+	config.limit = int64(limit)
 	pool := limitedReaderPool(config)
 
 	return func(next echo.HandlerFunc) echo.HandlerFunc {


### PR DESCRIPTION
```
# github.com/labstack/echo/middleware
.direnv/lib/src/github.com/labstack/echo/middleware/body_limit.go:48: cannot use limit (type int) as type int64 in assignment
```