### PR TITLE
Add field name in Error message when Binding type mismatch

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -44,7 +44,7 @@ func (b *DefaultBinder) Bind(i interface{}, c Context) (err error) {
 	case strings.HasPrefix(ctype, MIMEApplicationJSON):
 		if err = json.NewDecoder(req.Body).Decode(i); err != nil {
 			if ute, ok := err.(*json.UnmarshalTypeError); ok {
-				return NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Unmarshal type error: expected=%v, got=%v, offset=%v", ute.Type, ute.Value, ute.Offset))
+				return NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Unmarshal type error: expected=%v, got=%v, field=%v, offset=%v", ute.Type, ute.Value, ute.Field, ute.Offset))
 			} else if se, ok := err.(*json.SyntaxError); ok {
 				return NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Syntax error: offset=%v, error=%v", se.Offset, se.Error()))
 			} else {

--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -156,9 +156,9 @@ func JWTWithConfig(config JWTConfig) echo.MiddlewareFunc {
 				return next(c)
 			}
 			return &echo.HTTPError{
-				Code:     ErrJWTInvalid.Code,
-				Message:  ErrJWTInvalid.Message,
-				Internal: err,
+				Code:    ErrJWTInvalid.Code,
+				Message: ErrJWTInvalid.Message,
+				Inner:   err,
 			}
 		}
 	}


### PR DESCRIPTION
#1122 Add field name
Old error message
`
Unmarshal type error: expected=int, got=string, offset=47
`
New error message
`
Unmarshal type error: expected=int, got=string, field=age, offset=47
`
Make it easy to fix for client.
320351f

#Fix typo `Internal` should be `Inner`
follow by type declaration
It does not compile.