### PR TITLE
Move imports to gopkg.in/echo.v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ go:
     - 1.7
     - tip
 before_install:
+    - mkdir $GOPATH/src/gopkg.in && mv $GOPATH/src/github.com/labstack/echo $GOPATH/src/gopkg.in/echo.v2
+    - cd $GOPATH/src/gopkg.in/echo.v2
     - go get github.com/modocache/gover
     - go get github.com/mattn/goveralls
     - go get golang.org/x/tools/cmd/cover

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Echo v2](http://echo.labstack.com/v2) [![GoDoc](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](http://godoc.org/github.com/labstack/echo) [![License](http://img.shields.io/badge/license-mit-blue.svg?style=flat-square)](https://raw.githubusercontent.com/labstack/echo/master/LICENSE) [![Build Status](http://img.shields.io/travis/labstack/echo.svg?style=flat-square)](https://travis-ci.org/labstack/echo) [![Coverage Status](http://img.shields.io/coveralls/labstack/echo.svg?style=flat-square)](https://coveralls.io/r/labstack/echo) [![Join the chat at https://gitter.im/labstack/echo](https://img.shields.io/badge/gitter-join%20chat-brightgreen.svg?style=flat-square)](https://gitter.im/labstack/echo) [![Twitter](https://img.shields.io/badge/twitter-@labstack-55acee.svg?style=flat-square)](https://twitter.com/labstack)
+# [Echo v2](http://echo.labstack.com/v2) [![GoDoc](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](http://godoc.org/gopkg.in/echo.v2) [![License](http://img.shields.io/badge/license-mit-blue.svg?style=flat-square)](https://raw.githubusercontent.com/labstack/echo/master/LICENSE) [![Build Status](http://img.shields.io/travis/labstack/echo.svg?style=flat-square)](https://travis-ci.org/labstack/echo) [![Coverage Status](http://img.shields.io/coveralls/labstack/echo.svg?style=flat-square)](https://coveralls.io/r/labstack/echo) [![Join the chat at https://gitter.im/labstack/echo](https://img.shields.io/badge/gitter-join%20chat-brightgreen.svg?style=flat-square)](https://gitter.im/labstack/echo) [![Twitter](https://img.shields.io/badge/twitter-@labstack-55acee.svg?style=flat-square)](https://twitter.com/labstack)
 
 ## Don't forget to try the upcoming [v3](https://github.com/labstack/echo/tree/v3) tracked [here]( https://github.com/labstack/echo/issues/665)
 
@@ -37,7 +37,7 @@
 Echo is developed and tested using Go `1.6.x` and `1.7.x`
 
 ```sh
-$ go get -u github.com/labstack/echo
+$ go get -u gopkg.in/echo.v2
 ```
 
 > Ideally, you should rely on a [package manager](https://github.com/avelino/awesome-go#package-management) like glide or govendor to use a specific [version](https://github.com/labstack/echo/releases) of Echo.
@@ -51,8 +51,8 @@ package main
 
 import (
 	"net/http"
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine/standard"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine/standard"
 )
 
 func main() {

--- a/binder_test.go
+++ b/binder_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/labstack/echo/test"
+	"gopkg.in/echo.v2/test"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/context.go
+++ b/context.go
@@ -12,12 +12,12 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/labstack/echo/engine"
-	"github.com/labstack/echo/log"
+	"gopkg.in/echo.v2/engine"
+	"gopkg.in/echo.v2/log"
 
 	"bytes"
 
-	gcontext "github.com/labstack/echo/context"
+	gcontext "gopkg.in/echo.v2/context"
 )
 
 type (

--- a/context_test.go
+++ b/context_test.go
@@ -13,13 +13,13 @@ import (
 
 	"strings"
 
-	gcontext "github.com/labstack/echo/context"
+	gcontext "gopkg.in/echo.v2/context"
 
 	"net/url"
 
 	"encoding/xml"
 
-	"github.com/labstack/echo/test"
+	"gopkg.in/echo.v2/test"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/echo.go
+++ b/echo.go
@@ -8,9 +8,9 @@ Example:
 	import (
 	    "net/http"
 
-	    "github.com/labstack/echo"
-	    "github.com/labstack/echo/engine/standard"
-	    "github.com/labstack/echo/middleware"
+	    "gopkg.in/echo.v2"
+	    "gopkg.in/echo.v2/engine/standard"
+	    "gopkg.in/echo.v2/middleware"
 	)
 
 	// Handler
@@ -48,9 +48,9 @@ import (
 	"runtime"
 	"sync"
 
-	gcontext "github.com/labstack/echo/context"
-	"github.com/labstack/echo/engine"
-	"github.com/labstack/echo/log"
+	gcontext "gopkg.in/echo.v2/context"
+	"gopkg.in/echo.v2/engine"
+	"gopkg.in/echo.v2/log"
 	glog "github.com/labstack/gommon/log"
 )
 

--- a/echo_test.go
+++ b/echo_test.go
@@ -12,7 +12,7 @@ import (
 
 	"errors"
 
-	"github.com/labstack/echo/test"
+	"gopkg.in/echo.v2/test"
 	"github.com/labstack/gommon/log"
 	"github.com/stretchr/testify/assert"
 )

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -7,7 +7,7 @@ import (
 
 	"net"
 
-	"github.com/labstack/echo/log"
+	"gopkg.in/echo.v2/log"
 )
 
 type (

--- a/engine/fasthttp/cookie_test.go
+++ b/engine/fasthttp/cookie_test.go
@@ -1,7 +1,7 @@
 package fasthttp
 
 import (
-	"github.com/labstack/echo/engine/test"
+	"gopkg.in/echo.v2/engine/test"
 	fast "github.com/valyala/fasthttp"
 	"testing"
 	"time"

--- a/engine/fasthttp/header_test.go
+++ b/engine/fasthttp/header_test.go
@@ -1,7 +1,7 @@
 package fasthttp
 
 import (
-	"github.com/labstack/echo/engine/test"
+	"gopkg.in/echo.v2/engine/test"
 	"github.com/stretchr/testify/assert"
 	fast "github.com/valyala/fasthttp"
 	"testing"

--- a/engine/fasthttp/request.go
+++ b/engine/fasthttp/request.go
@@ -8,9 +8,9 @@ import (
 	"mime/multipart"
 	"net"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine"
-	"github.com/labstack/echo/log"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine"
+	"gopkg.in/echo.v2/log"
 	"github.com/valyala/fasthttp"
 )
 

--- a/engine/fasthttp/request_test.go
+++ b/engine/fasthttp/request_test.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/labstack/echo/engine/test"
+	"gopkg.in/echo.v2/engine/test"
 	"github.com/labstack/gommon/log"
 	fast "github.com/valyala/fasthttp"
 )

--- a/engine/fasthttp/response.go
+++ b/engine/fasthttp/response.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/labstack/echo/engine"
-	"github.com/labstack/echo/log"
+	"gopkg.in/echo.v2/engine"
+	"gopkg.in/echo.v2/log"
 	"github.com/valyala/fasthttp"
 )
 

--- a/engine/fasthttp/server.go
+++ b/engine/fasthttp/server.go
@@ -5,9 +5,9 @@ package fasthttp
 import (
 	"sync"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine"
-	"github.com/labstack/echo/log"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine"
+	"gopkg.in/echo.v2/log"
 	glog "github.com/labstack/gommon/log"
 	"github.com/valyala/fasthttp"
 )

--- a/engine/fasthttp/server_test.go
+++ b/engine/fasthttp/server_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine"
 	"github.com/stretchr/testify/assert"
 	"github.com/valyala/fasthttp"
 )

--- a/engine/fasthttp/url_test.go
+++ b/engine/fasthttp/url_test.go
@@ -1,7 +1,7 @@
 package fasthttp
 
 import (
-	"github.com/labstack/echo/engine/test"
+	"gopkg.in/echo.v2/engine/test"
 	"github.com/stretchr/testify/assert"
 	fast "github.com/valyala/fasthttp"
 	"testing"

--- a/engine/standard/cookie_test.go
+++ b/engine/standard/cookie_test.go
@@ -1,7 +1,7 @@
 package standard
 
 import (
-	"github.com/labstack/echo/engine/test"
+	"gopkg.in/echo.v2/engine/test"
 	"net/http"
 	"testing"
 	"time"

--- a/engine/standard/header_test.go
+++ b/engine/standard/header_test.go
@@ -1,7 +1,7 @@
 package standard
 
 import (
-	"github.com/labstack/echo/engine/test"
+	"gopkg.in/echo.v2/engine/test"
 	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"

--- a/engine/standard/request.go
+++ b/engine/standard/request.go
@@ -9,9 +9,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine"
-	"github.com/labstack/echo/log"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine"
+	"gopkg.in/echo.v2/log"
 )
 
 type (

--- a/engine/standard/request_test.go
+++ b/engine/standard/request_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/labstack/echo/engine/test"
+	"gopkg.in/echo.v2/engine/test"
 	"github.com/labstack/gommon/log"
 	"github.com/stretchr/testify/assert"
 )

--- a/engine/standard/response.go
+++ b/engine/standard/response.go
@@ -6,8 +6,8 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/labstack/echo/engine"
-	"github.com/labstack/echo/log"
+	"gopkg.in/echo.v2/engine"
+	"gopkg.in/echo.v2/log"
 )
 
 type (

--- a/engine/standard/server.go
+++ b/engine/standard/server.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine"
-	"github.com/labstack/echo/log"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine"
+	"gopkg.in/echo.v2/log"
 	glog "github.com/labstack/gommon/log"
 )
 

--- a/engine/standard/server_test.go
+++ b/engine/standard/server_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/engine/standard/url_test.go
+++ b/engine/standard/url_test.go
@@ -1,7 +1,7 @@
 package standard
 
 import (
-	"github.com/labstack/echo/engine/test"
+	"gopkg.in/echo.v2/engine/test"
 	"github.com/stretchr/testify/assert"
 	"net/url"
 	"testing"

--- a/engine/test/test_helpers.go
+++ b/engine/test/test_helpers.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/labstack/echo/engine"
+	"gopkg.in/echo.v2/engine"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/engine/test/test_request.go
+++ b/engine/test/test_request.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/labstack/echo/engine"
+	"gopkg.in/echo.v2/engine"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/labstack/echo
+package: gopkg.in/echo.v2
 import:
 - package: github.com/GeertJohan/go.rice
 - package: github.com/dgrijalva/jwt-go

--- a/middleware/basic_auth.go
+++ b/middleware/basic_auth.go
@@ -3,7 +3,7 @@ package middleware
 import (
 	"encoding/base64"
 
-	"github.com/labstack/echo"
+	"gopkg.in/echo.v2"
 )
 
 type (

--- a/middleware/basic_auth_test.go
+++ b/middleware/basic_auth_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/test"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/test"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/body_limit.go
+++ b/middleware/body_limit.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/labstack/echo"
+	"gopkg.in/echo.v2"
 	"github.com/labstack/gommon/bytes"
 )
 

--- a/middleware/body_limit_test.go
+++ b/middleware/body_limit_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/test"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/test"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine"
 )
 
 type (

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/test"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/test"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/labstack/echo"
+	"gopkg.in/echo.v2"
 )
 
 type (

--- a/middleware/cors_test.go
+++ b/middleware/cors_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/test"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/test"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/csrf.go
+++ b/middleware/csrf.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/labstack/echo"
+	"gopkg.in/echo.v2"
 	"github.com/labstack/gommon/random"
 )
 

--- a/middleware/csrf_test.go
+++ b/middleware/csrf_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/test"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/test"
 	"github.com/labstack/gommon/random"
 	"github.com/stretchr/testify/assert"
 )

--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/dgrijalva/jwt-go"
-	"github.com/labstack/echo"
+	"gopkg.in/echo.v2"
 )
 
 type (

--- a/middleware/jwt_test.go
+++ b/middleware/jwt_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/dgrijalva/jwt-go"
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/test"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/test"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/labstack/echo"
+	"gopkg.in/echo.v2"
 	"github.com/labstack/gommon/color"
 	isatty "github.com/mattn/go-isatty"
 	"github.com/valyala/fasttemplate"

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/test"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/test"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/method_override.go
+++ b/middleware/method_override.go
@@ -1,6 +1,6 @@
 package middleware
 
-import "github.com/labstack/echo"
+import "gopkg.in/echo.v2"
 
 type (
 	// MethodOverrideConfig defines the config for MethodOverride middleware.

--- a/middleware/method_override_test.go
+++ b/middleware/method_override_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/test"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/test"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -1,6 +1,6 @@
 package middleware
 
-import "github.com/labstack/echo"
+import "gopkg.in/echo.v2"
 
 type (
 	// Skipper defines a function to skip middleware. Returning true skips processing

--- a/middleware/recover.go
+++ b/middleware/recover.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/labstack/echo"
+	"gopkg.in/echo.v2"
 	"github.com/labstack/gommon/color"
 )
 

--- a/middleware/recover_test.go
+++ b/middleware/recover_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/test"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/test"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/redirect.go
+++ b/middleware/redirect.go
@@ -3,7 +3,7 @@ package middleware
 import (
 	"net/http"
 
-	"github.com/labstack/echo"
+	"gopkg.in/echo.v2"
 )
 
 type (

--- a/middleware/redirect_test.go
+++ b/middleware/redirect_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/test"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/test"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/secure.go
+++ b/middleware/secure.go
@@ -3,7 +3,7 @@ package middleware
 import (
 	"fmt"
 
-	"github.com/labstack/echo"
+	"gopkg.in/echo.v2"
 )
 
 type (

--- a/middleware/secure_test.go
+++ b/middleware/secure_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/test"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/test"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/slash.go
+++ b/middleware/slash.go
@@ -1,7 +1,7 @@
 package middleware
 
 import (
-	"github.com/labstack/echo"
+	"gopkg.in/echo.v2"
 )
 
 type (

--- a/middleware/slash_test.go
+++ b/middleware/slash_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/test"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/test"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/static.go
+++ b/middleware/static.go
@@ -6,7 +6,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/labstack/echo"
+	"gopkg.in/echo.v2"
 )
 
 type (

--- a/middleware/static_test.go
+++ b/middleware/static_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/test"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/test"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/recipe/cors/server.go
+++ b/recipe/cors/server.go
@@ -3,9 +3,9 @@ package main
 import (
 	"net/http"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine/standard"
-	"github.com/labstack/echo/middleware"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine/standard"
+	"gopkg.in/echo.v2/middleware"
 )
 
 var (

--- a/recipe/crud/server.go
+++ b/recipe/crud/server.go
@@ -4,9 +4,9 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine/standard"
-	"github.com/labstack/echo/middleware"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine/standard"
+	"gopkg.in/echo.v2/middleware"
 )
 
 type (

--- a/recipe/embed-resources/server.go
+++ b/recipe/embed-resources/server.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 
 	"github.com/GeertJohan/go.rice"
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine/standard"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine/standard"
 )
 
 func main() {

--- a/recipe/file-upload/multiple/server.go
+++ b/recipe/file-upload/multiple/server.go
@@ -7,9 +7,9 @@ import (
 
 	"net/http"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine/standard"
-	"github.com/labstack/echo/middleware"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine/standard"
+	"gopkg.in/echo.v2/middleware"
 )
 
 func upload(c echo.Context) error {

--- a/recipe/file-upload/single/server.go
+++ b/recipe/file-upload/single/server.go
@@ -7,9 +7,9 @@ import (
 
 	"net/http"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine/standard"
-	"github.com/labstack/echo/middleware"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine/standard"
+	"gopkg.in/echo.v2/middleware"
 )
 
 func upload(c echo.Context) error {

--- a/recipe/google-app-engine/app-engine.go
+++ b/recipe/google-app-engine/app-engine.go
@@ -3,8 +3,8 @@
 package main
 
 import (
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine/standard"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine/standard"
 	"net/http"
 )
 

--- a/recipe/google-app-engine/app-managed.go
+++ b/recipe/google-app-engine/app-managed.go
@@ -3,8 +3,8 @@
 package main
 
 import (
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine/standard"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine/standard"
 	"google.golang.org/appengine"
 	"net/http"
 	"runtime"

--- a/recipe/google-app-engine/app-standalone.go
+++ b/recipe/google-app-engine/app-standalone.go
@@ -3,9 +3,9 @@
 package main
 
 import (
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine/standard"
-	"github.com/labstack/echo/middleware"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine/standard"
+	"gopkg.in/echo.v2/middleware"
 )
 
 func createMux() *echo.Echo {

--- a/recipe/google-app-engine/users.go
+++ b/recipe/google-app-engine/users.go
@@ -3,8 +3,8 @@ package main
 import (
 	"net/http"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/middleware"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/middleware"
 )
 
 type (

--- a/recipe/google-app-engine/welcome.go
+++ b/recipe/google-app-engine/welcome.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/labstack/echo"
+	"gopkg.in/echo.v2"
 )
 
 type (

--- a/recipe/graceful-shutdown/grace/server.go
+++ b/recipe/graceful-shutdown/grace/server.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 
 	"github.com/facebookgo/grace/gracehttp"
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine/standard"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine/standard"
 )
 
 func main() {

--- a/recipe/graceful-shutdown/graceful/server.go
+++ b/recipe/graceful-shutdown/graceful/server.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine/standard"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine/standard"
 	"github.com/tylerb/graceful"
 )
 

--- a/recipe/hello-world/server.go
+++ b/recipe/hello-world/server.go
@@ -3,9 +3,9 @@ package main
 import (
 	"net/http"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine/standard"
-	"github.com/labstack/echo/middleware"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine/standard"
+	"gopkg.in/echo.v2/middleware"
 )
 
 func main() {

--- a/recipe/http2/server.go
+++ b/recipe/http2/server.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine"
-	"github.com/labstack/echo/engine/standard"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine"
+	"gopkg.in/echo.v2/engine/standard"
 )
 
 func request(c echo.Context) error {

--- a/recipe/jsonp/server.go
+++ b/recipe/jsonp/server.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine/standard"
-	"github.com/labstack/echo/middleware"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine/standard"
+	"gopkg.in/echo.v2/middleware"
 )
 
 func main() {

--- a/recipe/jwt/custom-claims/server.go
+++ b/recipe/jwt/custom-claims/server.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine/standard"
-	"github.com/labstack/echo/middleware"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine/standard"
+	"gopkg.in/echo.v2/middleware"
 )
 
 // jwtCustomClaims are custom claims extending default ones.

--- a/recipe/jwt/map-claims/server.go
+++ b/recipe/jwt/map-claims/server.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine/standard"
-	"github.com/labstack/echo/middleware"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine/standard"
+	"gopkg.in/echo.v2/middleware"
 )
 
 func login(c echo.Context) error {

--- a/recipe/middleware/server.go
+++ b/recipe/middleware/server.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine/standard"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine/standard"
 )
 
 type (

--- a/recipe/streaming-response/server.go
+++ b/recipe/streaming-response/server.go
@@ -6,8 +6,8 @@ import (
 
 	"encoding/json"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine/standard"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine/standard"
 )
 
 type (

--- a/recipe/subdomains/server.go
+++ b/recipe/subdomains/server.go
@@ -3,9 +3,9 @@ package main
 import (
 	"net/http"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine/standard"
-	"github.com/labstack/echo/middleware"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine/standard"
+	"gopkg.in/echo.v2/middleware"
 )
 
 type (

--- a/recipe/websocket/gorilla/server.go
+++ b/recipe/websocket/gorilla/server.go
@@ -5,11 +5,11 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/labstack/echo"
+	"gopkg.in/echo.v2"
 
 	"github.com/gorilla/websocket"
-	"github.com/labstack/echo/engine/standard"
-	"github.com/labstack/echo/middleware"
+	"gopkg.in/echo.v2/engine/standard"
+	"gopkg.in/echo.v2/middleware"
 )
 
 var (

--- a/recipe/websocket/net/server.go
+++ b/recipe/websocket/net/server.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine/standard"
-	"github.com/labstack/echo/middleware"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine/standard"
+	"gopkg.in/echo.v2/middleware"
 	"golang.org/x/net/websocket"
 )
 

--- a/test/request.go
+++ b/test/request.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/labstack/echo/engine"
+	"gopkg.in/echo.v2/engine"
 )
 
 type (

--- a/test/response.go
+++ b/test/response.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"github.com/labstack/echo/engine"
+	"gopkg.in/echo.v2/engine"
 	"github.com/labstack/gommon/log"
 )
 

--- a/test/server.go
+++ b/test/server.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/labstack/echo/engine"
+	"gopkg.in/echo.v2/engine"
 	"github.com/labstack/gommon/log"
 )
 

--- a/website/content/godoc/echo.md
+++ b/website/content/godoc/echo.md
@@ -4,5 +4,5 @@ title = "echo"
   name = "echo"
   parent = "godoc"
   weight = 1
-  url = "https://godoc.org/github.com/labstack/echo"
+  url = "https://godoc.org/gopkg.in/echo.v2"
 +++

--- a/website/content/godoc/engine.md
+++ b/website/content/godoc/engine.md
@@ -4,5 +4,5 @@ title = "engine"
   name = "engine"
   parent = "godoc"
   weight = 3
-  url = "https://godoc.org/github.com/labstack/echo/engine"
+  url = "https://godoc.org/gopkg.in/echo.v2/engine"
 +++

--- a/website/content/godoc/fasthttp.md
+++ b/website/content/godoc/fasthttp.md
@@ -4,5 +4,5 @@ title = "fasthttp"
   name = "engine/fasthttp"
   parent = "godoc"
   weight = 5
-  url = "https://godoc.org/github.com/labstack/echo/engine/fasthttp"
+  url = "https://godoc.org/gopkg.in/echo.v2/engine/fasthttp"
 +++

--- a/website/content/godoc/middleware.md
+++ b/website/content/godoc/middleware.md
@@ -5,5 +5,5 @@ title = "middleware"
   identifier = "godoc-middleware"
   parent = "godoc"
   weight = 1
-  url = "https://godoc.org/github.com/labstack/echo/middleware"
+  url = "https://godoc.org/gopkg.in/echo.v2/middleware"
 +++

--- a/website/content/godoc/standard.md
+++ b/website/content/godoc/standard.md
@@ -4,5 +4,5 @@ title = "standard"
   name = "engine/standard"
   parent = "godoc"
   weight = 4
-  url = "https://godoc.org/github.com/labstack/echo/engine/standard"
+  url = "https://godoc.org/gopkg.in/echo.v2/engine/standard"
 +++

--- a/website/content/guide/error-handling.md
+++ b/website/content/guide/error-handling.md
@@ -24,8 +24,8 @@ package main
 import (
 	"net/http"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine/standard"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine/standard"
 )
 
 func main() {

--- a/website/content/guide/installation.md
+++ b/website/content/guide/installation.md
@@ -12,7 +12,7 @@ description = "Installing Echo"
 Echo is developed and tested using Go `1.6.x` and `1.7.x`
 
 ```sh
-$ go get -u github.com/labstack/echo
+$ go get -u gopkg.in/echo.v2
 ```
 
 > Ideally, you should rely on a [package manager](https://github.com/avelino/awesome-go#package-management) like glide or govendor to use a specific [version](https://github.com/labstack/echo/releases) of Echo.

--- a/website/content/guide/migrating.md
+++ b/website/content/guide/migrating.md
@@ -62,8 +62,8 @@ package main
 import (
 	"net/http"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine/standard"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine/standard"
 )
 
 // Standard middleware

--- a/website/content/guide/testing.md
+++ b/website/content/guide/testing.md
@@ -39,7 +39,7 @@ package handler
 import (
 	"net/http"
 
-	"github.com/labstack/echo"
+	"gopkg.in/echo.v2"
 )
 
 type (
@@ -81,8 +81,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine/standard"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine/standard"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -158,4 +158,4 @@ req, err := http.NewRequest(echo.POST, "/?"+q.Encode(), nil)
 
 *TBD*
 
-You can looking to built-in middleware [test cases](https://github.com/labstack/echo/tree/master/middleware).
+You can looking to built-in middleware [test cases](https://github.com/labstack/echo/tree/v2/middleware).

--- a/website/content/index.md
+++ b/website/content/index.md
@@ -36,7 +36,7 @@ title = "Index"
 ### Installation
 
 ```sh
-$ go get -u github.com/labstack/echo
+$ go get -u gopkg.in/echo.v2
 ```
 
 ### Hello, World!
@@ -48,8 +48,8 @@ package main
 
 import (
 	"net/http"
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine/standard"
+	"gopkg.in/echo.v2"
+	"gopkg.in/echo.v2/engine/standard"
 )
 
 func main() {


### PR DESCRIPTION
This allows me to properly vendor it without v3 dependencies.

Please take a look, merge if it looks good and make a new release/tag.

Do you sync it with https://github.com/go-echo/echo manually?
