### PR TITLE
Make group.Match signature the same as echo.Match for interfaces

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -119,9 +119,25 @@ type (
 	// Map defines a generic map of type `map[string]interface{}`.
 	Map map[string]interface{}
 
-	// i is the interface for Echo and Group.
-	i interface {
-		GET(string, HandlerFunc, ...MiddlewareFunc) *Route
+	// Register is the interface for Echo and Group.
+	Register interface {
+		Use(middleware ...MiddlewareFunc)
+
+		CONNECT(path string, h HandlerFunc, m ...MiddlewareFunc) *Route
+		DELETE(path string, h HandlerFunc, m ...MiddlewareFunc) *Route
+		GET(path string, h HandlerFunc, m ...MiddlewareFunc) *Route
+		HEAD(path string, h HandlerFunc, m ...MiddlewareFunc) *Route
+		OPTIONS(path string, h HandlerFunc, m ...MiddlewareFunc) *Route
+		PATCH(path string, h HandlerFunc, m ...MiddlewareFunc) *Route
+		POST(path string, h HandlerFunc, m ...MiddlewareFunc) *Route
+		PUT(path string, h HandlerFunc, m ...MiddlewareFunc) *Route
+		TRACE(path string, h HandlerFunc, m ...MiddlewareFunc) *Route
+
+		Add(method, path string, handler HandlerFunc, middleware ...MiddlewareFunc) *Route
+		Any(path string, handler HandlerFunc, middleware ...MiddlewareFunc) []*Route
+		Match(methods []string, path string, handler HandlerFunc, middleware ...MiddlewareFunc) []*Route
+		Static(prefix, root string) *Route
+		File(path, file string) *Route
 	}
 )
 
@@ -436,7 +452,7 @@ func (e *Echo) Static(prefix, root string) *Route {
 	return static(e, prefix, root)
 }
 
-func static(i i, prefix, root string) *Route {
+func static(i Register, prefix, root string) *Route {
 	h := func(c Context) error {
 		p, err := PathUnescape(c.Param("*"))
 		if err != nil {

--- a/group.go
+++ b/group.go
@@ -71,17 +71,21 @@ func (g *Group) TRACE(path string, h HandlerFunc, m ...MiddlewareFunc) *Route {
 }
 
 // Any implements `Echo#Any()` for sub-routes within the Group.
-func (g *Group) Any(path string, handler HandlerFunc, middleware ...MiddlewareFunc) {
+func (g *Group) Any(path string, handler HandlerFunc, middleware ...MiddlewareFunc) []*Route {
+	routes := make([]*Route, 0, len(methods))
 	for _, m := range methods {
-		g.Add(m, path, handler, middleware...)
+		routes = append(routes, g.Add(m, path, handler, middleware...))
 	}
+	return routes
 }
 
 // Match implements `Echo#Match()` for sub-routes within the Group.
-func (g *Group) Match(methods []string, path string, handler HandlerFunc, middleware ...MiddlewareFunc) {
+func (g *Group) Match(methods []string, path string, handler HandlerFunc, middleware ...MiddlewareFunc) []*Route {
+	routes := make([]*Route, 0, len(methods))
 	for _, m := range methods {
-		g.Add(m, path, handler, middleware...)
+		routes = append(routes, g.Add(m, path, handler, middleware...))
 	}
+	return routes
 }
 
 // Group creates a new sub-group with prefix and optional sub-group-level middleware.
@@ -93,13 +97,13 @@ func (g *Group) Group(prefix string, middleware ...MiddlewareFunc) *Group {
 }
 
 // Static implements `Echo#Static()` for sub-routes within the Group.
-func (g *Group) Static(prefix, root string) {
-	static(g, prefix, root)
+func (g *Group) Static(prefix, root string) *Route {
+	return static(g, prefix, root)
 }
 
 // File implements `Echo#File()` for sub-routes within the Group.
-func (g *Group) File(path, file string) {
-	g.echo.File(g.prefix+path, file)
+func (g *Group) File(path, file string) *Route {
+	return g.echo.File(g.prefix+path, file)
 }
 
 // Add implements `Echo#Add()` for sub-routes within the Group.


### PR DESCRIPTION
This is for anyone who wants to use an interface for `Echo` or a `Group` interchangeably.  We use this to allow for packages to register at the root or in a group at a sub path, for example:

```go
type EchoOrContext interface {
	Match(methods []string, path string, handler echo.HandlerFunc, middleware ...echo.MiddlewareFunc) []*echo.Route
}

var eoc EchoOrContext
e := echo.New()
eoc = e
eoc = e.Group("/api")
```

Alternatively, we could expose `group.add` public so that the interface could be at the `Add` level.