### PR TITLE
fix href url from armor to echo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="https://armor.labstack.com"><img height="80" src="https://cdn.labstack.com/images/echo-logo.svg"></a>
+<a href="https://echo.labstack.com"><img height="80" src="https://cdn.labstack.com/images/echo-logo.svg"></a>
 
 [![Sourcegraph](https://sourcegraph.com/github.com/labstack/echo/-/badge.svg?style=flat-square)](https://sourcegraph.com/github.com/labstack/echo?badge)
 [![GoDoc](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](http://godoc.org/github.com/labstack/echo)


### PR DESCRIPTION
image shows echo but links to armor.labstack.com.
i think this should be echo.labstack.com