### PR TITLE
Wrap Content-Disposition filename with quotes

### DIFF
--- a/context.go
+++ b/context.go
@@ -525,7 +525,7 @@ func (c *context) Inline(file, name string) (err error) {
 }
 
 func (c *context) contentDisposition(file, name, dispositionType string) (err error) {
-	c.response.Header().Set(HeaderContentDisposition, fmt.Sprintf("%s; filename=%s", dispositionType, name))
+	c.response.Header().Set(HeaderContentDisposition, fmt.Sprintf("%s; filename=%q", dispositionType, name))
 	c.File(file)
 	return
 }


### PR DESCRIPTION
Filenames including space are truncated if not wrapped with quotes.
See [this](http://kb.mozillazine.org/Filenames_with_spaces_are_truncated_upon_download).