### PR TITLE
Update type typo for Header handler

### DIFF
--- a/website/content/cookbook/middleware.md
+++ b/website/content/cookbook/middleware.md
@@ -25,7 +25,7 @@ description = "Middleware example for Echo"
 Content-Length:122
 Content-Type:application/json; charset=utf-8
 Date:Thu, 14 Apr 2016 20:31:46 GMT
-Server:Echo/2.0
+Server:Echo/3.0
 ```
 
 *Body*


### PR DESCRIPTION
The example for ServerHeader middleware is trying to set a `Echo/3.0` header,
but the response out put has a Echo/2.0 header, may confuse people.