### PR TITLE
Use the NotFoundHandler when a file haven't been found.

### DIFF
--- a/context.go
+++ b/context.go
@@ -496,7 +496,7 @@ func (c *context) Stream(code int, contentType string, r io.Reader) (err error) 
 func (c *context) File(file string) (err error) {
 	f, err := os.Open(file)
 	if err != nil {
-		return ErrNotFound
+		return NotFoundHandler(c)
 	}
 	defer f.Close()
 
@@ -505,7 +505,7 @@ func (c *context) File(file string) (err error) {
 		file = filepath.Join(file, indexPage)
 		f, err = os.Open(file)
 		if err != nil {
-			return ErrNotFound
+			return NotFoundHandler(c)
 		}
 		defer f.Close()
 		if fi, err = f.Stat(); err != nil {

--- a/group.go
+++ b/group.go
@@ -21,7 +21,7 @@ func (g *Group) Use(middleware ...MiddlewareFunc) {
 	// Allow all requests to reach the group as they might get dropped if router
 	// doesn't find a match, making none of the group middleware process.
 	g.echo.Any(path.Clean(g.prefix+"/*"), func(c Context) error {
-		return ErrNotFound
+		return NotFoundHandler(c)
 	}, g.middleware...)
 }
 


### PR DESCRIPTION
This is especialy usefull when you use e.Static("/", "static") and you
want a notfoundhandler that serves your index.html like this:

```go
echo.NotFoundHandler = func(c2 echo.Context) error {
	index := path.Join("static", "index.html")
	f, err := os.Open(index)
	if err != nil {
		return echo.ErrNotFound
	}
	return c2.File(index)
}
```

One caveat, you need to make sure that your NotFoundHandler doesn't
produce loops.

Signed-off-by: Rene Jochum <rene@jochums.at>