### PR TITLE
the logging interface add SetHeader method

### DIFF
--- a/log.go
+++ b/log.go
@@ -15,6 +15,7 @@ type (
 		SetPrefix(p string)
 		Level() log.Lvl
 		SetLevel(v log.Lvl)
+		SetHeader(h string)
 		Print(i ...interface{})
 		Printf(format string, args ...interface{})
 		Printj(j log.JSON)


### PR DESCRIPTION
Add SetHeader method in Logger interface, and we can customize log formats like this:

```
e := echo.New()
e.Logger.SetHeader(`[${time_unix}] [${level}] {"time":"${time_unix}","file":"${short_file}","line":"${line}"}`)
```

output:
```
[2018-03-21T14:49:06+08:00] [ERROR] {"time":":1521616167,","file":"log.go","line":"309","message":"code=404, message=Not Found"}
```