### PR TITLE
Support context DefaultQueryParam for return default value if param does not exits

### DIFF
--- a/context.go
+++ b/context.go
@@ -65,6 +65,10 @@ type (
 		// QueryParam returns the query param for the provided name.
 		QueryParam(name string) string
 
+		// DefaultQueryParam returns the query param for the provided name if it exists,
+		// otherwise it returns the specified defaultValue string.
+		DefaultQueryParam(name, defaultValue string) string
+
 		// QueryParams returns the query parameters as `url.Values`.
 		QueryParams() url.Values
 
@@ -307,6 +311,13 @@ func (c *context) QueryParam(name string) string {
 		c.query = c.request.URL.Query()
 	}
 	return c.query.Get(name)
+}
+
+func (c *context) DefaultQueryParam(name, defaultValue string) string {
+	if value := c.QueryParam(name); len(value) > 0 {
+		return c.QueryParam(name)
+	}
+	return defaultValue
 }
 
 func (c *context) QueryParams() url.Values {

--- a/context_test.go
+++ b/context_test.go
@@ -367,7 +367,7 @@ func TestContextDefaultQueryParam(t *testing.T) {
 	c := e.NewContext(req, nil)
 
 	// QueryParam
-	assert.Equal(t, "Huy Huynh", c.QueryParam("name"))
+	assert.Equal(t, "Huy Huynh", c.DefaultQueryParam("name","John Wick"))
 	assert.Equal(t, "huyhvq@deptrai.com", c.DefaultQueryParam("email","huyhvq@deptrai.com"))
 
 	// QueryParams

--- a/context_test.go
+++ b/context_test.go
@@ -358,6 +358,24 @@ func TestContextQueryParam(t *testing.T) {
 	}, c.QueryParams())
 }
 
+
+func TestContextDefaultQueryParam(t *testing.T) {
+	q := make(url.Values)
+	q.Set("name", "Huy Huynh")
+	req := httptest.NewRequest(GET, "/?"+q.Encode(), nil)
+	e := New()
+	c := e.NewContext(req, nil)
+
+	// QueryParam
+	assert.Equal(t, "Huy Huynh", c.QueryParam("name"))
+	assert.Equal(t, "huyhvq@deptrai.com", c.DefaultQueryParam("email","huyhvq@deptrai.com"))
+
+	// QueryParams
+	assert.Equal(t, url.Values{
+		"name":  []string{"Huy Huynh"},
+	}, c.QueryParams())
+}
+
 func TestContextFormFile(t *testing.T) {
 	e := New()
 	buf := new(bytes.Buffer)


### PR DESCRIPTION
Hi my friends,
I am an inconvenience when I want to get a default value parameter does not exits, and I have a ton of code to check it's empty then return value bla bla bla... So I think it's simply when we have method for do it.

```go
value := c.DefaultQueryParam("name", "Echo")
```
--


