### PR TITLE
Allow custom listener with TLS server

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -658,11 +658,13 @@ func (e *Echo) StartServer(s *http.Server) (err error) {
 		return s.Serve(e.Listener)
 	}
 	if e.TLSListener == nil {
-		l, err := newListener(s.Addr)
-		if err != nil {
-			return err
+		if e.Listener == nil {
+			e.Listener, err = newListener(s.Addr)
+			if err != nil {
+				return err
+			}
 		}
-		e.TLSListener = tls.NewListener(l, s.TLSConfig)
+		e.TLSListener = tls.NewListener(e.Listener, s.TLSConfig)
 	}
 	if !e.HidePort {
 		e.colorer.Printf("⇨ https server started on %s\n", e.colorer.Green(e.TLSListener.Addr()))


### PR DESCRIPTION
Currently, you can create a custom listener and assign it to e.Listener, for regular tcp non-tls connection.

The equivalent for tls connection would be to create a customer listener and assign it to e.TLSListener, but the problem is you would need to create a TLSConfig manually, instead of reusing all the code in StartTLS.

This change allows creating a custom listener for tls connections with maximum code reuse.