### PR TITLE
Add go.mod file for vgo compatibility.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module "github.com/labstack/echo"
+
+require (
+	"github.com/dgrijalva/jwt-go" v1.0.2
+	"github.com/labstack/gommon" v0.2.1
+	"golang.org/x/crypto" v0.0.0-20180313195238-c4a91bd4f524
+)


### PR DESCRIPTION
This will require a tag at or after this commit for vgo users.