### PR TITLE
Support Go v1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 go:
-    - 1.5
-    - 1.6
+    - 1.7
     - tip
 before_install:
     - go get github.com/modocache/gover

--- a/context.go
+++ b/context.go
@@ -1,6 +1,8 @@
 package echo
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"encoding/xml"
 	"io"
@@ -13,20 +15,16 @@ import (
 
 	"github.com/labstack/echo/engine"
 	"github.com/labstack/echo/log"
-
-	"bytes"
-
-	"golang.org/x/net/context"
 )
 
 type (
 	// Context represents the context of the current HTTP request. It holds request and
 	// response objects, path, path parameters, data and registered handler.
 	Context interface {
-		// Context returns `net/context.Context`.
+		// Context returns `context.Context`.
 		Context() context.Context
 
-		// SetContext sets `net/context.Context`.
+		// SetContext sets `context.Context`.
 		SetContext(context.Context)
 
 		// Deadline returns the time when work done on behalf of this context

--- a/context_test.go
+++ b/context_test.go
@@ -2,6 +2,7 @@ package echo
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"mime/multipart"
@@ -10,8 +11,6 @@ import (
 	"testing"
 	"text/template"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"strings"
 

--- a/echo.go
+++ b/echo.go
@@ -39,6 +39,7 @@ package echo
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -47,8 +48,6 @@ import (
 	"reflect"
 	"runtime"
 	"sync"
-
-	"golang.org/x/net/context"
 
 	"github.com/labstack/echo/engine"
 	"github.com/labstack/echo/log"


### PR DESCRIPTION
Hi,

Go 1.7 has just been released and a problem with net/context appeared. Unfortunately this change is not backward compatible with SDK versions older than 1.7.

Kind regards,
Marcin