### PR TITLE
Return error of context.File in c.contentDisposition

### DIFF
--- a/context.go
+++ b/context.go
@@ -509,18 +509,17 @@ func (c *context) File(file string) (err error) {
 	return
 }
 
-func (c *context) Attachment(file, name string) (err error) {
+func (c *context) Attachment(file, name string) error {
 	return c.contentDisposition(file, name, "attachment")
 }
 
-func (c *context) Inline(file, name string) (err error) {
+func (c *context) Inline(file, name string) error {
 	return c.contentDisposition(file, name, "inline")
 }
 
-func (c *context) contentDisposition(file, name, dispositionType string) (err error) {
+func (c *context) contentDisposition(file, name, dispositionType string) error {
 	c.response.Header().Set(HeaderContentDisposition, fmt.Sprintf("%s; filename=%q", dispositionType, name))
-	c.File(file)
-	return
+	return c.File(file)
 }
 
 func (c *context) NoContent(code int) error {


### PR DESCRIPTION
Both `context.Attachment` and `context.Inline` use `context.contentDisposition` under the hood.
However, `context.contentDisposition` does not forward the error of `context.File`, leading to response 200 OK even when the file does not exist.
This commit forward the return value of `context.File` to `context.contentDisposition` to prevent that.

I did not add tests for this given that the error cases are not tested. But I can do that if you wish.