### PR TITLE
Add directory to store the certificate and mention rate limits

### DIFF
--- a/recipe/auto-tls/server.go
+++ b/recipe/auto-tls/server.go
@@ -10,6 +10,8 @@ import (
 func main() {
 	e := echo.New()
 	// e.AutoTLSManager.HostPolicy = autocert.HostWhitelist("<your_domain>")
+	// Store the certificate to avoid issues with rate limits (https://letsencrypt.org/docs/rate-limits/)
+	// e.AutoTLSManager.Cache = autocert.DirCache("<path to store key and certificate>")
 	e.Use(middleware.Recover())
 	e.Use(middleware.Logger())
 	e.GET("/", func(c echo.Context) error {


### PR DESCRIPTION
The certificate must be cached to avoid problems with rate limits during testing.