### PR TITLE
Adding custom binder funcs for binding types from 3rd party packages

### DIFF
--- a/context.go
+++ b/context.go
@@ -525,7 +525,7 @@ func (c *context) Inline(file, name string) (err error) {
 }
 
 func (c *context) contentDisposition(file, name, dispositionType string) (err error) {
-	c.response.Header().Set(HeaderContentDisposition, fmt.Sprintf("%s; filename=%s", dispositionType, name))
+	c.response.Header().Set(HeaderContentDisposition, fmt.Sprintf("%s; filename=%q", dispositionType, name))
 	c.File(file)
 	return
 }


### PR DESCRIPTION
Hi.

This is an idea/proposal for registering custom binder funcs to be used inside the default Echo#Bind, without the need of satisfying `BindUnmarshaler` interface.

Because satisfying `BindUnmarshaler` interface can be done only for the types that the users of echo package own. But often times, you want to bind certain types from other packages, in which you can't change the implementation of the type, or ask the author of the package to do it for you, and/or extending the type can be troublesome.

An example can be `bson.ObjectId` type from bson package:
```
echo.AddBinderFunc("bson.ObjectId", func(id string) (interface{}, error) {
	if !bson.IsObjectIdHex(id) {
		return nil, errors.New("not a bson.ObjectId")
	}
	return bson.ObjectIdHex(id)
})
```
At first I defined `bindersMap` as `map[reflect.Type]BinderFunc` but I figured providing the correct `Type` can be troublesome for the users, and it's exposing to much implementation. On the other hand the interface for registering binder funcs might be more familiar as it is now.
Also we could change it to `echo.RegisterBindersMap(m BindersMap)` to make things more clean. An example of similar interface like this could be `template.FuncMap` in standard text/html template libraries. 

Please let me know how you feel about this.