### PR TITLE
support show all form log with customizing log config

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -191,7 +191,7 @@ func LoggerWithConfig(config LoggerConfig) echo.MiddlewareFunc {
 					return buf.WriteString(cl)
 				case "bytes_out":
 					return buf.WriteString(strconv.FormatInt(res.Size, 10))
-				case "form":
+				case "post_form":
 					form, err := c.FormParams()
 					if err == nil {
 						formData, marshalErr := json.Marshal(form)

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -12,6 +12,7 @@ import (
 	"github.com/labstack/echo"
 	"github.com/labstack/gommon/color"
 	"github.com/valyala/fasttemplate"
+	"encoding/json"
 )
 
 type (
@@ -190,6 +191,14 @@ func LoggerWithConfig(config LoggerConfig) echo.MiddlewareFunc {
 					return buf.WriteString(cl)
 				case "bytes_out":
 					return buf.WriteString(strconv.FormatInt(res.Size, 10))
+				case "form":
+					form, err := c.FormParams()
+					if err == nil {
+						formData, marshalErr := json.Marshal(form)
+						if marshalErr == nil {
+							return buf.WriteString([]byte(formData))
+						}
+					}
 				default:
 					switch {
 					case strings.HasPrefix(tag, "header:"):

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -12,7 +12,6 @@ import (
 	"github.com/labstack/echo"
 	"github.com/labstack/gommon/color"
 	"github.com/valyala/fasttemplate"
-	"encoding/json"
 )
 
 type (
@@ -194,10 +193,7 @@ func LoggerWithConfig(config LoggerConfig) echo.MiddlewareFunc {
 				case "post_form":
 					form, err := c.FormParams()
 					if err == nil {
-						formData, marshalErr := json.Marshal(form)
-						if marshalErr == nil {
-							return buf.Write([]byte(formData))
-						}
+						return buf.WriteString(form.Encode())
 					}
 				default:
 					switch {

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -196,7 +196,7 @@ func LoggerWithConfig(config LoggerConfig) echo.MiddlewareFunc {
 					if err == nil {
 						formData, marshalErr := json.Marshal(form)
 						if marshalErr == nil {
-							return buf.WriteString([]byte(formData))
+							return buf.Write([]byte(formData))
 						}
 					}
 				default:

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -93,7 +93,7 @@ func TestLoggerTemplate(t *testing.T) {
 			`"method":"${method}","uri":"${uri}","status":${status}, "latency":${latency},` +
 			`"latency_human":"${latency_human}","bytes_in":${bytes_in}, "path":"${path}", "referer":"${referer}",` +
 			`"bytes_out":${bytes_out},"ch":"${header:X-Custom-Header}", "protocol":"${protocol}"` +
-			`"us":"${query:username}", "cf":"${form:username}", "post_form":"${post_form}", "session":"${cookie:session}"}` + "\n",
+			`"us":"${query:username}", "cf":"${form:username}", "session":"${cookie:session}"}` + "\n",
 		Output: buf,
 	}))
 
@@ -156,7 +156,7 @@ func TestLoggerCustomTimestamp(t *testing.T) {
 			`"method":"${method}","uri":"${uri}","status":${status}, "latency":${latency},` +
 			`"latency_human":"${latency_human}","bytes_in":${bytes_in}, "path":"${path}", "referer":"${referer}",` +
 			`"bytes_out":${bytes_out},"ch":"${header:X-Custom-Header}",` +
-			`"us":"${query:username}", "cf":"${form:username}", "post_form":"${post_form}", "session":"${cookie:session}"}` + "\n",
+			`"us":"${query:username}", "cf":"${form:username}", "session":"${cookie:session}"}` + "\n",
 		CustomTimeFormat: customTimeFormat,
 		Output:           buf,
 	}))

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -111,8 +111,8 @@ func TestLoggerTemplate(t *testing.T) {
 	req.Header.Add("X-Request-ID", "6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 	req.Header.Add("Cookie", "_ga=GA1.2.000000000.0000000000; session=ac08034cd216a647fc2eb62f2bcf7b810")
 	req.PostForm = url.Values{
-		"username": []string{"apagano-form"},
 		"password": []string{"secret-form"},
+		"username": []string{"apagano-form"},
 	}
 	req.Form = url.Values{
 		"username": []string{"apagano-form"},
@@ -129,7 +129,7 @@ func TestLoggerTemplate(t *testing.T) {
 		"apagano-form":                         true,
 		"AAA-CUSTOM-VALUE":                     true,
 		"BBB-CUSTOM-VALUE":                     false,
-		"secret-form":                          false,
+		"secret-form":                          true,
 		"hexvalue":                             false,
 		"GET":                                  true,
 		"127.0.0.1":                            true,

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -140,7 +140,7 @@ func TestLoggerTemplate(t *testing.T) {
 		"echo-tests-agent":                     true,
 		"6ba7b810-9dad-11d1-80b4-00c04fd430c8": true,
 		"ac08034cd216a647fc2eb62f2bcf7b810":    true,
-		"{\"password\":[\"secret-form\"],\"username\":[\"apagano-form\"]}" : true,
+		"password=secret-form&username=apagano-form" : true,
 	}
 
 	for token, present := range cases {

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/labstack/echo"
 	"github.com/stretchr/testify/assert"
-	"fmt"
 )
 
 func TestLogger(t *testing.T) {

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -109,10 +109,6 @@ func TestLoggerTemplate(t *testing.T) {
 	req.Header.Add("X-Custom-Header", "AAA-CUSTOM-VALUE")
 	req.Header.Add("X-Request-ID", "6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 	req.Header.Add("Cookie", "_ga=GA1.2.000000000.0000000000; session=ac08034cd216a647fc2eb62f2bcf7b810")
-	req.PostForm = url.Values{
-		"username": []string{"apagano-form"},
-		"password": []string{"secret-form"},
-	}
 	req.Form = url.Values{
 		"username": []string{"apagano-form"},
 		"password": []string{"secret-form"},

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -93,7 +93,7 @@ func TestLoggerTemplate(t *testing.T) {
 			`"method":"${method}","uri":"${uri}","status":${status}, "latency":${latency},` +
 			`"latency_human":"${latency_human}","bytes_in":${bytes_in}, "path":"${path}", "referer":"${referer}",` +
 			`"bytes_out":${bytes_out},"ch":"${header:X-Custom-Header}", "protocol":"${protocol}"` +
-			`"us":"${query:username}", "cf":"${form:username}", "session":"${cookie:session}"}` + "\n",
+			`"us":"${query:username}", "cf":"${form:username}", "post_form":"${post_form}", "session":"${cookie:session}"}` + "\n",
 		Output: buf,
 	}))
 
@@ -109,6 +109,10 @@ func TestLoggerTemplate(t *testing.T) {
 	req.Header.Add("X-Custom-Header", "AAA-CUSTOM-VALUE")
 	req.Header.Add("X-Request-ID", "6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 	req.Header.Add("Cookie", "_ga=GA1.2.000000000.0000000000; session=ac08034cd216a647fc2eb62f2bcf7b810")
+	req.PostForm = url.Values{
+		"username": []string{"apagano-form"},
+		"password": []string{"secret-form"},
+	}
 	req.Form = url.Values{
 		"username": []string{"apagano-form"},
 		"password": []string{"secret-form"},
@@ -136,6 +140,7 @@ func TestLoggerTemplate(t *testing.T) {
 		"echo-tests-agent":                     true,
 		"6ba7b810-9dad-11d1-80b4-00c04fd430c8": true,
 		"ac08034cd216a647fc2eb62f2bcf7b810":    true,
+		"{\"username\":[\"apagano-form\"], \"password\":[\"secret-form\"]}" : true,
 	}
 
 	for token, present := range cases {
@@ -152,7 +157,7 @@ func TestLoggerCustomTimestamp(t *testing.T) {
 			`"method":"${method}","uri":"${uri}","status":${status}, "latency":${latency},` +
 			`"latency_human":"${latency_human}","bytes_in":${bytes_in}, "path":"${path}", "referer":"${referer}",` +
 			`"bytes_out":${bytes_out},"ch":"${header:X-Custom-Header}",` +
-			`"us":"${query:username}", "cf":"${form:username}", "session":"${cookie:session}"}` + "\n",
+			`"us":"${query:username}", "cf":"${form:username}", "post_form":"${post_form}", "session":"${cookie:session}"}` + "\n",
 		CustomTimeFormat: customTimeFormat,
 		Output:           buf,
 	}))

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -111,8 +111,8 @@ func TestLoggerTemplate(t *testing.T) {
 	req.Header.Add("X-Request-ID", "6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 	req.Header.Add("Cookie", "_ga=GA1.2.000000000.0000000000; session=ac08034cd216a647fc2eb62f2bcf7b810")
 	req.PostForm = url.Values{
-		"password": []string{"secret-form"},
 		"username": []string{"apagano-form"},
+		"password": []string{"secret-form"},
 	}
 	req.Form = url.Values{
 		"username": []string{"apagano-form"},
@@ -141,7 +141,7 @@ func TestLoggerTemplate(t *testing.T) {
 		"echo-tests-agent":                     true,
 		"6ba7b810-9dad-11d1-80b4-00c04fd430c8": true,
 		"ac08034cd216a647fc2eb62f2bcf7b810":    true,
-		"{\"username\":[\"apagano-form\"], \"password\":[\"secret-form\"]}" : true,
+		"{\"password\":[\"secret-form\"], \"username\":[\"apagano-form\"]}" : true,
 	}
 
 	fmt.Println(buf.String())

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -93,7 +93,7 @@ func TestLoggerTemplate(t *testing.T) {
 			`"method":"${method}","uri":"${uri}","status":${status}, "latency":${latency},` +
 			`"latency_human":"${latency_human}","bytes_in":${bytes_in}, "path":"${path}", "referer":"${referer}",` +
 			`"bytes_out":${bytes_out},"ch":"${header:X-Custom-Header}", "protocol":"${protocol}"` +
-			`"us":"${query:username}", "cf":"${form:username}", "session":"${cookie:session}"}` + "\n",
+			`"us":"${query:username}", "cf":"${form:username}", "form":"${form}", "session":"${cookie:session}"}` + "\n",
 		Output: buf,
 	}))
 
@@ -150,7 +150,7 @@ func TestLoggerCustomTimestamp(t *testing.T) {
 			`"method":"${method}","uri":"${uri}","status":${status}, "latency":${latency},` +
 			`"latency_human":"${latency_human}","bytes_in":${bytes_in}, "path":"${path}", "referer":"${referer}",` +
 			`"bytes_out":${bytes_out},"ch":"${header:X-Custom-Header}",` +
-			`"us":"${query:username}", "cf":"${form:username}", "session":"${cookie:session}"}` + "\n",
+			`"us":"${query:username}", "cf":"${form:username}", "form":"${form}", "session":"${cookie:session}"}` + "\n",
 		CustomTimeFormat: customTimeFormat,
 		Output:           buf,
 	}))

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/labstack/echo"
 	"github.com/stretchr/testify/assert"
+	"fmt"
 )
 
 func TestLogger(t *testing.T) {
@@ -143,6 +144,7 @@ func TestLoggerTemplate(t *testing.T) {
 		"{\"username\":[\"apagano-form\"], \"password\":[\"secret-form\"]}" : true,
 	}
 
+	fmt.Println(buf.String())
 	for token, present := range cases {
 		assert.True(t, strings.Contains(buf.String(), token) == present, "Case: "+token)
 	}

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -93,7 +93,7 @@ func TestLoggerTemplate(t *testing.T) {
 			`"method":"${method}","uri":"${uri}","status":${status}, "latency":${latency},` +
 			`"latency_human":"${latency_human}","bytes_in":${bytes_in}, "path":"${path}", "referer":"${referer}",` +
 			`"bytes_out":${bytes_out},"ch":"${header:X-Custom-Header}", "protocol":"${protocol}"` +
-			`"us":"${query:username}", "cf":"${form:username}", "form":"${form}", "session":"${cookie:session}"}` + "\n",
+			`"us":"${query:username}", "cf":"${form:username}", "post_form":"${post_form}", "session":"${cookie:session}"}` + "\n",
 		Output: buf,
 	}))
 
@@ -109,10 +109,16 @@ func TestLoggerTemplate(t *testing.T) {
 	req.Header.Add("X-Custom-Header", "AAA-CUSTOM-VALUE")
 	req.Header.Add("X-Request-ID", "6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 	req.Header.Add("Cookie", "_ga=GA1.2.000000000.0000000000; session=ac08034cd216a647fc2eb62f2bcf7b810")
+	req.PostForm = url.Values{
+		"username": []string{"apagano-form"},
+		"password": []string{"secret-form"},
+	}
 	req.Form = url.Values{
 		"username": []string{"apagano-form"},
 		"password": []string{"secret-form"},
 	}
+
+
 
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
@@ -150,7 +156,7 @@ func TestLoggerCustomTimestamp(t *testing.T) {
 			`"method":"${method}","uri":"${uri}","status":${status}, "latency":${latency},` +
 			`"latency_human":"${latency_human}","bytes_in":${bytes_in}, "path":"${path}", "referer":"${referer}",` +
 			`"bytes_out":${bytes_out},"ch":"${header:X-Custom-Header}",` +
-			`"us":"${query:username}", "cf":"${form:username}", "form":"${form}", "session":"${cookie:session}"}` + "\n",
+			`"us":"${query:username}", "cf":"${form:username}", "post_form":"${post_form}", "session":"${cookie:session}"}` + "\n",
 		CustomTimeFormat: customTimeFormat,
 		Output:           buf,
 	}))

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -144,7 +144,6 @@ func TestLoggerTemplate(t *testing.T) {
 		"{\"password\":[\"secret-form\"],\"username\":[\"apagano-form\"]}" : true,
 	}
 
-	fmt.Println(buf.String())
 	for token, present := range cases {
 		assert.True(t, strings.Contains(buf.String(), token) == present, "Case: "+token)
 	}

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -141,7 +141,7 @@ func TestLoggerTemplate(t *testing.T) {
 		"echo-tests-agent":                     true,
 		"6ba7b810-9dad-11d1-80b4-00c04fd430c8": true,
 		"ac08034cd216a647fc2eb62f2bcf7b810":    true,
-		"{\"password\":[\"secret-form\"], \"username\":[\"apagano-form\"]}" : true,
+		"{\"password\":[\"secret-form\"],\"username\":[\"apagano-form\"]}" : true,
 	}
 
 	fmt.Println(buf.String())


### PR DESCRIPTION
In order to output post request params, adding switch case "form" in logger file.

Different request have different params, we don't know specific params. With all form params, we can know which post request is called and it's form params.

just add "form" in Format of middleware.LoggerConfig when needed