### PR TITLE
Possibility to force strict JSON (and others formats if implemented) parsing into structs

### DIFF
--- a/context.go
+++ b/context.go
@@ -102,6 +102,10 @@ type (
 		// does it based on Content-Type header.
 		Bind(i interface{}) error
 
+		// StrictBind signaling to Bind() to use strict mode whenever
+		// possible.
+		StrictBind()
+
 		// Validate validates provided `i`. It is usually called after `Context#Bind()`.
 		// Validator must be registered using `Echo#Validator`.
 		Validate(i interface{}) error
@@ -189,15 +193,16 @@ type (
 	}
 
 	context struct {
-		request  *http.Request
-		response *Response
-		path     string
-		pnames   []string
-		pvalues  []string
-		query    url.Values
-		handler  HandlerFunc
-		store    Map
-		echo     *Echo
+		request    *http.Request
+		response   *Response
+		path       string
+		pnames     []string
+		pvalues    []string
+		query      url.Values
+		handler    HandlerFunc
+		store      Map
+		echo       *Echo
+		strictBind bool
 	}
 )
 
@@ -371,8 +376,10 @@ func (c *context) Set(key string, val interface{}) {
 }
 
 func (c *context) Bind(i interface{}) error {
-	return c.echo.Binder.Bind(i, c)
+	return c.echo.Binder.Bind(i, c, c.strictBind)
 }
+
+func (c *context) StrictBind() { c.strictBind = true }
 
 func (c *context) Validate(i interface{}) error {
 	if c.echo.Validator == nil {
@@ -573,4 +580,5 @@ func (c *context) Reset(r *http.Request, w http.ResponseWriter) {
 	c.pnames = nil
 	// NOTE: Don't reset because it has to have length c.echo.maxParam at all times
 	// c.pvalues = nil
+	c.strictBind = false
 }

--- a/echo_test.go
+++ b/echo_test.go
@@ -19,13 +19,19 @@ type (
 		ID   int    `json:"id" xml:"id" form:"id" query:"id"`
 		Name string `json:"name" xml:"name" form:"name" query:"name"`
 	}
+
+	userInvalid struct {
+		IDD   int    `json:"idd" xml:"idd" form:"idd" query:"idd"`
+		UName string `json:"uname" xml:"uname" form:"uname" query:"uname"`
+	}
 )
 
 const (
-	userJSON       = `{"id":1,"name":"Jon Snow"}`
-	userXML        = `<user><id>1</id><name>Jon Snow</name></user>`
-	userForm       = `id=1&name=Jon Snow`
-	invalidContent = "invalid content"
+	userJSON        = `{"id":1,"name":"Jon Snow"}`
+	userInvalidJSON = `{"idd": 1, "uname": "Linux"}`
+	userXML         = `<user><id>1</id><name>Jon Snow</name></user>`
+	userForm        = `id=1&name=Jon Snow`
+	invalidContent  = "invalid content"
 )
 
 const userJSONPretty = `{


### PR DESCRIPTION
By default Go's behaviour to silently drop invalid data which will result in problems while building APIs that have different request structures.

This PR adds:

1. ``echo.Context.StrictBind()`` function that will set approriate flag used by Binder (default one).
2. Somewhat refactored ``DefaultBinder.Bind`` to use this flag.
3. Little tests refactoring to get everything right :).