### PR TITLE
Fix group middleware

### DIFF
--- a/group.go
+++ b/group.go
@@ -1,9 +1,5 @@
 package echo
 
-import (
-	"path"
-)
-
 type (
 	// Group is a set of sub-routes for a specified route. It can be used for inner
 	// routes that share a common middleware or functionality that should be separate
@@ -18,11 +14,6 @@ type (
 // Use implements `Echo#Use()` for sub-routes within the Group.
 func (g *Group) Use(middleware ...MiddlewareFunc) {
 	g.middleware = append(g.middleware, middleware...)
-	// Allow all requests to reach the group as they might get dropped if router
-	// doesn't find a match, making none of the group middleware process.
-	g.echo.Any(path.Clean(g.prefix+"/*"), func(c Context) error {
-		return NotFoundHandler(c)
-	}, g.middleware...)
 }
 
 // CONNECT implements `Echo#CONNECT()` for sub-routes within the Group.

--- a/group_test.go
+++ b/group_test.go
@@ -3,6 +3,8 @@ package echo
 import (
 	"testing"
 
+	"net/http"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -63,4 +65,24 @@ func TestGroupRouteMiddleware(t *testing.T) {
 	assert.Equal(t, 404, c)
 	c, _ = request(GET, "/group/405", e)
 	assert.Equal(t, 405, c)
+}
+
+func TestGroupMiddlewareNotCalledIfRouteNotInGroup(t *testing.T) {
+	// Ensure that group middlewares are not called for routes that are not part of the group
+
+	m := func(next HandlerFunc) HandlerFunc {
+		return func(c Context) error {
+			return c.String(http.StatusOK, "BODY")
+		}
+	}
+
+	e := New()
+	g := e.Group("", m)
+	g.GET("/route", func(Context) error { return nil })
+
+	_, b := request(GET, "/route", e)
+	assert.Equal(t, "BODY", b)
+
+	_, b = request(GET, "/other", e)
+	assert.Equal(t, "{\"message\":\"Not Found\"}", b)
 }

--- a/middleware/static_test.go
+++ b/middleware/static_test.go
@@ -65,3 +65,25 @@ func TestStatic(t *testing.T) {
 		assert.Contains(t, rec.Body.String(), "cert.pem")
 	}
 }
+
+func request(method, path string, e *echo.Echo) (int, string) {
+	req := httptest.NewRequest(method, path, nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	return rec.Code, rec.Body.String()
+}
+
+func TestMultipleStaticDirectory(t *testing.T) {
+	e := echo.New()
+	e.Use(Static("../_fixture"))
+	e.Use(Static("../_fixture/images"))
+
+	code, _ := request(echo.GET, "/walle.png", e) // Served from  ../_fixture/images
+	assert.Equal(t, 200, code)
+
+	code, _ = request(echo.GET, "/favicon.ico", e) // served from ../_fixture
+	assert.Equal(t, 200, code)
+
+	code, _ = request(echo.GET, "/missing.file", e)
+	assert.Equal(t, 404, code)
+}


### PR DESCRIPTION
Middleware should not be called for routes that are not wrapped by the middleware.

## The bug I'm fixing:

**Expected**
When I create a `.Group` with middlewares, I expect the middlewares to be executed only for the routes that are part of the group.

**Current behavior:**
The middleware is executed for all the routes even if they don't match any route in the group.

**Example**:

```go
e := New()

e.GET("/no_auth_required", func(Context) error { return nil })

myGroup := e.Group("", IsAuthMiddleware)
myGroup.GET("/route_that_needs_auth_1", func(Context) error { return nil })
myGroup.GET("/route_that_needs_auth_2", func(Context) error { return nil })
```

In the above example, if I call `/no_auth_required` everything is fine, the middleware isn't called.
But, if I call `/some_other_route`, the middleware will be executed even if it is not part of the group.

-----

## Pull request explained

**First**
I'm removing some code that is apparently doing nothing other than introducing a bug. **(group.go)**

**Second**
The removed code was supposed to fix this issue https://github.com/labstack/echo/issues/838.
So I added a test to ensure that this issue is actually fixed. **(static_test.go)**
(Because the removed code apparently doesn't fixed the mentioned issue)

**Third**
I added a test to ensure the bug I'm reporting will not come back. **(group_test.go)**
 