### PR TITLE
Expose echo.add() method for dynamic route registration

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -356,55 +356,55 @@ func (e *Echo) Use(middleware ...MiddlewareFunc) {
 // CONNECT registers a new CONNECT route for a path with matching handler in the
 // router with optional route-level middleware.
 func (e *Echo) CONNECT(path string, h HandlerFunc, m ...MiddlewareFunc) *Route {
-	return e.add(CONNECT, path, h, m...)
+	return e.Add(CONNECT, path, h, m...)
 }
 
 // DELETE registers a new DELETE route for a path with matching handler in the router
 // with optional route-level middleware.
 func (e *Echo) DELETE(path string, h HandlerFunc, m ...MiddlewareFunc) *Route {
-	return e.add(DELETE, path, h, m...)
+	return e.Add(DELETE, path, h, m...)
 }
 
 // GET registers a new GET route for a path with matching handler in the router
 // with optional route-level middleware.
 func (e *Echo) GET(path string, h HandlerFunc, m ...MiddlewareFunc) *Route {
-	return e.add(GET, path, h, m...)
+	return e.Add(GET, path, h, m...)
 }
 
 // HEAD registers a new HEAD route for a path with matching handler in the
 // router with optional route-level middleware.
 func (e *Echo) HEAD(path string, h HandlerFunc, m ...MiddlewareFunc) *Route {
-	return e.add(HEAD, path, h, m...)
+	return e.Add(HEAD, path, h, m...)
 }
 
 // OPTIONS registers a new OPTIONS route for a path with matching handler in the
 // router with optional route-level middleware.
 func (e *Echo) OPTIONS(path string, h HandlerFunc, m ...MiddlewareFunc) *Route {
-	return e.add(OPTIONS, path, h, m...)
+	return e.Add(OPTIONS, path, h, m...)
 }
 
 // PATCH registers a new PATCH route for a path with matching handler in the
 // router with optional route-level middleware.
 func (e *Echo) PATCH(path string, h HandlerFunc, m ...MiddlewareFunc) *Route {
-	return e.add(PATCH, path, h, m...)
+	return e.Add(PATCH, path, h, m...)
 }
 
 // POST registers a new POST route for a path with matching handler in the
 // router with optional route-level middleware.
 func (e *Echo) POST(path string, h HandlerFunc, m ...MiddlewareFunc) *Route {
-	return e.add(POST, path, h, m...)
+	return e.Add(POST, path, h, m...)
 }
 
 // PUT registers a new PUT route for a path with matching handler in the
 // router with optional route-level middleware.
 func (e *Echo) PUT(path string, h HandlerFunc, m ...MiddlewareFunc) *Route {
-	return e.add(PUT, path, h, m...)
+	return e.Add(PUT, path, h, m...)
 }
 
 // TRACE registers a new TRACE route for a path with matching handler in the
 // router with optional route-level middleware.
 func (e *Echo) TRACE(path string, h HandlerFunc, m ...MiddlewareFunc) *Route {
-	return e.add(TRACE, path, h, m...)
+	return e.Add(TRACE, path, h, m...)
 }
 
 // Any registers a new route for all HTTP methods and path with matching handler
@@ -412,7 +412,7 @@ func (e *Echo) TRACE(path string, h HandlerFunc, m ...MiddlewareFunc) *Route {
 func (e *Echo) Any(path string, handler HandlerFunc, middleware ...MiddlewareFunc) []*Route {
 	routes := make([]*Route, 0)
 	for _, m := range methods {
-		routes = append(routes, e.add(m, path, handler, middleware...))
+		routes = append(routes, e.Add(m, path, handler, middleware...))
 	}
 	return routes
 }
@@ -422,7 +422,7 @@ func (e *Echo) Any(path string, handler HandlerFunc, middleware ...MiddlewareFun
 func (e *Echo) Match(methods []string, path string, handler HandlerFunc, middleware ...MiddlewareFunc) []*Route {
 	routes := make([]*Route, 0)
 	for _, m := range methods {
-		routes = append(routes, e.add(m, path, handler, middleware...))
+		routes = append(routes, e.Add(m, path, handler, middleware...))
 	}
 	return routes
 }
@@ -460,7 +460,9 @@ func (e *Echo) File(path, file string) *Route {
 	})
 }
 
-func (e *Echo) add(method, path string, handler HandlerFunc, middleware ...MiddlewareFunc) *Route {
+// Add registers a new route for an HTTP method and path with matching handler
+// in the router with optional route-level middleware.
+func (e *Echo) Add(method, path string, handler HandlerFunc, middleware ...MiddlewareFunc) *Route {
 	name := handlerName(handler)
 	e.router.Add(method, path, func(c Context) error {
 		h := handler

--- a/echo_test.go
+++ b/echo_test.go
@@ -285,7 +285,7 @@ func TestEchoRoutes(t *testing.T) {
 		{POST, "/repos/:owner/:repo/git/tags", ""},
 	}
 	for _, r := range routes {
-		e.add(r.Method, r.Path, func(c Context) error {
+		e.Add(r.Method, r.Path, func(c Context) error {
 			return c.String(http.StatusOK, "OK")
 		})
 	}

--- a/group.go
+++ b/group.go
@@ -109,5 +109,5 @@ func (g *Group) add(method, path string, handler HandlerFunc, middleware ...Midd
 	m := []MiddlewareFunc{}
 	m = append(m, g.middleware...)
 	m = append(m, middleware...)
-	return g.echo.add(method, g.prefix+path, handler, m...)
+	return g.echo.Add(method, g.prefix+path, handler, m...)
 }


### PR DESCRIPTION
This exposes the `echo.add` (becomes `echo.Add`) method which makes it easy to iterate over a map of routes and dynamically register them.

For example:
```go
package main

import (
	"log"
	"net/http"

	"github.com/labstack/echo"
)

type Route struct {
	Path    string
	Method  string
	Handler echo.HandlerFunc
}

var routes = []*Route{
	&Route{
		Path:   "/api/users",
		Method: echo.GET,
		Handler: func(c echo.Context) error {
			return c.String(http.StatusOK, "Listing users...")
		},
	},
	&Route{
		Path:   "/api/users",
		Method: echo.POST,
		Handler: func(c echo.Context) error {
			return c.String(http.StatusOK, "Creating user...")
		},
	},
}

func main() {
	e := echo.New()

	for _, route := range routes {
		e.Add(route.Method, route.Path, route.Handler)
	}

	if err := e.Start(":8888"); err != nil {
		log.Fatalf("Failed to start server: %s", err.Error())
	}
}
```