### PR TITLE
Add more information in "already committed" log message

### DIFF
--- a/context.go
+++ b/context.go
@@ -566,6 +566,7 @@ func (c *context) Logger() Logger {
 func (c *context) Reset(r *http.Request, w http.ResponseWriter) {
 	c.request = r
 	c.response.reset(w)
+	c.response.request = r
 	c.query = nil
 	c.handler = NotFoundHandler
 	c.store = nil

--- a/echo.go
+++ b/echo.go
@@ -301,7 +301,7 @@ func New() (e *Echo) {
 func (e *Echo) NewContext(r *http.Request, w http.ResponseWriter) Context {
 	return &context{
 		request:  r,
-		response: NewResponse(w, e),
+		response: NewResponse(w, r, e),
 		store:    make(Map),
 		echo:     e,
 		pvalues:  make([]string, *e.maxParam),

--- a/echo.go
+++ b/echo.go
@@ -299,9 +299,14 @@ func New() (e *Echo) {
 
 // NewContext returns a Context instance.
 func (e *Echo) NewContext(r *http.Request, w http.ResponseWriter) Context {
+	response := NewResponse(w, e)
+
+	// request is injected to add more context in the warning messages
+	response.request = r
+
 	return &context{
 		request:  r,
-		response: NewResponse(w, r, e),
+		response: response,
 		store:    make(Map),
 		echo:     e,
 		pvalues:  make([]string, *e.maxParam),

--- a/response.go
+++ b/response.go
@@ -15,6 +15,7 @@ type (
 		beforeFuncs []func()
 		afterFuncs  []func()
 		Writer      http.ResponseWriter
+		request     *http.Request
 		Status      int
 		Size        int64
 		Committed   bool
@@ -22,8 +23,8 @@ type (
 )
 
 // NewResponse creates a new instance of Response.
-func NewResponse(w http.ResponseWriter, e *Echo) (r *Response) {
-	return &Response{Writer: w, echo: e}
+func NewResponse(w http.ResponseWriter, request *http.Request, e *Echo) (r *Response) {
+	return &Response{Writer: w, request: request, echo: e}
 }
 
 // Header returns the header map for the writer that will be sent by
@@ -53,7 +54,7 @@ func (r *Response) After(fn func()) {
 // used to send error codes.
 func (r *Response) WriteHeader(code int) {
 	if r.Committed {
-		r.echo.Logger.Warn("response already committed with status %d, cannot apply status %d", r.Status, code)
+		r.echo.Logger.Warn("response already committed on URI '%s' with status %d, cannot apply status %d", r.request.RequestURI, r.Status, code)
 		return
 	}
 	for _, fn := range r.beforeFuncs {

--- a/response.go
+++ b/response.go
@@ -53,7 +53,7 @@ func (r *Response) After(fn func()) {
 // used to send error codes.
 func (r *Response) WriteHeader(code int) {
 	if r.Committed {
-		r.echo.Logger.Warn("response already committed")
+		r.echo.Logger.Warn("response already committed with status %d, cannot apply status %d", r.Status, code)
 		return
 	}
 	for _, fn := range r.beforeFuncs {


### PR DESCRIPTION
It is more useful to identify the problem if the log message has more details about the context that it occurred.

Ideally we should also add the HTTP request URI to identify the endpoint that had the issue, but I couldn't think on a solution without injecting the *http.Request into the response object.