### PR TITLE
Allows LoggerConfig to add new header, form, path and query tags

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -37,10 +37,9 @@ type (
 		// - latency_human (Human readable)
 		// - bytes_in (Bytes received)
 		// - bytes_out (Bytes sent)
-		// - header_HEADER_NAME (Where HEADER_NAME is your desired header)
-		// - path_PATH_PARAM_NAME
-		// - query_QUERY_PARAM_NAME
-		// - form_FORM_PARAM_NAME
+		// - header:<name>
+		// - query:<name>
+		// - form:<name>
 		//
 		// Example "${remote_ip} ${status}"
 		//
@@ -169,8 +168,6 @@ func LoggerWithConfig(config LoggerConfig) echo.MiddlewareFunc {
 					switch {
 					case strings.HasPrefix(tag, "header:"):
 						return buf.Write([]byte(c.Request().Header.Get(tag[7:])))
-					case strings.HasPrefix(tag, "path:"):
-						return buf.Write([]byte(c.Param(tag[5:])))
 					case strings.HasPrefix(tag, "query:"):
 						return buf.Write([]byte(c.QueryParam(tag[6:])))
 					case strings.HasPrefix(tag, "form:"):

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -36,6 +37,10 @@ type (
 		// - latency_human (Human readable)
 		// - bytes_in (Bytes received)
 		// - bytes_out (Bytes sent)
+		// - header_HEADER_NAME (Where HEADER_NAME is your desired header)
+		// - path_PATH_PARAM_NAME
+		// - query_QUERY_PARAM_NAME
+		// - form_FORM_PARAM_NAME
 		//
 		// Example "${remote_ip} ${status}"
 		//
@@ -160,6 +165,17 @@ func LoggerWithConfig(config LoggerConfig) echo.MiddlewareFunc {
 					return w.Write([]byte(b))
 				case "bytes_out":
 					return w.Write([]byte(strconv.FormatInt(res.Size, 10)))
+				default:
+					switch {
+					case strings.HasPrefix(tag, "header:"):
+						return buf.Write([]byte(c.Request().Header.Get(tag[7:])))
+					case strings.HasPrefix(tag, "path:"):
+						return buf.Write([]byte(c.Param(tag[5:])))
+					case strings.HasPrefix(tag, "query:"):
+						return buf.Write([]byte(c.QueryParam(tag[6:])))
+					case strings.HasPrefix(tag, "form:"):
+						return buf.Write([]byte(c.FormValue(tag[5:])))
+					}
 				}
 				return 0, nil
 			})

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -94,11 +94,9 @@ func TestLoggerTemplate(t *testing.T) {
 		Output: buf,
 	}))
 
