### PR TITLE
Add ValidateBinder as an optional Binder implementation 

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -20,12 +20,25 @@ type (
 	// DefaultBinder is the default implementation of the Binder interface.
 	DefaultBinder struct{}
 
+	// ValidateBinder calls context.Validate after bind.
+	ValidateBinder struct {
+		binder DefaultBinder
+	}
+
 	// BindUnmarshaler is the interface used to wrap the UnmarshalParam method.
 	BindUnmarshaler interface {
 		// UnmarshalParam decodes and assigns a value from an form or query param.
 		UnmarshalParam(param string) error
 	}
 )
+
+// Bind implements the `Binder#Bind` function.
+func (b *ValidateBinder) Bind(i interface{}, c Context) (err error) {
+	if err = b.binder.Bind(i, c); err != nil {
+		return
+	}
+	return c.Validate(i)
+}
 
 // Bind implements the `Binder#Bind` function.
 func (b *DefaultBinder) Bind(i interface{}, c Context) (err error) {
@@ -72,6 +85,7 @@ func (b *DefaultBinder) Bind(i interface{}, c Context) (err error) {
 	default:
 		return ErrUnsupportedMediaType
 	}
+
 	return
 }
 


### PR DESCRIPTION
My attempt at #1105 

I added a new Binder implementation `ValidateBinder` that basically calls `context.Validate` after successful bind. You enable it like this:
```go
e := echo.New()
e.Binder = &echo.ValidateBinder{}
e.Validator = ...
```

Then later in your handler when you call `context.Bind` the `ValidateBinder` will call both bind and validate.

I added some tests based on the existing ones for bind. Also used this as a test implementation:
https://gist.github.com/Tethik/ef55db82e82fc662262245949593deea

Somewhat newbie at Golang, feedback and suggestions would be greatly appreciated :)