### PR TITLE
BodyLimit middleware: (r *limitedReader) Reset does not reset read counter

### DIFF
--- a/middleware/body_limit.go
+++ b/middleware/body_limit.go
@@ -105,6 +105,7 @@ func (r *limitedReader) Close() error {
 func (r *limitedReader) Reset(reader io.ReadCloser, context echo.Context) {
 	r.reader = reader
 	r.context = context
+	r.read = 0
 }
 
 func limitedReaderPool(c BodyLimitConfig) sync.Pool {


### PR DESCRIPTION
The limitedReader in the body limit middleware does not reset its read counter when calling the Reset method.

This PR fixes this and also adds a test for this case.