### PR TITLE
Fix issue with middleware from one route leaking into the middleware …

### DIFF
--- a/group.go
+++ b/group.go
@@ -142,6 +142,11 @@ func (g *Group) File(path, file string) {
 }
 
 func (g *Group) add(method, path string, handler HandlerFunc, middleware ...MiddlewareFunc) {
-	middleware = append(g.middleware, middleware...)
-	g.echo.add(method, g.prefix+path, handler, middleware...)
+	// combine into a new slice, to avoid accidentally passing the same
+	// slice for multiple routes, which would lead to later add() calls overwriting
+	// the middleware from earlier calls
+	var mw []MiddlewareFunc
+	mw = append(mw, g.middleware...)
+	mw = append(mw, middleware...)
+	g.echo.add(method, g.prefix+path, handler, mw...)
 }


### PR DESCRIPTION
…of other routes.

The underlying array of the group's middleware slice was being reused.  On the third middleware you add to the group, the group's middleware slice's capacity is increased to 4.  In the add method, the route-specific middleware is appended onto the existing array.  Later routes end up overwriting the earlier route's middleware.

Pull includes test and fix.