### PR TITLE
Fix issue with JWT race

### DIFF
--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -141,7 +141,8 @@ func JWTWithConfig(config JWTConfig) echo.MiddlewareFunc {
 			if _, ok := config.Claims.(jwt.MapClaims); ok {
 				token, err = jwt.Parse(auth, config.keyFunc)
 			} else {
-				claims := reflect.ValueOf(config.Claims).Interface().(jwt.Claims)
+				t := reflect.ValueOf(config.Claims).Type().Elem()
+				claims := reflect.New(t).Interface().(jwt.Claims)
 				token, err = jwt.ParseWithClaims(auth, claims, config.keyFunc)
 			}
 			if err == nil && token.Valid {

--- a/middleware/jwt_test.go
+++ b/middleware/jwt_test.go
@@ -22,6 +22,42 @@ type jwtCustomClaims struct {
 	jwtCustomInfo
 }
 
+func TestJWTRace(t *testing.T) {
+	e := echo.New()
+	handler := func(c echo.Context) error {
+		return c.String(http.StatusOK, "test")
+	}
+	initialToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ"
+	raceToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IlJhY2UgQ29uZGl0aW9uIiwiYWRtaW4iOmZhbHNlfQ.Xzkx9mcgGqYMTkuxSCbJ67lsDyk5J2aB7hu65cEE-Ss"
+	validKey := []byte("secret")
+
+	h := JWTWithConfig(JWTConfig{
+		Claims:     &jwtCustomClaims{},
+		SigningKey: validKey,
+	})(handler)
+
+	makeReq := func(token string) echo.Context {
+		req := httptest.NewRequest(echo.GET, "/", nil)
+		res := httptest.NewRecorder()
+		req.Header.Set(echo.HeaderAuthorization, DefaultJWTConfig.AuthScheme+" "+token)
+		c := e.NewContext(req, res)
+		assert.NoError(t, h(c))
+		return c
+	}
+
+	c := makeReq(initialToken)
+	user := c.Get("user").(*jwt.Token)
+	claims := user.Claims.(*jwtCustomClaims)
+	assert.Equal(t, claims.Name, "John Doe")
+
+	makeReq(raceToken)
+	user = c.Get("user").(*jwt.Token)
+	claims = user.Claims.(*jwtCustomClaims)
+	// Initial context should still be "John Doe", not "Race Condition"
+	assert.Equal(t, claims.Name, "John Doe")
+	assert.Equal(t, claims.Admin, true)
+}
+
 func TestJWT(t *testing.T) {
 	e := echo.New()
 	handler := func(c echo.Context) error {


### PR DESCRIPTION
Currently the custom claims pointer handling in the JWT middleware reuses the same pointer between contexts so the JWT claims bleed between requests, this test demonstrates the issue.

The first request creates a context with JWT data, the second request just discards its context, but the first request's user is overwritten.