### PR TITLE
Add BasicAuth Realm support

### DIFF
--- a/middleware/basic_auth.go
+++ b/middleware/basic_auth.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"encoding/base64"
+	"strconv"
 
 	"github.com/labstack/echo"
 )
@@ -15,6 +16,9 @@ type (
 		// Validator is a function to validate BasicAuth credentials.
 		// Required.
 		Validator BasicAuthValidator
+
+		// Realm is a string to define realm attribute of BasicAuth
+		Realm string
 	}
 
 	// BasicAuthValidator defines a function to validate BasicAuth credentials.
@@ -22,13 +26,15 @@ type (
 )
 
 const (
-	basic = "Basic"
+	basic        = "Basic"
+	defaultRealm = "Restricted"
 )
 
 var (
 	// DefaultBasicAuthConfig is the default BasicAuth middleware config.
 	DefaultBasicAuthConfig = BasicAuthConfig{
 		Skipper: DefaultSkipper,
+		Realm:   defaultRealm,
 	}
 )
 
@@ -51,6 +57,9 @@ func BasicAuthWithConfig(config BasicAuthConfig) echo.MiddlewareFunc {
 	}
 	if config.Skipper == nil {
 		config.Skipper = DefaultBasicAuthConfig.Skipper
+	}
+	if config.Realm == "" {
+		config.Realm = defaultRealm
 	}
 
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
@@ -78,8 +87,15 @@ func BasicAuthWithConfig(config BasicAuthConfig) echo.MiddlewareFunc {
 				}
 			}
 
+			var realm string
+			if config.Realm == defaultRealm {
+				realm = defaultRealm
+			} else {
+				realm = strconv.Quote(config.Realm)
+			}
+
 			// Need to return `401` for browsers to pop-up login box.
-			c.Response().Header().Set(echo.HeaderWWWAuthenticate, basic+" realm=Restricted")
+			c.Response().Header().Set(echo.HeaderWWWAuthenticate, basic+" realm="+realm)
 			return echo.ErrUnauthorized
 		}
 	}


### PR DESCRIPTION
Hi,
Thank you for great library!

I want to split urls into two area. like this:
```
 http:// _ _ _ .com/admin/
 -> admin area

 http:// _ _ _ .com/super_user/
 -> super user's area
```
and each area has different id and password.

Most web browser manages id and password by domain and realm.
So if domain and realm are same, one pair of id / pw will be saved in browser, and another pair of id / pw will be forgotten.

I hope to BasicAuth middleware can change realm for this situation.
Would you please check this Pull Request?