### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ type User struct {
 
 e.POST("/users", func(c echo.Context) error {
 	u := new(User)
-	if err := c.Bind(u); err != nil {
+	if err := c.Bind(&u); err != nil {
 		return err
 	}
 	return c.JSON(http.StatusCreated, u)


### PR DESCRIPTION
Added missing '&'. The example throws a non-pointer unmarshal error otherwise.