### PR TITLE
Fixed error reassignment

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -333,6 +333,7 @@ func (e *Echo) DefaultHTTPErrorHandler(err error, c Context) {
 	}
 
 	if !c.Response().Committed {
+		var err error
 		if c.Request().Method == HEAD { // Issue #608
 			err = c.NoContent(code)
 		} else {


### PR DESCRIPTION
Hello! I have noticed that DefaultHTTPErrorHandler always logs `"message":"<nil>"` for every error:
```
{"time":"2017-09-08T09:25:46.390299469Z","level":"ERROR","prefix":"echo","file":"api.go","line":"67","message":"<nil>"}
```

This PR fix it by shadowing original err variable in conditional block.