### PR TITLE
Fix deferring close in middleware/compress test

### DIFF
--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -35,8 +35,8 @@ func TestGzip(t *testing.T) {
 	assert.Equal(t, gzipScheme, rec.Header().Get(echo.HeaderContentEncoding))
 	assert.Contains(t, rec.Header().Get(echo.HeaderContentType), echo.MIMETextPlain)
 	r, err := gzip.NewReader(rec.Body)
-	defer r.Close()
 	if assert.NoError(t, err) {
+		defer r.Close()
 		buf := new(bytes.Buffer)
 		buf.ReadFrom(r)
 		assert.Equal(t, "test", buf.String())


### PR DESCRIPTION
if there is an error, it would crash so we check error and then defer closing.