### PR TITLE
Refractor RealIP func

### DIFF
--- a/context.go
+++ b/context.go
@@ -250,11 +250,7 @@ func (c *context) Scheme() string {
 func getIPAddr(hostport string) string {
 	ra, _, err := net.SplitHostPort(hostport)
 	if nil != err {
-		if ae, ok := err.(*net.AddrError); ok {
-			if ae.Err == "missing port in address" {
-				return hostport
-			}
-		}
+		return hostport
 	}
 	return ra
 }

--- a/context.go
+++ b/context.go
@@ -531,6 +531,9 @@ func (c *context) contentDisposition(file, name, dispositionType string) (err er
 }
 
 func (c *context) NoContent(code int) error {
+	// library will try to determinate the content type if the header is not set
+	// even when the content is nil , it still costly to do that, so set it to make it more effecient
+	c.response.Header().Set(HeaderContentType, MIMETextPlainCharsetUTF8)
 	c.response.WriteHeader(code)
 	return nil
 }


### PR DESCRIPTION
`RealIP` func in `context`, there are a few issues in it
1. When it call `request.Header.Get` to get the value in header , if there are multiple values match the given key, it will return the first item. thus there is no need to call `strings.Split(ip, ", ")`
refer to [here](https://github.com/golang/go/blob/master/src/net/http/header.go#L34)
2.Even the address is from X-Forward-For, it could have port in it as well, 
3.`net.SplitHostPort` will return error if the given value doesn't have a port in it, which will cause it to return empty I don't believe that's the intend behavior

Another minor improvement with `NoContent` func, the golang standard http library will try to determinate the content type if it is not set, in the case of NoContent, I feel it is ok to set the content type to `MIMETextPlainCharsetUTF8` to avoid it. This one I think it might be ok for my cases, but not for some others
