### PR TITLE
[docs] extension was missing

### DIFF
--- a/website/content/guide/templates.md
+++ b/website/content/guide/templates.md
@@ -53,6 +53,6 @@ Example below shows how to use Go `html/template`:
 
     ```go
     func Hello(c echo.Context) error {
-    	return c.Render(http.StatusOK, "hello", "World")
+    	return c.Render(http.StatusOK, "hello.html", "World")
     }
     ```


### PR DESCRIPTION
I was following this example, but didn't work until I appended the extension.