### PR TITLE
Document how to use httptest for testing

### DIFF
--- a/website/content/guide/testing.md
+++ b/website/content/guide/testing.md
@@ -152,6 +152,21 @@ q.Set("email", "jon@labstack.com")
 req, err := http.NewRequest(echo.POST, "/?"+q.Encode(), nil)
 ```
 
+## Testing with httptest
+
+```go
+e := echo.New()
+e.GET("/hello", func(c echo.Context) error {
+  return c.String(200, "World")
+})
+	
+
+server := httptest.NewServer(e)
+defer server.Close()
+
+// Do actual http request like you would with a normal httptest instance
+```
+
 ## Testing Middleware
 
 *TBD*


### PR DESCRIPTION
I couldn't find any documentation about how to use net/http/httptest for hosting the echo instance for testing. The feature is there in echo, so i just wrote it out.