-	h := func(c echo.Context) error {
+	e.GET("/", func(c echo.Context) error {
 		return c.String(http.StatusOK, "Header Logged")
-	}
-
-	e.GET("/", h)
+	})
 
 	req, _ := http.NewRequest(echo.GET, "/?username=apagano-param&password=secret", nil)
 	req.RequestURI = "/"

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/labstack/echo"
@@ -77,4 +78,120 @@ func TestLoggerIPAddress(t *testing.T) {
 	buf.Reset()
 	h(c)
 	assert.Contains(t, ip, buf.String())
+}
+
+func TestLoggerHeaders(t *testing.T) {
+	e := echo.New()
+	buf := new(bytes.Buffer)
+
+	logger := LoggerWithConfig(LoggerConfig{
+		Skipper: defaultSkipper,
+		Format: `{"time":"${time_rfc3339}","remote_ip":"${remote_ip}","host":"${host}",` +
+			`"method":"${method}","uri":"${uri}","status":${status}, "latency":${latency},` +
+			`"latency_human":"${latency_human}","bytes_in":${bytes_in},` +
+			`"bytes_out":${bytes_out},"custom_header":"${header:X-Custom-Header}"}` + "\n",
+		Output: buf,
+	})
+
+	req, _ := http.NewRequest(echo.GET, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	h := logger(func(c echo.Context) error {
+		return c.String(http.StatusOK, "Header Logged")
+	})
+
+	req.Header.Add("X-Custom-Header", "AAA-CUSTOM-VALUE")
+	req.Header.Add("X-Custom-B-Header", "BBB-CUSTOM-VALUE")
+	h(c)
+
+	assert.Contains(t, buf.String(), "AAA-CUSTOM-VALUE")
+	assert.NotContains(t, buf.String(), "BBB-CUSTOM-VALUE")
+}
+
+func TestLoggerQuery(t *testing.T) {
+	e := echo.New()
+	buf := new(bytes.Buffer)
+
+	logger := LoggerWithConfig(LoggerConfig{
+		Skipper: defaultSkipper,
+		Format: `{"time":"${time_rfc3339}","remote_ip":"${remote_ip}","host":"${host}",` +
+			`"method":"${method}","uri":"${uri}","status":${status}, "latency":${latency},` +
+			`"latency_human":"${latency_human}","bytes_in":${bytes_in},` +
+			`"bytes_out":${bytes_out},"custom_header":"${query:username}"}` + "\n",
+		Output: buf,
+	})
+
+	req, _ := http.NewRequest(echo.GET, "/?username=apagano&password=secret", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	h := logger(func(c echo.Context) error {
+		return c.String(http.StatusOK, "Header Logged")
+	})
+
+	h(c)
+
+	assert.Contains(t, buf.String(), "apagano")
+	assert.NotContains(t, buf.String(), "secret")
+}
+
+func TestLoggerForm(t *testing.T) {
+	e := echo.New()
+	buf := new(bytes.Buffer)
+
+	logger := LoggerWithConfig(LoggerConfig{
+		Skipper: defaultSkipper,
+		Format: `{"time":"${time_rfc3339}","remote_ip":"${remote_ip}","host":"${host}",` +
+			`"method":"${method}","uri":"${uri}","status":${status}, "latency":${latency},` +
+			`"latency_human":"${latency_human}","bytes_in":${bytes_in},` +
+			`"bytes_out":${bytes_out},"custom_header":"${form:username}"}` + "\n",
+		Output: buf,
+	})
+
+	req, _ := http.NewRequest(echo.POST, "/", nil)
+	req.Form = url.Values{
+		"username": []string{"apagano"},
+		"password": []string{"secret"},
+	}
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	h := logger(func(c echo.Context) error {
+		return c.String(http.StatusOK, "Header Logged")
+	})
+
+	h(c)
+
+	assert.Contains(t, buf.String(), "apagano")
+	assert.NotContains(t, buf.String(), "secret")
+}
+
+func TestLoggerPath(t *testing.T) {
+	e := echo.New()
+	buf := new(bytes.Buffer)
+
+	logger := LoggerWithConfig(LoggerConfig{
+		Skipper: defaultSkipper,
+		Format: `{"time":"${time_rfc3339}","remote_ip":"${remote_ip}","host":"${host}",` +
+			`"method":"${method}","uri":"${uri}","status":${status}, "latency":${latency},` +
+			`"latency_human":"${latency_human}","bytes_in":${bytes_in},` +
+			`"bytes_out":${bytes_out},"custom_header":"${path:username}"}` + "\n",
+		Output: buf,
+	})
+
+	req, _ := http.NewRequest(echo.POST, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("username", "hash")
+	c.SetParamValues("apagano", "hexvalue")
+
+	h := logger(func(c echo.Context) error {
+		return c.String(http.StatusOK, "Header Logged")
+	})
+
+	h(c)
+
+	assert.Contains(t, buf.String(), "apagano")
+	assert.NotContains(t, buf.String(), "hexvalue")
 }

--- a/website/content/middleware/logger.md
+++ b/website/content/middleware/logger.md
@@ -63,10 +63,9 @@ LoggerConfig struct {
   // - latency_human (Human readable)
   // - bytes_in (Bytes received)
   // - bytes_out (Bytes sent)
-  // - header_HEADER_NAME (Where HEADER_NAME is your desired header)
-  // - path_PATH_PARAM_NAME
-  // - query_QUERY_PARAM_NAME
-  // - form_FORM_PARAM_NAME
+  // - header:<name>
+  // - query:<name>
+  // - form:<name>
   //
   // Example "${remote_ip} ${status}"
   //

--- a/website/content/middleware/logger.md
+++ b/website/content/middleware/logger.md
@@ -63,6 +63,10 @@ LoggerConfig struct {
   // - latency_human (Human readable)
   // - bytes_in (Bytes received)
   // - bytes_out (Bytes sent)
+  // - header_HEADER_NAME (Where HEADER_NAME is your desired header)
+  // - path_PATH_PARAM_NAME
+  // - query_QUERY_PARAM_NAME
+  // - form_FORM_PARAM_NAME
   //
   // Example "${remote_ip} ${status}"
   //


### PR DESCRIPTION
@vishr this adds the ability to use header, form, query, path tags to the logger middleware format.
(crossing fingers this one actually shows only one commit :D)