### PR TITLE
Fix parameter routes with an extension (/foo/:id.json)

### DIFF
--- a/router.go
+++ b/router.go
@@ -68,7 +68,7 @@ func (r *Router) Add(method, path string, h HandlerFunc) {
 			j := i + 1
 
 			r.insert(method, path[:i], nil, skind, "", nil)
-			for ; i < l && path[i] != '/'; i++ {
+			for ; i < l && path[i] != '/' && path[i] != '.'; i++ {
 			}
 
 			pnames = append(pnames, path[j:i])


### PR DESCRIPTION
This is a follow-up to #1101. It turns out that that patch is
incomplete, as a similar check also needs to be added in the
`Router.Add()` method.

I don't understand why the test works fine, but when using it in a real
application. For example with this example:

	func main() {
		e := echo.New()
		e.GET("/xxx/:id.json", func(c echo.Context) error {
			return c.String(200, fmt.Sprintf("%#v: names: %#v; vals: %#v",
				c.Path(), c.ParamNames(), c.ParamValues()))
		})
		log.Fatal(e.Start(":8000"))
	}

Gives a 404 on `/xxx/42.json`, and for `/xxx/42` it gives the output:

	/xxx/:id.json": names: []string{"id.json"}; vals: []string{"42"}

It makes sense to add the test there too; I just don't get why the test
cases that I added in ##1101 *does* produce the correct output :-/