### PR TITLE
Basic scheme is case-insensitive

### DIFF
--- a/middleware/basic_auth.go
+++ b/middleware/basic_auth.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"encoding/base64"
 	"strconv"
+	"strings"
 
 	"github.com/labstack/echo"
 )
@@ -27,7 +28,7 @@ type (
 )
 
 const (
-	basic        = "Basic"
+	basic        = "basic"
 	defaultRealm = "Restricted"
 )
 
@@ -72,7 +73,7 @@ func BasicAuthWithConfig(config BasicAuthConfig) echo.MiddlewareFunc {
 			auth := c.Request().Header.Get(echo.HeaderAuthorization)
 			l := len(basic)
 
-			if len(auth) > l+1 && auth[:l] == basic {
+			if len(auth) > l+1 && strings.ToLower(auth[:l]) == basic {
 				b, err := base64.StdEncoding.DecodeString(auth[l+1:])
 				if err != nil {
 					return err

--- a/middleware/basic_auth_test.go
+++ b/middleware/basic_auth_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/labstack/echo"
@@ -27,6 +28,11 @@ func TestBasicAuth(t *testing.T) {
 
 	// Valid credentials
 	auth := basic + " " + base64.StdEncoding.EncodeToString([]byte("joe:secret"))
+	req.Header.Set(echo.HeaderAuthorization, auth)
+	assert.NoError(t, h(c))
+
+	// Case-insensitive header scheme
+	auth = strings.ToUpper(basic) + " " + base64.StdEncoding.EncodeToString([]byte("joe:secret"))
 	req.Header.Set(echo.HeaderAuthorization, auth)
 	assert.NoError(t, h(c))
 


### PR DESCRIPTION
According to [RFC2617](https://tools.ietf.org/html/rfc2617#section-1.2) scheme in authorization header is case-insensitive.