### PR TITLE
Change echo http error message

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -657,7 +657,7 @@ func NewHTTPError(code int, message ...interface{}) *HTTPError {
 
 // Error makes it compatible with `error` interface.
 func (he *HTTPError) Error() string {
-	return fmt.Sprintf("code=%d, message=%s", he.Code, he.Message)
+	return fmt.Sprintf("code=%d, message=%v", he.Code, he.Message)
 }
 
 // WrapHandler wraps `http.Handler` into `echo.HandlerFunc`.

--- a/echo_test.go
+++ b/echo_test.go
@@ -434,3 +434,13 @@ func request(method, path string, e *Echo) (int, string) {
 	e.ServeHTTP(rec, req)
 	return rec.Code, rec.Body.String()
 }
+
+func TestHTTPError(t *testing.T) {
+	err := NewHTTPError(400, map[string]interface{}{
+		"code": 12,
+	})
+	expected := "code=400, message=map[code:12]"
+	if expected != err.Error() {
+		t.Errorf("expected body %s,got %s", expected, err.Error())
+	}
+}


### PR DESCRIPTION
The `Message` field of `HTTPError` is `interface{}` not just `string`, so the format `message=%v` is better.