### PR TITLE
Enable custom request id generator

### DIFF
--- a/middleware/request_id.go
+++ b/middleware/request_id.go
@@ -50,7 +50,7 @@ func RequestIDWithConfig(config RequestIDConfig) echo.MiddlewareFunc {
 			res := c.Response()
 			rid := req.Header.Get(echo.HeaderXRequestID)
 			if rid == "" {
-				rid = random.String(32)
+				rid = config.Generator()
 			}
 			res.Header().Set(echo.HeaderXRequestID, rid)
 

--- a/middleware/request_id_test.go
+++ b/middleware/request_id_test.go
@@ -14,10 +14,20 @@ func TestRequestID(t *testing.T) {
 	req, _ := http.NewRequest(echo.GET, "/", nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
-	rid := RequestIDWithConfig(RequestIDConfig{})
-	h := rid(func(c echo.Context) error {
+	handler := func(c echo.Context) error {
 		return c.String(http.StatusOK, "test")
-	})
+	}
+
+	rid := RequestIDWithConfig(RequestIDConfig{})
+	h := rid(handler)
 	h(c)
 	assert.Len(t, rec.Header().Get(echo.HeaderXRequestID), 32)
+
+	// Custom generator
+	rid = RequestIDWithConfig(RequestIDConfig{
+		Generator: func() string { return "customGenerator" },
+	})
+	h = rid(handler)
+	h(c)
+	assert.Equal(t, rec.Header().Get(echo.HeaderXRequestID), "customGenerator")
 }


### PR DESCRIPTION
Hi! ☀️ 

I couldn't use a custom ID generator for RequestID middleware and fixed! 