### PR TITLE
Enable case insensitive query param matching

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -104,18 +104,19 @@ func (b *DefaultBinder) bindData(ptr interface{}, data map[string][]string, tag 
 			}
 		}
 
-		var inputValue []string
-		var exists bool
-
-		// Go json.Unmarshal supports case insensitive binding.  However the url
-		// params are bound case sensitive which is inconsistent.  To fix this
-		// we must check all of the map values in a case-insensitive search.
-		inputFieldName = strings.ToLower(inputFieldName)
-		for k, v := range data {
-			if strings.ToLower(k) == inputFieldName {
-				inputValue = v
-				exists = true
-				break
+		inputValue, exists := data[inputFieldName]
+		if !exists {
+			// Go json.Unmarshal supports case insensitive binding.  However the
+			// url params are bound case sensitive which is inconsistent.  To
+			// fix this we must check all of the map values in a
+			// case-insensitive search.
+			inputFieldName = strings.ToLower(inputFieldName)
+			for k, v := range data {
+				if strings.ToLower(k) == inputFieldName {
+					inputValue = v
+					exists = true
+					break
+				}
 			}
 		}
 

--- a/bind.go
+++ b/bind.go
@@ -103,7 +103,22 @@ func (b *DefaultBinder) bindData(ptr interface{}, data map[string][]string, tag 
 				continue
 			}
 		}
-		inputValue, exists := data[inputFieldName]
+
+		var inputValue []string
+		var exists bool
+
+		// Go json.Unmarshal supports case insensitive binding.  However the url
+		// params are bound case sensitive which is inconsistent.  To fix this
+		// we must check all of the map values in a case-insensitive search.
+		inputFieldName = strings.ToLower(inputFieldName)
+		for k, v := range data {
+			if strings.ToLower(k) == inputFieldName {
+				inputValue = v
+				exists = true
+				break
+			}
+		}
+
 		if !exists {
 			continue
 		}

--- a/bind_test.go
+++ b/bind_test.go
@@ -152,6 +152,19 @@ func TestBindQueryParams(t *testing.T) {
 	}
 }
 
+func TestBindQueryParamsCaseInsensitive(t *testing.T) {
+	e := New()
+	req := httptest.NewRequest(GET, "/?ID=1&NAME=Jon+Snow", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	u := new(user)
+	err := c.Bind(u)
+	if assert.NoError(t, err) {
+		assert.Equal(t, 1, u.ID)
+		assert.Equal(t, "Jon Snow", u.Name)
+	}
+}
+
 func TestBindUnmarshalParam(t *testing.T) {
 	e := New()
 	req := httptest.NewRequest(GET, "/?ts=2016-12-06T19:09:05Z&sa=one,two,three&ta=2016-12-06T19:09:05Z&ta=2016-12-06T19:09:05Z&ST=baz", nil)

--- a/bind_test.go
+++ b/bind_test.go
@@ -165,6 +165,19 @@ func TestBindQueryParamsCaseInsensitive(t *testing.T) {
 	}
 }
 
+func TestBindQueryParamsCaseSensitivePrioritized(t *testing.T) {
+	e := New()
+	req := httptest.NewRequest(GET, "/?id=1&ID=2&NAME=Jon+Snow&name=Jon+Doe", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	u := new(user)
+	err := c.Bind(u)
+	if assert.NoError(t, err) {
+		assert.Equal(t, 1, u.ID)
+		assert.Equal(t, "Jon Doe", u.Name)
+	}
+}
+
 func TestBindUnmarshalParam(t *testing.T) {
 	e := New()
 	req := httptest.NewRequest(GET, "/?ts=2016-12-06T19:09:05Z&sa=one,two,three&ta=2016-12-06T19:09:05Z&ta=2016-12-06T19:09:05Z&ST=baz", nil)


### PR DESCRIPTION
Unmarshalling body params with json.Unmarshal supports case-insensitive
matching against struct tags.  Matching query params case insensitive
provides a more sane and consistent experience for API consumers.

The original url.Values keys remain case sensitive.