### PR TITLE
Allow using middleware with echo.File

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -458,10 +458,10 @@ func static(i i, prefix, root string) *Route {
 }
 
 // File registers a new route with path to serve a static file.
-func (e *Echo) File(path, file string) *Route {
+func (e *Echo) File(path, file string, m ...MiddlewareFunc) *Route {
 	return e.GET(path, func(c Context) error {
 		return c.File(file)
-	})
+	}, m...)
 }
 
 // Add registers a new route for an HTTP method and path with matching handler


### PR DESCRIPTION
My Use case:

I have an SPA application. A small `index.html` of the SPA is generated by webpack, and it references to js/css files with hashes in the names.

The simplest way to serve this file is 

```go
	e.File("/", "/path/to/index.html", middleware.NoCache())
```

I need to add cache control to ensure that the `index.html` won't be cached by the browser.


Adding middleware to the function also make it more consistent with other functions `e.GET`, `e.POST`