### PR TITLE
Tested and fixed bug with reused context (path parameters).

### DIFF
--- a/context.go
+++ b/context.go
@@ -275,7 +275,7 @@ func (c *context) SetParamNames(names ...string) {
 }
 
 func (c *context) ParamValues() []string {
-	return c.pvalues
+	return c.pvalues[:len(c.pnames)]
 }
 
 func (c *context) SetParamValues(values ...string) {
@@ -553,4 +553,7 @@ func (c *context) Reset(r *http.Request, w http.ResponseWriter) {
 	c.query = nil
 	c.handler = NotFoundHandler
 	c.store = nil
+	c.pnames = nil
+	// WARNING: Don't reset because it has to have length c.echo.maxParam at all times: c.pvalues = nil
+	c.path = ""
 }

--- a/context_test.go
+++ b/context_test.go
@@ -190,7 +190,16 @@ func TestContext(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 
 	// Reset
+	c.SetParamNames("foo")
+	c.SetParamValues("bar")
+	c.Set("foe", "ban")
+	c.query = url.Values(map[string][]string{"fon": []string{"baz"}})
 	c.Reset(req, httptest.NewRecorder())
+	assert.Equal(t, 0, len(c.ParamValues()))
+	assert.Equal(t, 0, len(c.ParamNames()))
+	assert.Equal(t, 0, len(c.store))
+	assert.Equal(t, "", c.Path())
+	assert.Equal(t, 0, len(c.QueryParams()))
 }
 
 func TestContextCookie(t *testing.T) {


### PR DESCRIPTION
We use path parameters in our project.
Unfortunately we saw old parameters from `c.ParamValues()` in later requests.

The context wasn't reset properly.
The `Reset()` method of the context wasn't tested at all.

So I fixed this and added a test for the reset of `c.ParamValues()`.
The underlying `c.pvalues` slice is keeping its constant length of `c.echo.maxParam`.
To me this looks like the cleanest solution that doesn't destroy any echo performance improvements.