### PR TITLE
Wrap functionality

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -495,6 +495,13 @@ func (e *Echo) Group(prefix string, m ...MiddlewareFunc) (g *Group) {
 	return
 }
 
+// Wrap wraps a defined set of routes with middlewares.
+func (e *Echo) Wrap(m ...MiddlewareFunc) (g *Group) {
+	g = &Group{echo: e}
+	g.WrapUse(m...)
+	return
+}
+
 // URI generates a URI from handler.
 func (e *Echo) URI(handler HandlerFunc, params ...interface{}) string {
 	name := handlerName(handler)

--- a/group.go
+++ b/group.go
@@ -15,6 +15,11 @@ type (
 	}
 )
 
+// WrapUse implements `Echo#Use()` for sub-routes within the Group.
+func (g *Group) WrapUse(middleware ...MiddlewareFunc) {
+	g.middleware = append(g.middleware, middleware...)
+}
+
 // Use implements `Echo#Use()` for sub-routes within the Group.
 func (g *Group) Use(middleware ...MiddlewareFunc) {
 	g.middleware = append(g.middleware, middleware...)
@@ -96,6 +101,16 @@ func (g *Group) Group(prefix string, middleware ...MiddlewareFunc) *Group {
 	m = append(m, g.middleware...)
 	m = append(m, middleware...)
 	return g.echo.Group(g.prefix+prefix, m...)
+}
+
+// Wrap creates a new sub-group.
+func (g *Group) Wrap(middleware ...MiddlewareFunc) *Group {
+	m := []MiddlewareFunc{}
+	m = append(m, g.middleware...)
+	m = append(m, middleware...)
+	subGroup := g.echo.Group(g.prefix)
+	subGroup.WrapUse(m...)
+	return subGroup
 }
 
 // Static implements `Echo#Static()` for sub-routes within the Group.

--- a/middleware/static_test.go
+++ b/middleware/static_test.go
@@ -65,3 +65,25 @@ func TestStatic(t *testing.T) {
 		assert.Contains(t, rec.Body.String(), "cert.pem")
 	}
 }
+
+func request(method, path string, e *echo.Echo) (int, string) {
+	req := httptest.NewRequest(method, path, nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	return rec.Code, rec.Body.String()
+}
+
+func TestMultipleStaticDirectory(t *testing.T) {
+	e := echo.New()
+	e.Use(Static("../_fixture"))
+	e.Use(Static("../_fixture/images"))
+
+	code, _ := request(echo.GET, "/walle.png", e) // Served from  ../_fixture/images
+	assert.Equal(t, 200, code)
+
+	code, _ = request(echo.GET, "/favicon.ico", e) // served from ../_fixture
+	assert.Equal(t, 200, code)
+
+	code, _ = request(echo.GET, "/missing.file", e)
+	assert.Equal(t, 404, code)
+}


### PR DESCRIPTION
# Contextualization
I need a way to "wrap" a defined set of routes, and apply one or more middleware to these routes.

The current way of doing it is by creating a `.Group`. But the group will also apply the middleware to all the possible sub routes even if they are not defined.

## Examples

### With .Group

```go
package main

import "github.com/labstack/echo"

func IsAuthMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
  return func(ctx echo.Context) error {
    return ctx.String(401, "Auth required")
  }
}

func main() {
  e := echo.New()

  e.GET("/no_auth_required", func(c echo.Context) error { return c.String(200, "Text1") })

  myGroup := e.Group("", IsAuthMiddleware)
  myGroup.GET("/needs_auth_1", func(c echo.Context) error { return c.String(200, "Text2") })
  myGroup.GET("/needs_auth_2", func(c echo.Context) error { return c.String(200, "Text3") })

  e.Start(":8080")

  // curl 127.0.0.1:8080/no_auth_required # (middleware not called) (✓ good behavior)
  // curl 127.0.0.1:8080/needs_auth_1     # (middleware called)     (✓ good behavior)
  // curl 127.0.0.1:8080/needs_auth_2     # (middleware called)     (✓ good behavior)
  // curl 127.0.0.1:8080/does_not_exists  # (middleware called)     (✖ bad behavior)
}
```

Here, when `/does_not_exists` is called, the middleware is executed as well. (unwanted)

### With .Wrap

```go
package main

import "github.com/labstack/echo"

func IsAuthMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
  return func(ctx echo.Context) error {
    return ctx.String(401, "Auth required")
  }
}

func main() {
  e := echo.New()

  e.GET("/no_auth_required", func(c echo.Context) error { return c.String(200, "Text1") })

  myWrapper := e.Wrap(IsAuthMiddleware)
  myWrapper.GET("/needs_auth_1", func(c echo.Context) error { return c.String(200, "Text2") })
  myWrapper.GET("/needs_auth_2", func(c echo.Context) error { return c.String(200, "Text3") })

  e.Start(":8080")

  // curl 127.0.0.1:8080/no_auth_required # (middleware not called) (✓ good behavior)
  // curl 127.0.0.1:8080/needs_auth_1     # (middleware called)     (✓ good behavior)
  // curl 127.0.0.1:8080/needs_auth_2     # (middleware called)     (✓ good behavior)
  // curl 127.0.0.1:8080/does_not_exists  # (middleware not called) (✓ good behavior)
}
```
So here, if we call a route that does not exists, the `IsAuthMiddleware`, won't be called.