### PR TITLE
Automatically use JSONPretty/XMLPretty if '?pretty' in querystring

### DIFF
--- a/context.go
+++ b/context.go
@@ -385,10 +385,8 @@ func (c *context) String(code int, s string) (err error) {
 }
 
 func (c *context) JSON(code int, i interface{}) (err error) {
-	query := c.request.URL.Query()
-	_, isPretty := query["pretty"]
-
-	if c.echo.Debug || isPretty {
+	_, pretty := c.request.URL.Query()["pretty"]
+	if c.echo.Debug || pretty {
 		return c.JSONPretty(code, i, "  ")
 	}
 	b, err := json.Marshal(i)
@@ -432,10 +430,8 @@ func (c *context) JSONPBlob(code int, callback string, b []byte) (err error) {
 }
 
 func (c *context) XML(code int, i interface{}) (err error) {
-	query := c.request.URL.Query()
-	_, isPretty := query["pretty"]
-
-	if c.echo.Debug || isPretty {
+	_, pretty := c.request.URL.Query()["pretty"]
+	if c.echo.Debug || pretty {
 		return c.XMLPretty(code, i, "  ")
 	}
 	b, err := xml.Marshal(i)

--- a/context.go
+++ b/context.go
@@ -385,7 +385,10 @@ func (c *context) String(code int, s string) (err error) {
 }
 
 func (c *context) JSON(code int, i interface{}) (err error) {
-	if c.echo.Debug {
+	query := c.request.URL.Query()
+	_, isPretty := query["pretty"]
+
+	if c.echo.Debug || isPretty {
 		return c.JSONPretty(code, i, "  ")
 	}
 	b, err := json.Marshal(i)
@@ -429,7 +432,10 @@ func (c *context) JSONPBlob(code int, callback string, b []byte) (err error) {
 }
 
 func (c *context) XML(code int, i interface{}) (err error) {
-	if c.echo.Debug {
+	query := c.request.URL.Query()
+	_, isPretty := query["pretty"]
+
+	if c.echo.Debug || isPretty {
 		return c.XMLPretty(code, i, "  ")
 	}
 	b, err := xml.Marshal(i)

--- a/context_test.go
+++ b/context_test.go
@@ -73,10 +73,22 @@ func TestContext(t *testing.T) {
 		assert.Equal(t, userJSON, rec.Body.String())
 	}
 
+	// JSON with "?pretty"
+	req = httptest.NewRequest(GET, "/?pretty", nil)
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec).(*context)
+	err = c.JSON(http.StatusOK, user{1, "Jon Snow"})
+	if assert.NoError(t, err) {
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, MIMEApplicationJSONCharsetUTF8, rec.Header().Get(HeaderContentType))
+		assert.Equal(t, userJSONPretty, rec.Body.String())
+	}
+	req = httptest.NewRequest(GET, "/", nil) // reset
+
 	// JSONPretty
 	rec = httptest.NewRecorder()
 	c = e.NewContext(req, rec).(*context)
-	err = c.JSONPretty(http.StatusOK, user{1, "Jon Snow"}, "\t")
+	err = c.JSONPretty(http.StatusOK, user{1, "Jon Snow"}, "  ")
 	if assert.NoError(t, err) {
 		assert.Equal(t, http.StatusOK, rec.Code)
 		assert.Equal(t, MIMEApplicationJSONCharsetUTF8, rec.Header().Get(HeaderContentType))
@@ -110,6 +122,18 @@ func TestContext(t *testing.T) {
 		assert.Equal(t, xml.Header+userXML, rec.Body.String())
 	}
 
+	// XML with "?pretty"
+	req = httptest.NewRequest(GET, "/?pretty", nil)
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec).(*context)
+	err = c.XML(http.StatusOK, user{1, "Jon Snow"})
+	if assert.NoError(t, err) {
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, MIMEApplicationXMLCharsetUTF8, rec.Header().Get(HeaderContentType))
+		assert.Equal(t, xml.Header+userXMLPretty, rec.Body.String())
+	}
+	req = httptest.NewRequest(GET, "/", nil)
+
 	// XML (error)
 	rec = httptest.NewRecorder()
 	c = e.NewContext(req, rec).(*context)
@@ -119,7 +143,7 @@ func TestContext(t *testing.T) {
 	// XMLPretty
 	rec = httptest.NewRecorder()
 	c = e.NewContext(req, rec).(*context)
-	err = c.XMLPretty(http.StatusOK, user{1, "Jon Snow"}, "\t")
+	err = c.XMLPretty(http.StatusOK, user{1, "Jon Snow"}, "  ")
 	if assert.NoError(t, err) {
 		assert.Equal(t, http.StatusOK, rec.Code)
 		assert.Equal(t, MIMEApplicationXMLCharsetUTF8, rec.Header().Get(HeaderContentType))

--- a/echo_test.go
+++ b/echo_test.go
@@ -31,13 +31,13 @@ const (
 )
 
 const userJSONPretty = `{
-	"id": 1,
-	"name": "Jon Snow"
+  "id": 1,
+  "name": "Jon Snow"
 }`
 
 const userXMLPretty = `<user>
-	<id>1</id>
-	<name>Jon Snow</name>
+  <id>1</id>
+  <name>Jon Snow</name>
 </user>`
 
 func TestEcho(t *testing.T) {

--- a/website/content/guide/response.md
+++ b/website/content/guide/response.md
@@ -108,6 +108,33 @@ func(c echo.Context) error {
 }
 ```
 
+Today, `Context#JSON(code int, i interface{})` also can output a pretty printed JSON
+(indented with spaces) when a querystring `?pretty` is attached in request URL.
+
+*Example*
+
+```go
+func(c echo.Context) error {
+  u := &User{
+    Name:  "Jon",
+    Email: "joe@labstack.com",
+  }
+  return c.JSON(http.StatusOK, u)
+}
+```
+
+```bash
+curl -fSL http://127.0.0.1:8080/v1/users/123?pretty
+```
+
+```js
+{
+  "email": "joe@labstack.com",
+  "name": "Jon"
+}
+```
+
+
 ### JSON Blob
 
 `Context#JSONBlob(code int, b []byte)` can be used to send pre-encoded JSON blob directly
@@ -181,6 +208,33 @@ func(c echo.Context) error {
   }
   return c.XMLPretty(http.StatusOK, u, "  ")
 }
+```
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<User>
+  <Name>Jon</Name>
+  <Email>joe@labstack.com</Email>
+</User>
+```
+
+Today, `Context#XML(code int, i interface{})` also can output a pretty printed XML
+(indented with spaces) when a querystring `?pretty` is attached in request URL.
+
+*Example*
+
+```go
+func(c echo.Context) error {
+  u := &User{
+    Name:  "Jon",
+    Email: "joe@labstack.com",
+  }
+  return c.XML(http.StatusOK, u)
+}
+```
+
+```bash
+curl -fSL http://127.0.0.1:8080/v1/users/123?pretty
 ```
 
 ```xml


### PR DESCRIPTION
We usually use `c.JSON()` to response a json object, but it outputs a compact json format as default, that are not readable. 

As debug purpose, we maybe want to get a pretty json format for readable. Then, we have to change code to add`echo.Debug=true` or use `c.JSONPretty()`, rebuild and redeploy. It is not accepted for us in a deployed box.

So I bring a dynamic pretty response for `JSON` and `XML`.
In code, I will always use `c.JSON()` to output json. When I want to get a pretty json response, I only need add a `?pretty` into querystring in my request URL, no any changes for my application.

Example:
```
# get default json
curl -fSL http://127.0.0.1:8080/v1/test

{"error":500,"message":"unable to get status","casue":"file not found: /tmp/data"}

# get pretty json
curl -fSL http://127.0.0.1:8080/v1/test?pretty

{
    "error":500,
    "message":"unable to get status",
    "casue":"file not found: /tmp/data"
}
```

It works on all APIs, includes `GET`, `POST`, etc.