### PR TITLE
Add server-level Not Found and Method Not Allowed handlers

### DIFF
--- a/context.go
+++ b/context.go
@@ -547,5 +547,5 @@ func (c *context) Reset(r *http.Request, w http.ResponseWriter) {
 	c.store = nil
 	c.request = r
 	c.response.reset(w)
-	c.handler = NotFoundHandler
+	c.handler = c.echo.NotFoundHandler
 }

--- a/echo.go
+++ b/echo.go
@@ -59,27 +59,29 @@ import (
 type (
 	// Echo is the top-level framework instance.
 	Echo struct {
-		DisableHTTP2     bool
-		Debug            bool
-		HTTPErrorHandler HTTPErrorHandler
-		Binder           Binder
-		Validator        Validator
-		Renderer         Renderer
-		AutoTLSManager   autocert.Manager
-		ReadTimeout      time.Duration
-		WriteTimeout     time.Duration
-		ShutdownTimeout  time.Duration
-		Color            *color.Color
-		Logger           Logger
-		stdLogger        *slog.Logger
-		server           *graceful.Server
-		tlsServer        *graceful.Server
-		premiddleware    []MiddlewareFunc
-		middleware       []MiddlewareFunc
-		maxParam         *int
-		router           *Router
-		notFoundHandler  HandlerFunc
-		pool             sync.Pool
+		DisableHTTP2            bool
+		Debug                   bool
+		HTTPErrorHandler        HTTPErrorHandler
+		NotFoundHandler         HandlerFunc
+		MethodNotAllowedHandler HandlerFunc
+		Binder                  Binder
+		Validator               Validator
+		Renderer                Renderer
+		AutoTLSManager          autocert.Manager
+		ReadTimeout             time.Duration
+		WriteTimeout            time.Duration
+		ShutdownTimeout         time.Duration
+		Color                   *color.Color
+		Logger                  Logger
+		stdLogger               *slog.Logger
+		server                  *graceful.Server
+		tlsServer               *graceful.Server
+		premiddleware           []MiddlewareFunc
+		middleware              []MiddlewareFunc
+		maxParam                *int
+		router                  *Router
+		notFoundHandler         HandlerFunc
+		pool                    sync.Pool
 	}
 
 	// Route contains a handler and information for matching against requests.
@@ -250,6 +252,8 @@ func New() (e *Echo) {
 		Color:           color.New(),
 	}
 	e.HTTPErrorHandler = e.DefaultHTTPErrorHandler
+	e.NotFoundHandler = NotFoundHandler
+	e.MethodNotAllowedHandler = MethodNotAllowedHandler
 	e.Binder = &DefaultBinder{}
 	e.Logger.SetLevel(log.OFF)
 	e.stdLogger = slog.New(e.Logger.Output(), e.Logger.Prefix()+": ", 0)


### PR DESCRIPTION
We run multiple Echo servers in the same process on different ports. This PR adds the ability to set a different Not Found and Method Not Allowed handler for each instance of `*echo.Echo`.

I'd ideally like to make the `NotFoundHandler` and the `MethodNotAllowedHandler` immutable functions (using `func NotFoundHandler(...) ...` syntax) but opted not to because it could break existing code. Instead, calls to `echo.New()` will just default the server-level Not Found/Method Not Allowed handlers to those global values.

Added a test; existing tests still pass.