### PR TITLE
logger: Don't copy lock value in LoggerConfig.pool, use a pointer

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -54,7 +54,7 @@ type (
 
 		template *fasttemplate.Template
 		colorer  *color.Color
-		pool     sync.Pool
+		pool     *sync.Pool
 	}
 )
 
@@ -93,7 +93,7 @@ func LoggerWithConfig(config LoggerConfig) echo.MiddlewareFunc {
 	config.template = fasttemplate.New(config.Format, "${", "}")
 	config.colorer = color.New()
 	config.colorer.SetOutput(config.Output)
-	config.pool = sync.Pool{
+	config.pool = &sync.Pool{
 		New: func() interface{} {
 			return bytes.NewBuffer(make([]byte, 256))
 		},


### PR DESCRIPTION
Fixes #710 `go vet` failures.

Trivial fix, no new tests, just passes `go vet` now.