### PR TITLE
Slice don't bind the route parameter

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -39,8 +39,12 @@ func (b *DefaultBinder) Bind(i interface{}, c Context) (err error) {
 		}
 		return NewHTTPError(http.StatusBadRequest, "Request body can't be empty")
 	}
-	if err = b.bindPathData(i, c); err != nil {
-		return NewHTTPError(http.StatusBadRequest, err.Error())
+	// Slice Don't Bind the route parameter
+	typ := reflect.TypeOf(i).Elem()
+	if typ.Kind() != reflect.Slice {
+		if err = b.bindPathData(i, c); err != nil {
+			return NewHTTPError(http.StatusBadRequest, err.Error())
+		}
 	}
 	ctype := req.Header.Get(HeaderContentType)
 	switch {

--- a/bind_test.go
+++ b/bind_test.go
@@ -118,6 +118,7 @@ var values = map[string][]string{
 func TestBindJSON(t *testing.T) {
 	testBindOkay(t, strings.NewReader(userJSON), MIMEApplicationJSON)
 	testBindError(t, strings.NewReader(invalidContent), MIMEApplicationJSON)
+	testBindSliceOkay(t, strings.NewReader(userJSONMulti), MIMEApplicationJSON)
 }
 
 func TestBindXML(t *testing.T) {
@@ -314,6 +315,12 @@ func assertBindTestStruct(t *testing.T, ts *bindTestStruct) {
 	assert.Equal(t, "", ts.GetCantSet())
 }
 
+func assertUsers(t *testing.T, ts users) {
+	us := users{user{1, "Jon Snow"}, user{2, "John Smith"}}
+	assert.Equal(t, us[0], ts[0])
+	assert.Equal(t, us[1], ts[1])
+}
+
 func testBindOkay(t *testing.T, r io.Reader, ctype string) {
 	e := New()
 	req := httptest.NewRequest(POST, "/", r)
@@ -325,6 +332,19 @@ func testBindOkay(t *testing.T, r io.Reader, ctype string) {
 	if assert.NoError(t, err) {
 		assert.Equal(t, 1, u.ID)
 		assert.Equal(t, "Jon Snow", u.Name)
+	}
+}
+
+func testBindSliceOkay(t *testing.T, r io.Reader, ctype string) {
+	e := New()
+	req := httptest.NewRequest(POST, "/", r)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	req.Header.Set(HeaderContentType, ctype)
+	us := new(users)
+	err := c.Bind(us)
+	if assert.NoError(t, err) {
+		assertUsers(t, *us)
 	}
 }
 

--- a/echo_test.go
+++ b/echo_test.go
@@ -22,10 +22,12 @@ type (
 		Name string `json:"name" xml:"name" form:"name" query:"name"`
 	}
 )
+type users []user
 
 const (
 	userJSON         = `{"id":1,"name":"Jon Snow"}`
 	userJSONOnlyName = `{"name":"Jon Snow"}`
+	userJSONMulti    = `[{"id":1,"name":"Jon Snow"},{"id":2,"name":"John Smith"}]`
 	userXML          = `<user><id>1</id><name>Jon Snow</name></user>`
 	userForm         = `id=1&name=Jon Snow`
 	invalidContent   = "invalid content"


### PR DESCRIPTION
hi.
Support of Bind to Slice of Struct which was possible before this PR (https://github.com/labstack/echo/pull/973) was supported.
Because BindData is always invoked, Struct was mandatory.

As another solution, I studied to make the route parameter Bind to each element Struct of Slice, but I stopped because I seemed unnatural.

Please comment if Bind does not assume Slice of Struct.
I will withdraw this PR and take action on the user side.