### PR TITLE
Security Fix: Filesystem traversal bug

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -45,6 +45,7 @@ import (
 	stdLog "log"
 	"net"
 	"net/http"
+	"net/url"
 	"path"
 	"path/filepath"
 	"reflect"
@@ -434,7 +435,11 @@ func (e *Echo) Static(prefix, root string) {
 
 func static(i i, prefix, root string) {
 	h := func(c Context) error {
-		name := filepath.Join(root, path.Clean("/"+c.Param("*"))) // "/"+ for security
+		p, err := url.PathUnescape(c.Param("*"))
+		if err != nil {
+			return err
+		}
+		name := filepath.Join(root, path.Clean("/"+p)) // "/"+ for security
 		return c.File(name)
 	}
 	i.GET(prefix, h)

--- a/middleware/static.go
+++ b/middleware/static.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -74,6 +75,12 @@ func StaticWithConfig(config StaticConfig) echo.MiddlewareFunc {
 			p := c.Request().URL.Path
 			if strings.HasSuffix(c.Path(), "*") { // When serving from a group, e.g. `/static*`.
 				p = c.Param("*")
+			}
+
+			var err error
+			p, err = url.PathUnescape(p)
+			if err != nil {
+				return err
 			}
 			name := filepath.Join(config.Root, path.Clean("/"+p)) // "/"+ for security
 


### PR DESCRIPTION
This PR fixes an issue where encoded URLs could escape the static directory and traverse the filesystem.