### PR TITLE
Fix for issue #977 - prevent binder overwriting HTTP errors

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -47,6 +47,8 @@ func (b *DefaultBinder) Bind(i interface{}, c Context) (err error) {
 				return NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Unmarshal type error: expected=%v, got=%v, offset=%v", ute.Type, ute.Value, ute.Offset))
 			} else if se, ok := err.(*json.SyntaxError); ok {
 				return NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Syntax error: offset=%v, error=%v", se.Offset, se.Error()))
+			} else if _, ok := err.(*HTTPError); ok {
+				return err
 			} else {
 				return NewHTTPError(http.StatusBadRequest, err.Error())
 			}
@@ -57,6 +59,8 @@ func (b *DefaultBinder) Bind(i interface{}, c Context) (err error) {
 				return NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Unsupported type error: type=%v, error=%v", ute.Type, ute.Error()))
 			} else if se, ok := err.(*xml.SyntaxError); ok {
 				return NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Syntax error: line=%v, error=%v", se.Line, se.Error()))
+			} else if _, ok := err.(*HTTPError); ok {
+				return err
 			} else {
 				return NewHTTPError(http.StatusBadRequest, err.Error())
 			}
@@ -64,6 +68,9 @@ func (b *DefaultBinder) Bind(i interface{}, c Context) (err error) {
 	case strings.HasPrefix(ctype, MIMEApplicationForm), strings.HasPrefix(ctype, MIMEMultipartForm):
 		params, err := c.FormParams()
 		if err != nil {
+			if _, ok := err.(*HTTPError); ok {
+				return err
+			}
 			return NewHTTPError(http.StatusBadRequest, err.Error())
 		}
 		if err = b.bindData(i, params, "form"); err != nil {

--- a/bind_test.go
+++ b/bind_test.go
@@ -214,14 +214,20 @@ func TestBindUnsupportedMediaType(t *testing.T) {
 }
 
 func TestBindWithBodyLimitMiddleware(t *testing.T) {
-	e := New()
-	req := httptest.NewRequest(POST, "/", &limitReader{"\"JSON too large\""})
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	req.Header.Set(HeaderContentType, MIMEApplicationJSON)
-	result := ""
-	err := c.Bind(&result)
-	assert.Equal(t, http.StatusRequestEntityTooLarge, err.(*HTTPError).Code)
+	cases := map[string]string{
+		MIMEApplicationJSON: "\"JSON too large\"",
+		MIMEApplicationXML:  "<xml>too large</xml>",
+	}
+	for ctype, body := range cases {
+		e := New()
+		req := httptest.NewRequest(POST, "/", &limitReader{body})
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		req.Header.Set(HeaderContentType, ctype)
+		result := ""
+		err := c.Bind(&result)
+		assert.Equal(t, http.StatusRequestEntityTooLarge, err.(*HTTPError).Code)
+	}
 }
 
 func TestBindbindData(t *testing.T) {


### PR DESCRIPTION
This PR implements a fix for issue #977 that I reported.  It does introduce a breaking change for users who use the BodyLimit middleware along with the Echo binder for XML and JSON data, because HTTP 413 will now be returned instead of HTTP 400.  However in my opinion the correct behaviour is to return the more specific (413) error.