### PR TITLE
Add pointer binding of proper types to DefaultBinder

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -142,6 +142,8 @@ func setWithProperType(valueKind reflect.Kind, val string, structField reflect.V
 	}
 
 	switch valueKind {
+	case reflect.Ptr:
+		return setWithProperType(structField.Elem().Kind(), val, structField.Elem())
 	case reflect.Int:
 		return setIntField(val, 0, structField)
 	case reflect.Int8:

--- a/bind_test.go
+++ b/bind_test.go
@@ -17,26 +17,39 @@ import (
 type (
 	bindTestStruct struct {
 		I           int
+		PtrI        *int
 		I8          int8
+		PtrI8       *int8
 		I16         int16
+		PtrI16      *int16
 		I32         int32
+		PtrI32      *int32
 		I64         int64
+		PtrI64      *int64
 		UI          uint
+		PtrUI       *uint
 		UI8         uint8
+		PtrUI8      *uint8
 		UI16        uint16
+		PtrUI16     *uint16
 		UI32        uint32
+		PtrUI32     *uint32
 		UI64        uint64
+		PtrUI64     *uint64
 		B           bool
+		PtrB        *bool
 		F32         float32
+		PtrF32      *float32
 		F64         float64
+		PtrF64      *float64
 		S           string
+		PtrS        *string
 		cantSet     string
 		DoesntExist string
 		T           Timestamp
 		Tptr        *Timestamp
 		SA          StringArray
 	}
-
 	Timestamp   time.Time
 	TA          []Timestamp
 	StringArray []string
@@ -69,19 +82,33 @@ func (t bindTestStruct) GetCantSet() string {
 
 var values = map[string][]string{
 	"I":       {"0"},
+	"PtrI":    {"0"},
 	"I8":      {"8"},
+	"PtrI8":   {"8"},
 	"I16":     {"16"},
+	"PtrI16":  {"16"},
 	"I32":     {"32"},
+	"PtrI32":  {"32"},
 	"I64":     {"64"},
+	"PtrI64":  {"64"},
 	"UI":      {"0"},
+	"PtrUI":   {"0"},
 	"UI8":     {"8"},
+	"PtrUI8":  {"8"},
 	"UI16":    {"16"},
+	"PtrUI16": {"16"},
 	"UI32":    {"32"},
+	"PtrUI32": {"32"},
 	"UI64":    {"64"},
+	"PtrUI64": {"64"},
 	"B":       {"true"},
+	"PtrB":    {"true"},
 	"F32":     {"32.5"},
+	"PtrF32":  {"32.5"},
 	"F64":     {"64.5"},
+	"PtrF64":  {"64.5"},
 	"S":       {"test"},
+	"PtrS":    {"test"},
 	"cantSet": {"test"},
 	"T":       {"2016-12-06T19:09:05+01:00"},
 	"Tptr":    {"2016-12-06T19:09:05+01:00"},


### PR DESCRIPTION
By default, proper pointer types are not supported (*bool, *int *float64, etc.).
However, they are useful to implement REST APIs where not all fields of a request struct are necessary.

Example: Using a *bool is very useful, because you get an additional state. Imagine you want  to support a POST request where you can optionally set a flag to true or false. Without the pointer, the flag would always be false, if it were not specified in the POST request.

So missing == false, which is NOT what you want for REST-like things.

For consistency, all proper types should be pointer-able.

This relates to #911.
