### PR TITLE
Add FileSystem support

### DIFF
--- a/context.go
+++ b/context.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"path/filepath"
 	"strings"
 )
@@ -472,7 +471,7 @@ func (c *context) Stream(code int, contentType string, r io.Reader) (err error) 
 }
 
 func (c *context) File(file string) error {
-	f, err := os.Open(file)
+	f, err := c.echo.FS.Open(file)
 	if err != nil {
 		return ErrNotFound
 	}
@@ -481,7 +480,7 @@ func (c *context) File(file string) error {
 	fi, _ := f.Stat()
 	if fi.IsDir() {
 		file = filepath.Join(file, indexPage)
-		f, err = os.Open(file)
+		f, err = c.echo.FS.Open(file)
 		if err != nil {
 			return ErrNotFound
 		}

--- a/echo.go
+++ b/echo.go
@@ -45,6 +45,7 @@ import (
 	stdLog "log"
 	"net"
 	"net/http"
+	"os"
 	"path"
 	"reflect"
 	"runtime"
@@ -80,6 +81,7 @@ type (
 		AutoTLSManager   autocert.Manager
 		Mutex            sync.RWMutex
 		Logger           Logger
+		FS               http.FileSystem
 	}
 
 	// Route contains a handler and information for matching against requests.
@@ -238,6 +240,14 @@ var (
 	}
 )
 
+// FS implements http.FileSystem
+type FS struct{}
+
+// Open opens the named file for serving
+func (fs *FS) Open(name string) (http.File, error) {
+	return os.Open(name)
+}
+
 // New creates an instance of Echo.
 func New() (e *Echo) {
 	e = &Echo{
@@ -260,6 +270,7 @@ func New() (e *Echo) {
 		return e.NewContext(nil, nil)
 	}
 	e.router = NewRouter(e)
+	e.FS = &FS{}
 	return
 }
 

--- a/echo_test.go
+++ b/echo_test.go
@@ -2,15 +2,12 @@ package echo
 
 import (
 	"bytes"
+	"errors"
 	"net/http"
 	"net/http/httptest"
-	"testing"
-
 	"reflect"
 	"strings"
-
-	"errors"
-
+	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -83,6 +80,16 @@ func TestEchoStatic(t *testing.T) {
 	c, r = request(GET, "/folder", e)
 	assert.Equal(t, http.StatusOK, c)
 	assert.Equal(t, true, strings.HasPrefix(r, "<!doctype html>"))
+}
+
+func TestStaticCustomFS(t *testing.T) {
+	e := New()
+	e.FS = http.Dir("_fixture")
+
+	e.Static("/images", "images")
+	c, b := request(GET, "/images/walle.png", e)
+	assert.Equal(t, http.StatusOK, c)
+	assert.NotEmpty(t, b)
 }
 
 func TestEchoFile(t *testing.T) {


### PR DESCRIPTION
Hi there!

In some cases it would be really helpful to have possibility to use custom FS for opening files.
The best example is [go-bindata](https://github.com/jteeuwen/go-bindata) integration when we need to embed file assets in go binary.

```go
type BindataFS struct{}

// Open opens the named file
func (fs *BindataFS) Open(name string) (http.File, error) {
	b, err := bindata.Asset(name)
	if err != nil {
		return nil, err
	}

	return &file{
		Reader: bytes.NewReader(b),
		name:   name,
	}, nil
}

type file struct {
	*bytes.Reader
	name string
}

func (f *file) Close() error {
	return nil
}

func (f *file) Stat() (os.FileInfo, error) {
	return bindata.AssetInfo(f.name)
}

func (f *file) Readdir(count int) ([]os.FileInfo, error) {
	return nil, nil
}
```

Then we just change our filesystem and it works like a charm!
```go
e := echo.New()
e.FS = &BindataFS{}
```