### PR TITLE
fix bind with map[string]interface{} for json post but with no params

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -86,7 +86,7 @@ func (b *DefaultBinder) bindPathData(ptr interface{}, c Context) error {
 	for _, key := range c.ParamNames() {
 		m[key] = []string{c.Param(key)}
 	}
-	if len(m) >= 0 {
+	if len(m) > 0 {
 		if err := b.bindData(ptr, m, "param"); err != nil {
 			return err
 		}

--- a/bind_test.go
+++ b/bind_test.go
@@ -158,6 +158,20 @@ func TestBindRouteParam(t *testing.T) {
 	}
 }
 
+func TestBindMapString(t *testing.T) {
+	e := New()
+	r := strings.NewReader(userJSONOnlyName)
+	req := httptest.NewRequest(POST, "/", r)
+	req.Header.Set(HeaderContentType, MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	u := map[string]interface{}{}
+	err := c.Bind(&u)
+	if assert.NoError(t, err) {
+		assert.Equal(t, "Jon Snow", u["name"])
+	}
+}
+
 func TestBindQueryParams(t *testing.T) {
 	e := New()
 	req := httptest.NewRequest(GET, "/?id=1&name=Jon+Snow", nil)


### PR DESCRIPTION
hello, I hope to handle a post request with no params, but the binddata failed me.

bind data will check type as struct, I hope to decode use map[string]interface{}

hope to be merged.