### PR TITLE
Allow parameter routes to end with a dot (/foo/:id.json)

### DIFF
--- a/router.go
+++ b/router.go
@@ -378,7 +378,7 @@ func (r *Router) Find(method, path string, c Context) {
 
 			cn = child
 			i, l := 0, len(search)
-			for ; i < l && search[i] != '/'; i++ {
+			for ; i < l && search[i] != '/' && search[i] != '.'; i++ {
 			}
 			pvalues[n] = search[:i]
 			n++

--- a/router_test.go
+++ b/router_test.go
@@ -784,6 +784,9 @@ func TestRouterParamNames(t *testing.T) {
 	r.Add(GET, "/users/:id", func(c Context) error {
 		return nil
 	})
+	r.Add(GET, "/companies/:id.json", func(c Context) error {
+		return nil
+	})
 	r.Add(GET, "/users/:uid/files/:fid", func(c Context) error {
 		return nil
 	})
@@ -796,6 +799,11 @@ func TestRouterParamNames(t *testing.T) {
 
 	// Route > /users/:id
 	r.Find(GET, "/users/1", c)
+	assert.Equal(t, "id", c.pnames[0])
+	assert.Equal(t, "1", c.Param("id"))
+
+	// Route -> /companies/:id.json
+	r.Find(GET, "/companies/1.json", c)
 	assert.Equal(t, "id", c.pnames[0])
 	assert.Equal(t, "1", c.Param("id"))
 


### PR DESCRIPTION
Currently a route in the form of `/foo/:id.json` means echo will detect
the parameter name `id.json` instead of the expected `id`. I think this
is rather counter-intuitive, as adding an extension to paths is a fairly
common use case.

With this change both a `/` and a `.` will be treated as the end of a
parameter name.

Benchmark before this change:

	$ go test -bench .
	[..]

	goos: linux
	goarch: amd64
	pkg: github.com/labstack/echo
	BenchmarkRouterStaticRoutes-4             100000             17743 ns/op               0 B/op          0 allocs/op
	BenchmarkRouterGitHubAPI-4                 50000             33081 ns/op               1 B/op          0 allocs/op
	BenchmarkRouterParseAPI-4                 300000              5370 ns/op               0 B/op          0 allocs/op
	BenchmarkRouterGooglePlusAPI-4            200000              9183 ns/op               0 B/op          0 allocs/op
	PASS
	ok      github.com/labstack/echo        8.565s

After this change:

	goos: linux
	goarch: amd64
	pkg: github.com/labstack/echo
	BenchmarkRouterStaticRoutes-4             100000             17699 ns/op               0 B/op          0 allocs/op
	BenchmarkRouterGitHubAPI-4                 50000             32962 ns/op               1 B/op          0 allocs/op
	BenchmarkRouterParseAPI-4                 300000              5450 ns/op               0 B/op          0 allocs/op
	BenchmarkRouterGooglePlusAPI-4            200000              9205 ns/op               0 B/op          0 allocs/op
	PASS
	ok      github.com/labstack/echo        8.590s

Fixes #599