### PR TITLE
Fix XML double WriteHeader

### DIFF
--- a/context.go
+++ b/context.go
@@ -390,10 +390,13 @@ func (c *context) XML(code int, i interface{}) (err error) {
 }
 
 func (c *context) XMLBlob(code int, b []byte) (err error) {
+	c.response.Header().Set(HeaderContentType, MIMEApplicationXMLCharsetUTF8)
+	c.response.WriteHeader(code)
 	if _, err = c.response.Write([]byte(xml.Header)); err != nil {
 		return
 	}
-	return c.Blob(code, MIMEApplicationXMLCharsetUTF8, b)
+	_, err = c.response.Write(b)
+	return
 }
 
 func (c *context) Blob(code int, contentType string, b []byte) (err error) {

--- a/context_test.go
+++ b/context_test.go
@@ -99,9 +99,9 @@ func TestContext(t *testing.T) {
 	// XML
 	rec = test.NewResponseRecorder()
 	c = e.NewContext(req, rec).(*context)
-	err = c.XML(http.StatusOK, user{1, "Jon Snow"})
+	err = c.XML(http.StatusCreated, user{1, "Jon Snow"})
 	if assert.NoError(t, err) {
-		assert.Equal(t, http.StatusOK, rec.Status())
+		assert.Equal(t, http.StatusCreated, rec.Status())
 		assert.Equal(t, MIMEApplicationXMLCharsetUTF8, rec.Header().Get(HeaderContentType))
 		assert.Equal(t, xml.Header+userXML, rec.Body.String())
 	}

--- a/test/response.go
+++ b/test/response.go
@@ -55,6 +55,9 @@ func (r *Response) WriteHeader(code int) {
 }
 
 func (r *Response) Write(b []byte) (n int, err error) {
+	if !r.committed {
+		r.WriteHeader(http.StatusOK)
+	}
 	n, err = r.writer.Write(b)
 	r.size += int64(n)
 	return


### PR DESCRIPTION
Was getting a "response already committed" warning due to Write being called before WriteHeader, causing WriteHeader to be called with a http.StatusOK. Then WriteHeader is attempted later in Blob, triggering the warning and could cause the incorrect status code if you didn't call with 200.

I've updated the test Response to behave the same as the fasthttp and standard Responses and modified the XML test to use a non-200 status code to pick up on this. It could be worth while changing the others to non-200 to pick up on a regression.