### PR TITLE
Body can be output to log

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -53,6 +53,7 @@ type (
 		// Optional. Default value os.Stdout.
 		Output io.Writer
 
+		LogBody  bool
 		template *fasttemplate.Template
 		colorer  *color.Color
 		pool     *sync.Pool
@@ -69,6 +70,7 @@ var (
 			`"bytes_out":${bytes_out}}` + "\n",
 		Output:  os.Stdout,
 		colorer: color.New(),
+		LogBody: false,
 	}
 )
 
@@ -112,7 +114,7 @@ func LoggerWithConfig(config LoggerConfig) echo.MiddlewareFunc {
 			req := c.Request()
 			res := c.Response()
 
-			if req.Method == echo.PUT || req.Method == echo.POST {
+			if config.LogBody && (req.Method == echo.PUT || req.Method == echo.POST) {
 				body, ioerr = ioutil.ReadAll(req.Body)
 				if ioerr == nil {
 					// re-read
@@ -189,7 +191,7 @@ func LoggerWithConfig(config LoggerConfig) echo.MiddlewareFunc {
 				case "bytes_out":
 					return buf.WriteString(strconv.FormatInt(res.Size, 10))
 				case "body":
-					if (req.Method == echo.PUT || req.Method == echo.POST) && ioerr == nil {
+					if config.LogBody && ioerr == nil && (req.Method == echo.PUT || req.Method == echo.POST) {
 						return buf.Write(body)
 					}
 				default:

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -90,15 +90,15 @@ func TestLoggerTemplate(t *testing.T) {
 			`"method":"${method}","uri":"${uri}","status":${status}, "latency":${latency},` +
 			`"latency_human":"${latency_human}","bytes_in":${bytes_in}, "path":"${path}", "referer":"${referer}",` +
 			`"bytes_out":${bytes_out},"ch":"${header:X-Custom-Header}",` +
-			`"us":"${query:username}", "cf":"${form:username}"}` + "\n",
+			`"us":"${query:username}", "cf":"${form:username}", "body":"${body}" }` + "\n",
 		Output: buf,
 	}))
 
-	e.GET("/", func(c echo.Context) error {
+	e.POST("/", func(c echo.Context) error {
 		return c.String(http.StatusOK, "Header Logged")
 	})
 
-	req := httptest.NewRequest(echo.GET, "/?username=apagano-param&password=secret", nil)
+	req := httptest.NewRequest(echo.POST, "/?username=apagano-param&password=secret", bytes.NewReader([]byte("example_body")))
 	req.RequestURI = "/"
 	req.Header.Add(echo.HeaderXRealIP, "127.0.0.1")
 	req.Header.Add("Referer", "google.com")
@@ -120,7 +120,7 @@ func TestLoggerTemplate(t *testing.T) {
 		"BBB-CUSTOM-VALUE":                     false,
 		"secret-form":                          false,
 		"hexvalue":                             false,
-		"GET":                                  true,
+		"POST":                                 true,
 		"127.0.0.1":                            true,
 		"\"path\":\"/\"":                       true,
 		"\"uri\":\"/\"":                        true,


### PR DESCRIPTION
hi!
Echo is one of golang's best products.

There are cases where you want to output the body of the request to the log at the beginning of development, so I would like to make this change.

I may develop middleware, but since I become a patch while the difference is small, I want to avoid it if possible.

thanks.