### PR TITLE
Allow interface{} as key for JWT middleware argument

### DIFF
--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -77,7 +77,7 @@ var (
 //
 // See: https://jwt.io/introduction
 // See `JWTConfig.TokenLookup`
-func JWT(key []byte) echo.MiddlewareFunc {
+func JWT(key interface{}) echo.MiddlewareFunc {
 	c := DefaultJWTConfig
 	c.SigningKey = key
 	return JWTWithConfig(c)


### PR DESCRIPTION
The underlying use is an `interface{}` so forcing this to be `byte[]` means that default config can't be used with an `rsa.PublicKey` type.