### PR TITLE
Add support for a Scanner interface.

### DIFF
--- a/website/content/guide.md
+++ b/website/content/guide.md
@@ -172,13 +172,14 @@ ls avatar.png
 
 ### Handling Request
 
-- Bind `JSON` or `XML` or `form` payload into Go struct based on `Content-Type` request header.
+- Bind `JSON`, `XML`, `form` or `query` payload into Go struct based on `Content-Type` request header.
 - Render response as `JSON` or `XML` with status code.
+- Use the [BindUnmarshaler](https://godoc.org/github.com/labstack/echo#ParamUnmarshaler) interface to bind custom data types for `form` or `query` payloads. The standard [json.Unmarshaler](https://golang.org/pkg/encoding/json/#Unmarshaler) and [xml.Unmarshaler](https://golang.org/pkg/encoding/xml/#Unmarshaler) can of course be used for JSON and XML payloads, respectively.
 
 ```go
 type User struct {
-	Name  string `json:"name" xml:"name" form:"name"`
-	Email string `json:"email" xml:"email" form:"email"`
+	Name  string `json:"name" xml:"name" form:"name" query:"name"`
+	Email string `json:"email" xml:"email" form:"email" query:"name"`
 }
 
 e.POST("/users", func(c echo.Context) error {


### PR DESCRIPTION
This duplicates the Scanner interface implemented by the standard library's sql package, extending echo's standard Binder to support arbitrary data types, so long as they implement this interface.

This solves #763.