### PR TITLE
 Inline feature

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -145,6 +145,19 @@ func TestContext(t *testing.T) {
 		}
 	}
 
+	// Inline
+	rec = test.NewResponseRecorder()
+	c = e.NewContext(req, rec).(*echoContext)
+	file, err = os.Open("_fixture/images/walle.png")
+	if assert.NoError(t, err) {
+		err = c.Inline(file, "walle.png")
+		if assert.NoError(t, err) {
+			assert.Equal(t, http.StatusOK, rec.Status())
+			assert.Equal(t, "inline; filename=walle.png", rec.Header().Get(HeaderContentDisposition))
+			assert.Equal(t, 219885, rec.Body.Len())
+		}
+	}
+
 	// NoContent
 	rec = test.NewResponseRecorder()
 	c = e.NewContext(req, rec).(*echoContext)


### PR DESCRIPTION
Along with **attachment** it would be possible to return a file as **inline** according to [rfc 2183](https://www.ietf.org/rfc/rfc2183.txt) item `2.1  The Inline Disposition Type`