### PR TITLE
middleware/proxy.go : Changed ProxyBalancer.Next() to Next(*http.Request)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <a href="https://echo.labstack.com"><img height="80" src="https://cdn.labstack.com/images/echo-logo.svg"></a>
 
-[![Sourcegraph](https://sourcegraph.com/github.com/labstack/echo/-/badge.svg?style=flat-square)](https://sourcegraph.com/github.com/labstack/echo?badge)
-[![GoDoc](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](http://godoc.org/github.com/labstack/echo)
-[![Go Report Card](https://goreportcard.com/badge/github.com/labstack/echo?style=flat-square)](https://goreportcard.com/report/github.com/labstack/echo)
+[![Sourcegraph](https://sourcegraph.com/github.com/wangjia184/echo/-/badge.svg?style=flat-square)](https://sourcegraph.com/github.com/wangjia184/echo?badge)
+[![GoDoc](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](http://godoc.org/github.com/wangjia184/echo)
+[![Go Report Card](https://goreportcard.com/badge/github.com/wangjia184/echo?style=flat-square)](https://goreportcard.com/report/github.com/wangjia184/echo)
 [![Build Status](http://img.shields.io/travis/labstack/echo.svg?style=flat-square)](https://travis-ci.org/labstack/echo)
 [![Codecov](https://img.shields.io/codecov/c/github/labstack/echo.svg?style=flat-square)](https://codecov.io/gh/labstack/echo) 
 [![Join the chat at https://gitter.im/labstack/echo](https://img.shields.io/badge/gitter-join%20chat-brightgreen.svg?style=flat-square)](https://gitter.im/labstack/echo)
@@ -44,8 +44,8 @@ package main
 import (
 	"net/http"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/middleware"
+	"github.com/wangjia184/echo"
+	"github.com/wangjia184/echo/middleware"
 )
 
 func main() {
@@ -92,8 +92,8 @@ func hello(c echo.Context) error {
 ## Credits
 - [Vishal Rana](https://github.com/vishr) - Author
 - [Nitin Rana](https://github.com/nr17) - Consultant
-- [Contributors](https://github.com/labstack/echo/graphs/contributors)
+- [Contributors](https://github.com/wangjia184/echo/graphs/contributors)
 
 ## License
 
-[MIT](https://github.com/labstack/echo/blob/master/LICENSE)
+[MIT](https://github.com/wangjia184/echo/blob/master/LICENSE)

--- a/echo.go
+++ b/echo.go
@@ -8,8 +8,8 @@ Example:
   import (
     "net/http"
 
-    "github.com/labstack/echo"
-    "github.com/labstack/echo/middleware"
+    "github.com/wangjia184/echo"
+    "github.com/wangjia184/echo/middleware"
   )
 
   // Handler

--- a/middleware/basic_auth.go
+++ b/middleware/basic_auth.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 )
 
 type (

--- a/middleware/basic_auth_test.go
+++ b/middleware/basic_auth_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/body_dump.go
+++ b/middleware/body_dump.go
@@ -8,7 +8,7 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 )
 
 type (

--- a/middleware/body_dump_test.go
+++ b/middleware/body_dump_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/body_limit.go
+++ b/middleware/body_limit.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 	"github.com/labstack/gommon/bytes"
 )
 

--- a/middleware/body_limit_test.go
+++ b/middleware/body_limit_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 )
 
 type (

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 )
 
 type (

--- a/middleware/cors_test.go
+++ b/middleware/cors_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/csrf.go
+++ b/middleware/csrf.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 	"github.com/labstack/gommon/random"
 )
 

--- a/middleware/csrf_test.go
+++ b/middleware/csrf_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 	"github.com/labstack/gommon/random"
 	"github.com/stretchr/testify/assert"
 )

--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/dgrijalva/jwt-go"
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 )
 
 type (

--- a/middleware/jwt_test.go
+++ b/middleware/jwt_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/dgrijalva/jwt-go"
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/key_auth.go
+++ b/middleware/key_auth.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 )
 
 type (

--- a/middleware/key_auth_test.go
+++ b/middleware/key_auth_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 	"github.com/labstack/gommon/color"
 	"github.com/valyala/fasttemplate"
 )

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/method_override.go
+++ b/middleware/method_override.go
@@ -1,6 +1,6 @@
 package middleware
 
-import "github.com/labstack/echo"
+import "github.com/wangjia184/echo"
 
 type (
 	// MethodOverrideConfig defines the config for MethodOverride middleware.

--- a/middleware/method_override_test.go
+++ b/middleware/method_override_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 )
 
 type (

--- a/middleware/proxy.go
+++ b/middleware/proxy.go
@@ -14,7 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 )
 
 // TODO: Handle TLS proxy

--- a/middleware/proxy.go
+++ b/middleware/proxy.go
@@ -238,14 +238,13 @@ func ProxyWithConfig(config ProxyConfig) echo.MiddlewareFunc {
 			}
 
 			// Proxy
-			switch {
-			case c.IsWebSocket():
+			if c.IsWebSocket() ||
+				(c.Request() != nil && strings.EqualFold(c.Request().RequestURI, "/cluster")) {
 				proxyRaw(tgt, c).ServeHTTP(res, req)
-			case req.Header.Get(echo.HeaderAccept) == "text/event-stream":
-			default:
+			} else {
 				proxyHTTP(tgt).ServeHTTP(res, req)
 			}
-
+			
 			return
 		}
 	}

--- a/middleware/proxy_test.go
+++ b/middleware/proxy_test.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/recover.go
+++ b/middleware/recover.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 )
 
 type (

--- a/middleware/recover_test.go
+++ b/middleware/recover_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/redirect.go
+++ b/middleware/redirect.go
@@ -3,7 +3,7 @@ package middleware
 import (
 	"net/http"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 )
 
 // RedirectConfig defines the config for Redirect middleware.

--- a/middleware/redirect_test.go
+++ b/middleware/redirect_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/request_id.go
+++ b/middleware/request_id.go
@@ -1,7 +1,7 @@
 package middleware
 
 import (
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 	"github.com/labstack/gommon/random"
 )
 

--- a/middleware/request_id_test.go
+++ b/middleware/request_id_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/rewrite.go
+++ b/middleware/rewrite.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 )
 
 type (

--- a/middleware/rewrite_test.go
+++ b/middleware/rewrite_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/secure.go
+++ b/middleware/secure.go
@@ -3,7 +3,7 @@ package middleware
 import (
 	"fmt"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 )
 
 type (

--- a/middleware/secure_test.go
+++ b/middleware/secure_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/slash.go
+++ b/middleware/slash.go
@@ -1,7 +1,7 @@
 package middleware
 
 import (
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 )
 
 type (

--- a/middleware/slash_test.go
+++ b/middleware/slash_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/static.go
+++ b/middleware/static.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 	"github.com/labstack/gommon/bytes"
 )
 

--- a/middleware/static_test.go
+++ b/middleware/static_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/labstack/echo"
+	"github.com/wangjia184/echo"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
I intent to implement a reverse proxy with strategy like consistent-hashing, then I found echo is not flexible enough to accomplish.

The reason is - consistent-hashing is basing on the request, (e.g IP / host / cookie / url path),  and those information is not supplied to `ProxyBalancer` interface.

This change adds `*http.Request` to the parameter of `ProxyBalancer.Next` so that we can implement custom logic for routing.

Here is an example


```
type consistentHashBalancer struct {
	targets []*middleware.ProxyTarget
	mutex   sync.RWMutex
}

func newConsistentHashBalancer() *consistentHashBalancer {
	self := &consistentHashBalancer{}
	// Setup proxy
	url1, _ := url.Parse("http://127.0.0.1:80")
	url2, _ := url.Parse("http://192.168.2.88:5000")
	url3, _ := url.Parse("http://192.168.2.89:5000")
	self.targets = []*middleware.ProxyTarget{
		{
			URL: url1,
		},
		{
			URL: url2,
		},
		{
			URL: url3,
		},
	}
	return self
}

// AddTarget adds an upstream target to the list.
func (b *consistentHashBalancer) AddTarget(_ *middleware.ProxyTarget) bool {
	return true
}

// RemoveTarget removes an upstream target from the list.
func (b *consistentHashBalancer) RemoveTarget(_ string) bool {
	return false
}

// Select a target basing on the request
func (b *consistentHashBalancer) Next(req *http.Request) *middleware.ProxyTarget {

	// TODO : according to the request host or path, select a backend
	print(req.RequestURI)

    // Here is just an example shows selecting target accordingly
	return b.targets[int(time.Now().Unix()%(int64)(len(b.targets)))]
}

```


Then we can extend it, `e.Use(middleware.Proxy(newConsistentHashBalancer()))`