### PR TITLE
allow whitespace in regex

### DIFF
--- a/middleware/rewrite.go
+++ b/middleware/rewrite.go
@@ -57,7 +57,7 @@ func RewriteWithConfig(config RewriteConfig) echo.MiddlewareFunc {
 
 	// Initialize
 	for k, v := range config.Rules {
-		k = strings.Replace(k, "*", "(\\S*)", -1)
+		k = strings.Replace(k, "*", "(.*)", -1)
 		config.rulesRegex[regexp.MustCompile(k)] = v
 	}
 

--- a/middleware/rewrite_test.go
+++ b/middleware/rewrite_test.go
@@ -32,6 +32,9 @@ func TestRewrite(t *testing.T) {
 	req.URL.Path = "/users/jack/orders/1"
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, "/user/jack/order/1", req.URL.Path)
+	req.URL.Path = "/api/new users"
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, "/new users", req.URL.Path)
 }
 
 // Issue #1086


### PR DESCRIPTION
We had some issues with (properly escaped) whitespaces in urls. After some digging we found that the rewriter already has the escaped version of the path (not sure if that's intended or not), causing the part of the parameter after the whitespace to disappear. Allowing whitespaces as well fixes this.