### PR TITLE
Correct comment for Context.Response

### DIFF
--- a/context.go
+++ b/context.go
@@ -25,7 +25,7 @@ type (
 		// SetRequest sets `*http.Request`.
 		SetRequest(r *http.Request)
 
-		// Request returns `*Response`.
+		// Response returns `*Response`.
 		Response() *Response
 
 		// IsTLS returns true if HTTP connection is TLS otherwise false.


### PR DESCRIPTION
Just noticed this while trawling the docs and couldn't help but fix it.