### PR TITLE
Change Baisc-Auth to return 401 for the first request

### DIFF
--- a/middleware/basic_auth.go
+++ b/middleware/basic_auth.go
@@ -62,27 +62,26 @@ func BasicAuthWithConfig(config BasicAuthConfig) echo.MiddlewareFunc {
 			}
 
 			auth := c.Request().Header.Get(echo.HeaderAuthorization)
-			if auth == "" {
-				return echo.NewHTTPError(http.StatusBadRequest, "Missing authorization header")
-			}
-			l := len(basic)
+			if auth != "" {
+				l := len(basic)
 
-			if len(auth) > l+1 && auth[:l] == basic {
-				b, err := base64.StdEncoding.DecodeString(auth[l+1:])
-				if err != nil {
-					return err
-				}
-				cred := string(b)
-				for i := 0; i < len(cred); i++ {
-					if cred[i] == ':' {
-						// Verify credentials
-						if config.Validator(cred[:i], cred[i+1:]) {
-							return next(c)
+				if len(auth) > l + 1 && auth[:l] == basic {
+					b, err := base64.StdEncoding.DecodeString(auth[l + 1:])
+					if err != nil {
+						return err
+					}
+					cred := string(b)
+					for i := 0; i < len(cred); i++ {
+						if cred[i] == ':' {
+							// Verify credentials
+							if config.Validator(cred[:i], cred[i + 1:]) {
+								return next(c)
+							}
 						}
 					}
+				} else {
+					return echo.NewHTTPError(http.StatusBadRequest, "Invalid authorization header")
 				}
-			} else {
-				return echo.NewHTTPError(http.StatusBadRequest, "Invalid authorization header")
 			}
 
 			// Need to return `401` for browsers to pop-up login box.

--- a/middleware/basic_auth_test.go
+++ b/middleware/basic_auth_test.go
@@ -40,7 +40,8 @@ func TestBasicAuth(t *testing.T) {
 	// Missing Authorization header
 	req.Header.Del(echo.HeaderAuthorization)
 	he = h(c).(*echo.HTTPError)
-	assert.Equal(t, http.StatusBadRequest, he.Code)
+	assert.Equal(t, http.StatusUnauthorized, he.Code)
+	assert.Equal(t, basic+" realm=Restricted", res.Header().Get(echo.HeaderWWWAuthenticate))
 
 	// Invalid Authorization header
 	auth = base64.StdEncoding.EncodeToString([]byte("invalid"))


### PR DESCRIPTION
I guess [this commit](https://github.com/labstack/echo/commit/412823eabb0f1e4c0b93fcf7a26232099469938d) changes Basic-Auth behavior.

I think Basic-Auth should return 401 and `WWW-Authenticate: Basic realm=Restricted` header for browsers first request to pop-up login box. Would you please check this change?