### PR TITLE
make echo.Context implement context.Context

### DIFF
--- a/context.go
+++ b/context.go
@@ -2,6 +2,7 @@ package echo
 
 import (
 	"bytes"
+	stdcontext "context"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 type (
@@ -186,6 +188,12 @@ type (
 		// with `Echo#AcquireContext()` and `Echo#ReleaseContext()`.
 		// See `Echo#ServeHTTP()`
 		Reset(r *http.Request, w http.ResponseWriter)
+
+		// WithValue sets a value with the given key by replacing the Request context with
+		// a new context.
+		WithValue(key, val interface{})
+
+		stdcontext.Context
 	}
 
 	context struct {
@@ -573,4 +581,24 @@ func (c *context) Reset(r *http.Request, w http.ResponseWriter) {
 	c.pnames = nil
 	// NOTE: Don't reset because it has to have length c.echo.maxParam at all times
 	// c.pvalues = nil
+}
+
+func (c *context) Deadline() (deadline time.Time, ok bool) {
+	return c.request.Context().Deadline()
+}
+
+func (c *context) Done() <-chan struct{} {
+	return c.request.Context().Done()
+}
+
+func (c *context) Err() error {
+	return c.request.Context().Err()
+}
+
+func (c *context) Value(key interface{}) interface{} {
+	return c.request.Context().Value(key)
+}
+
+func (c *context) WithValue(key, val interface{}) {
+	c.request = c.request.WithContext(stdcontext.WithValue(c.request.Context(), key, val))
 }

--- a/context_test.go
+++ b/context_test.go
@@ -2,6 +2,7 @@ package echo
 
 import (
 	"bytes"
+	stdcontext "context"
 	"encoding/xml"
 	"errors"
 	"io"
@@ -409,4 +410,13 @@ func TestContextHandler(t *testing.T) {
 	r.Find(GET, "/handler", c)
 	c.Handler()(c)
 	assert.Equal(t, "handler", b.String())
+}
+
+func TestContextImplementsStdContext(t *testing.T) {
+	var _ stdcontext.Context = New().NewContext(nil, nil)
+	e := New()
+	c := e.NewContext(httptest.NewRequest("GET", "/", nil), nil)
+	c.WithValue("key", "red")
+	c.Value("key")
+	c.Value("notkey")
 }


### PR DESCRIPTION
@vishr @ansel1 So I know from the history that echo has had problems with having `echo.Context` implement `context.Context` which is why it has been change so many times and then completely removed. 
I want to start using echo but the fact that it doesn't integrate well with the go ecosystem, ie. using `context.Context` is stopping me. I mainly use `context.Context` for request-scoped data, so it's important to be able to do this cleanly. 

Referring to https://github.com/labstack/echo/issues/669 , the reason you would've encountered the stack overflow was because you had both  `echo.Context` implement `context.Context` and allow setting a `context.Context` on `echo.Context`. This means when you were doing 
```
c.SetStdContext(context.WithValue(c, "key", "red"))
```
you created a cyclic dependency and seen as `context.Context#Value` relies on recursion this created a stack overflow.

To prevent people from unwittingly doing this, you must choose either have `echo.Context` implement `context.Context` or allow setting a `context.Context` on `echo.Context` e.g 
```
c.SetContext(context.WithValue(c.Context(), k, v)
```
I've gone with option 1 as it provides a cleaner api, and added an extra method, `echo.Context#WithValue(key, val)` to actually make use of the context. I believe this is a pretty clean way to do it and would like to hear your thoughts. If you guys are willing to merge this I'll add some more tests and some docs.

PS. It is still possibly to run into the stackoverflow bug if you do the following after this merge
```
r:= c.Request().WithContext(context.WithValue(c, k, v))
c.SetRequest(r)
```
Ideally we would remove `echo.Context#SetRequest`, unless it is useful for something else. I don't want to remove it as part of this PR though as that means a breaking api change and I would like this merged asap if possible. We could probably just deprecate `SetRequest` and put a note with the deprecation.