### PR TITLE
Set the Content-Encoding header earlier for Static

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -66,16 +66,18 @@ func GzipWithConfig(config GzipConfig) echo.MiddlewareFunc {
 
 			res := c.Response()
 			res.Header().Add(echo.HeaderVary, echo.HeaderAcceptEncoding)
-			res.Header().Add(echo.HeaderContentEncoding, gzipScheme) // issue #806
 			if strings.Contains(c.Request().Header.Get(echo.HeaderAcceptEncoding), gzipScheme) {
+				res.Header().Add(echo.HeaderContentEncoding, gzipScheme) // issue #806
 				rw := res.Writer
 				w, err := gzip.NewWriterLevel(rw, config.Level)
 				if err != nil {
 					return err
 				}
 				defer func() {
-
 					if res.Size == 0 {
+						if res.Header().Get(echo.HeaderContentEncoding) == gzipScheme {
+							res.Header().Del(echo.HeaderContentEncoding)
+						}
 						// We have to reset response to it's pristine state when
 						// nothing is written to body or error is returned.
 						// See issue #424, #407.

--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -66,6 +66,7 @@ func GzipWithConfig(config GzipConfig) echo.MiddlewareFunc {
 
 			res := c.Response()
 			res.Header().Add(echo.HeaderVary, echo.HeaderAcceptEncoding)
+			res.Header().Add(echo.HeaderContentEncoding, gzipScheme) // issue #806
 			if strings.Contains(c.Request().Header.Get(echo.HeaderAcceptEncoding), gzipScheme) {
 				rw := res.Writer
 				w, err := gzip.NewWriterLevel(rw, config.Level)
@@ -92,8 +93,8 @@ func GzipWithConfig(config GzipConfig) echo.MiddlewareFunc {
 }
 
 func (w *gzipResponseWriter) WriteHeader(code int) {
-	if code != http.StatusNoContent { // Issue #489
-		w.ResponseWriter.Header().Set(echo.HeaderContentEncoding, gzipScheme)
+	if code == http.StatusNoContent { // Issue #489
+		w.ResponseWriter.Header().Del(echo.HeaderContentEncoding)
 	}
 	w.ResponseWriter.WriteHeader(code)
 }

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"bytes"
 	"compress/gzip"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -70,4 +71,30 @@ func TestGzipErrorReturned(t *testing.T) {
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 	assert.Empty(t, rec.Header().Get(echo.HeaderContentEncoding))
+}
+
+// Issue #806
+func TestGzipWithStatic(t *testing.T) {
+	e := echo.New()
+	e.Use(Gzip())
+	e.Static("/test", "testdata/compress")
+	req, _ := http.NewRequest(echo.GET, "/test/data", nil)
+	req.Header.Set(echo.HeaderAcceptEncoding, gzipScheme)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	// Data is written out in chunks when Content-Length == "", so only
+	// validate the content length if it's not set.
+	if cl := rec.Header().Get("Content-Length"); cl != "" {
+		assert.Equal(t, cl, rec.Body.Len())
+	}
+	r, err := gzip.NewReader(rec.Body)
+	assert.NoError(t, err)
+	defer r.Close()
+	want, err := ioutil.ReadFile("testdata/compress/data")
+	if assert.NoError(t, err) {
+		var buf bytes.Buffer
+		buf.ReadFrom(r)
+		assert.Equal(t, want, buf.Bytes())
+	}
 }

--- a/middleware/testdata/compress/data
+++ b/middleware/testdata/compress/data
@@ -1,0 +1,1 @@
+test data


### PR DESCRIPTION
Static uses http.ServeContent, which looks to see if the Content-Encoding
header is set or not to determine if it should set the Content-Length.

If Content-Length is set by something it will be wrong after the gzip
compression happens and strict proxies (and tools like curl) will
have problems with the request.

Fixes #806