### PR TITLE
Correcting the BasicAuth Method

### DIFF
--- a/website/content/middleware/basic-auth.md
+++ b/website/content/middleware/basic-auth.md
@@ -15,7 +15,7 @@ Basic auth middleware provides an HTTP basic authentication.
 *Usage*
 
 ```go
-e.Use(middleware.BasicAuth(func(username, password string) bool {
+e.Use(middleware.BasicAuth(func(username, password string, c echo.Context) bool {
 	if username == "joe" && password == "secret" {
 		return true
 	}


### PR DESCRIPTION
Current method gives type error because `context` variable is not present.
Adding the `c echo.Context` for resolving type error.