### PR TITLE
Send response based on Accept header.

### DIFF
--- a/context.go
+++ b/context.go
@@ -119,6 +119,9 @@ type (
 		// String sends a string response with status code.
 		String(code int, s string) error
 
+		// Send sends a JSON or XML response with status code, based on request Accept header.
+		Send(code int, i interface{}) error
+
 		// JSON sends a JSON response with status code.
 		JSON(code int, i interface{}) error
 
@@ -532,6 +535,16 @@ func (c *context) contentDisposition(file, name, dispositionType string) error {
 func (c *context) NoContent(code int) error {
 	c.response.WriteHeader(code)
 	return nil
+}
+
+func (c *context) Send(code int, i interface{}) error {
+	accept := c.request.Header.Get(HeaderAccept)
+
+	if strings.Contains(strings.ToLower(accept), MIMEApplicationXML) {
+		return c.XML(code, i)
+	}
+
+	return c.JSON(code, i)
 }
 
 func (c *context) Redirect(code int, url string) error {

--- a/context_test.go
+++ b/context_test.go
@@ -60,6 +60,28 @@ func TestContext(t *testing.T) {
 	err = c.Render(http.StatusOK, "hello", "Jon Snow")
 	assert.Error(t, err)
 
+	// Send with JSON
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec).(*context)
+	c.request.Header.Set(HeaderAccept, MIMEApplicationJSON)
+	err = c.Send(http.StatusOK, user{1, "Jon Snow"})
+	if assert.NoError(t, err) {
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, MIMEApplicationJSONCharsetUTF8, rec.Header().Get(HeaderContentType))
+		assert.Equal(t, userJSON, rec.Body.String())
+	}
+
+	// Send with XML
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec).(*context)
+	c.request.Header.Set(HeaderAccept, MIMEApplicationXML)
+	err = c.Send(http.StatusOK, user{1, "Jon Snow"})
+	if assert.NoError(t, err) {
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, MIMEApplicationXMLCharsetUTF8, rec.Header().Get(HeaderContentType))
+		assert.Equal(t, xml.Header+userXML, rec.Body.String())
+	}
+
 	// JSON
 	rec = httptest.NewRecorder()
 	c = e.NewContext(req, rec).(*context)


### PR DESCRIPTION
Allow user to request the desired response format.

- Encode output as JSON or XML based on the Accept header.
- Default is JSON.

Example:
```
package main

import (
	"net/http"

	"http://github.com/labstack/echo"
)

type (
	user struct {
		ID   int    `json:"id" xml:"id" form:"id" query:"id"`
		Name string `json:"name" xml:"name" form:"name" query:"name"`
	}
)

func main() {
	e := echo.New()
	e.GET("/", handler)
	e.Logger.Fatal(e.Start(":1323"))
}

func handler(c echo.Context) error {
	return c.Send(http.StatusOK, user{1, "Jon Snow"})
}

curl -X GET http://localhost:1323 -H 'Accept: application/xml'
curl -X GET http://localhost:1323
```
Other methods of requesting a specific output format could be implemented:
- URL extension: /api/users.json
- query param: ?_format=xml

