### PR TITLE
Avoid redirect loop in HTTPSRedirect middleware

### DIFF
--- a/middleware/redirect_test.go
+++ b/middleware/redirect_test.go
@@ -12,47 +12,74 @@ import (
 type middlewareGenerator func() echo.MiddlewareFunc
 
 func TestRedirectHTTPSRedirect(t *testing.T) {
-	res := redirectTest(HTTPSRedirect, "labstack.com")
+	res := redirectTest(HTTPSRedirect, "labstack.com", nil)
 
 	assert.Equal(t, http.StatusMovedPermanently, res.Code)
 	assert.Equal(t, "https://labstack.com/", res.Header().Get(echo.HeaderLocation))
 }
 
+func TestHTTPSRedirectBehindTLSTerminationProxy(t *testing.T) {
+	header := http.Header{}
+	header.Set(echo.HeaderXForwardedProto, "https")
+	res := redirectTest(HTTPSRedirect, "labstack.com", header)
+
+	assert.Equal(t, http.StatusOK, res.Code)
+}
+
 func TestRedirectHTTPSWWWRedirect(t *testing.T) {
-	res := redirectTest(HTTPSWWWRedirect, "labstack.com")
+	res := redirectTest(HTTPSWWWRedirect, "labstack.com", nil)
 
 	assert.Equal(t, http.StatusMovedPermanently, res.Code)
 	assert.Equal(t, "https://www.labstack.com/", res.Header().Get(echo.HeaderLocation))
 }
 
+func TestRedirectHTTPSWWWRedirectBehindTLSTerminationProxy(t *testing.T) {
+	header := http.Header{}
+	header.Set(echo.HeaderXForwardedProto, "https")
+	res := redirectTest(HTTPSWWWRedirect, "labstack.com", header)
+
+	assert.Equal(t, http.StatusOK, res.Code)
+}
+
 func TestRedirectHTTPSNonWWWRedirect(t *testing.T) {
-	res := redirectTest(HTTPSNonWWWRedirect, "www.labstack.com")
+	res := redirectTest(HTTPSNonWWWRedirect, "www.labstack.com", nil)
 
 	assert.Equal(t, http.StatusMovedPermanently, res.Code)
 	assert.Equal(t, "https://labstack.com/", res.Header().Get(echo.HeaderLocation))
 }
 
+func TestRedirectHTTPSNonWWWRedirectBehindTLSTerminationProxy(t *testing.T) {
+	header := http.Header{}
+	header.Set(echo.HeaderXForwardedProto, "https")
+	res := redirectTest(HTTPSNonWWWRedirect, "www.labstack.com", header)
+
+	assert.Equal(t, http.StatusOK, res.Code)
+}
+
 func TestRedirectWWWRedirect(t *testing.T) {
-	res := redirectTest(WWWRedirect, "labstack.com")
+	res := redirectTest(WWWRedirect, "labstack.com", nil)
 
 	assert.Equal(t, http.StatusMovedPermanently, res.Code)
 	assert.Equal(t, "http://www.labstack.com/", res.Header().Get(echo.HeaderLocation))
 }
 
 func TestRedirectNonWWWRedirect(t *testing.T) {
-	res := redirectTest(NonWWWRedirect, "www.labstack.com")
+	res := redirectTest(NonWWWRedirect, "www.labstack.com", nil)
 
 	assert.Equal(t, http.StatusMovedPermanently, res.Code)
 	assert.Equal(t, "http://labstack.com/", res.Header().Get(echo.HeaderLocation))
 }
 
-func redirectTest(fn middlewareGenerator, host string) *httptest.ResponseRecorder {
+func redirectTest(fn middlewareGenerator, host string, header http.Header) *httptest.ResponseRecorder {
 	e := echo.New()
 	next := func(c echo.Context) (err error) {
 		return c.NoContent(http.StatusOK)
 	}
 	req := httptest.NewRequest(echo.GET, "/", nil)
 	req.Host = host
+	if header != nil {
+		req.Header = header
+	}
 	res := httptest.NewRecorder()
 	c := e.NewContext(req, res)
 


### PR DESCRIPTION
In HTTPSRedirect and similar middlewares, determining if redirection is needed using `c.IsTLS()` causes redirect loop when an application is running behind a TLS termination proxy, e.g. AWS ELB.

This is because `c.IsTLS()` always returns `false` behind a TLS termination proxy even when a client connects with TLS.

```
[Client] ---https--> [TLS termination proxy] ---http--> [Echo application using HTTPSRedirect]
```

Instead, I believe, redirection should be determined by `c.Scheme() != "https"`. This works well even behind a TLS termination proxy thanks to a `X-Forwarded-Proto` header the proxy sets.