### PR TITLE
Fix template name in template Guide.

### DIFF
--- a/website/content/guide/templates.md
+++ b/website/content/guide/templates.md
@@ -23,7 +23,7 @@ Example below shows how to use Go `html/template`:
     }
 
     func (t *Template) Render(w io.Writer, name string, data interface{}, c echo.Context) error {
-    	return t.templates.ExecuteTemplate(w, name, data)
+    	return t.templates.ExecuteTemplate(w, name + ".html", data)
     }
     ```
 


### PR DESCRIPTION
The template name is actually the name of the file **with** the extension. Otherwise it's not found.