### PR TITLE
minor fix regarding jwt token parsing

### DIFF
--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -124,7 +124,7 @@ func jwtFromHeader(header string) jwtExtractor {
 		auth := c.Request().Header().Get(header)
 		l := len(bearer)
 		if len(auth) > l+1 && auth[:l] == bearer {
-			return auth[l+1:], nil
+			return auth[l:], nil
 		}
 		return "", errors.New("empty or invalid jwt in authorization header")
 	}


### PR DESCRIPTION
by returning `auth[l+1:]` the first byte of the JWT was being deleted therefore corrupting the token. Changed to `auth[l:]` hereby solving the issue.