### PR TITLE
 allow parameters to have arrays

### DIFF
--- a/context.go
+++ b/context.go
@@ -47,6 +47,9 @@ type (
 		// SetPath sets the registered path for the handler.
 		SetPath(p string)
 
+		// ParamArray returns path array parameter by name.
+		ParamArray(name string) []string
+
 		// Param returns path parameter by name.
 		Param(name string) string
 
@@ -193,7 +196,7 @@ type (
 		response *Response
 		path     string
 		pnames   []string
-		pvalues  []string
+		pvalues  [][]string
 		query    url.Values
 		handler  HandlerFunc
 		store    Map
@@ -275,11 +278,22 @@ func (c *context) SetPath(p string) {
 	c.path = p
 }
 
-func (c *context) Param(name string) string {
+func (c *context) ParamArray(name string) []string {
 	for i, n := range c.pnames {
 		if i < len(c.pvalues) {
 			if n == name {
 				return c.pvalues[i]
+			}
+		}
+	}
+	return nil
+}
+
+func (c *context) Param(name string) string {
+	for i, n := range c.pnames {
+		if i < len(c.pvalues) {
+			if n == name {
+				return c.pvalues[i][0]
 			}
 		}
 	}
@@ -295,11 +309,22 @@ func (c *context) SetParamNames(names ...string) {
 }
 
 func (c *context) ParamValues() []string {
-	return c.pvalues[:len(c.pnames)]
+	aux := c.pvalues[:len(c.pnames)]
+	var values []string
+
+	for _, item := range aux {
+		values = append(values, item[0])
+	}
+
+	return values
 }
 
 func (c *context) SetParamValues(values ...string) {
-	c.pvalues = values
+	c.pvalues = make([][]string, len(values))
+	for i, value := range values {
+		c.pvalues[i] = make([]string, 1)
+		c.pvalues[i][0] = value
+	}
 }
 
 func (c *context) QueryParam(name string) string {

--- a/context.go
+++ b/context.go
@@ -282,7 +282,9 @@ func (c *context) ParamArray(name string) []string {
 	for i, n := range c.pnames {
 		if i < len(c.pvalues) {
 			if n == name {
-				return c.pvalues[i]
+				if c.pvalues[i] != nil {
+					return c.pvalues[i]
+				}
 			}
 		}
 	}

--- a/context_test.go
+++ b/context_test.go
@@ -343,6 +343,20 @@ func TestContextQueryParam(t *testing.T) {
 	}, c.QueryParams())
 }
 
+func TestContextParamArray(t *testing.T) {
+	q := make(url.Values)
+	q.Set("name", "Jon")
+	q.Add("name", "Snow")
+	req := httptest.NewRequest(GET, "/?"+q.Encode(), nil)
+	e := New()
+	c := e.NewContext(req, nil)
+
+	// QueryParams
+	assert.Equal(t, url.Values{
+		"name":  []string{"Jon", "Snow"},
+	}, c.QueryParams())
+}
+
 func TestContextFormFile(t *testing.T) {
 	e := New()
 	buf := new(bytes.Buffer)

--- a/echo.go
+++ b/echo.go
@@ -297,12 +297,16 @@ func New() (e *Echo) {
 
 // NewContext returns a Context instance.
 func (e *Echo) NewContext(r *http.Request, w http.ResponseWriter) Context {
+	pvalues := make([][]string, *e.maxParam)
+	for i, _ := range pvalues {
+		pvalues[i] = make([]string, 1)
+	}
 	return &context{
 		request:  r,
 		response: NewResponse(w, e),
 		store:    make(Map),
 		echo:     e,
-		pvalues:  make([]string, *e.maxParam),
+		pvalues:  pvalues,
 		handler:  NotFoundHandler,
 	}
 }

--- a/router.go
+++ b/router.go
@@ -380,7 +380,7 @@ func (r *Router) Find(method, path string, c Context) {
 			i, l := 0, len(search)
 			for ; i < l && search[i] != '/'; i++ {
 			}
-			pvalues[n] = search[:i]
+			pvalues[n][0] = search[:i]
 			n++
 			search = search[i:]
 			continue
@@ -402,7 +402,7 @@ func (r *Router) Find(method, path string, c Context) {
 			// Not found
 			return
 		}
-		pvalues[len(cn.pnames)-1] = search
+		pvalues[len(cn.pnames)-1][0] = search
 		goto End
 	}
 
@@ -427,7 +427,7 @@ End:
 		}
 		ctx.path = cn.ppath
 		ctx.pnames = cn.pnames
-		pvalues[len(cn.pnames)-1] = ""
+		pvalues[len(cn.pnames)-1][0] = ""
 	}
 
 	return

--- a/router_test.go
+++ b/router_test.go
@@ -539,6 +539,19 @@ func TestRouterTwoParam(t *testing.T) {
 	assert.Equal(t, "1", c.Param("fid"))
 }
 
+func TestRouterParamArray(t *testing.T) {
+	e := New()
+	r := e.router
+	r.Add(GET, "/users/:uid/files/:fid", func(Context) error {
+		return nil
+	})
+	c := e.NewContext(nil, nil).(*context)
+
+	r.Find(GET, "/users/1/files/1", c)
+	assert.Equal(t, "1", c.ParamArray("uid")[0])
+	assert.Equal(t, "1", c.ParamArray("fid")[0])
+}
+
 // Issue #378
 func TestRouterParamWithSlash(t *testing.T) {
 	e := New()


### PR DESCRIPTION
this way we can get an array from the context without breaking the actual interfaces