### PR TITLE
 Redirect requests to directory with trailing slash added

### DIFF
--- a/middleware/static.go
+++ b/middleware/static.go
@@ -179,6 +179,10 @@ func StaticWithConfig(config StaticConfig) echo.MiddlewareFunc {
 			}
 
 			if fi.IsDir() {
+				if !strings.HasSuffix(p, "/") {
+					return c.Redirect(http.StatusMovedPermanently, p+"/")
+				}
+
 				index := filepath.Join(name, config.Index)
 				fi, err = os.Stat(index)
 

--- a/middleware/static.go
+++ b/middleware/static.go
@@ -179,8 +179,9 @@ func StaticWithConfig(config StaticConfig) echo.MiddlewareFunc {
 			}
 
 			if fi.IsDir() {
+				// Redirect when missing trailing slash
 				if !strings.HasSuffix(p, "/") {
-					return c.Redirect(http.StatusMovedPermanently, p+"/")
+					return c.Redirect(http.StatusFound, p+"/")
 				}
 
 				index := filepath.Join(name, config.Index)

--- a/middleware/static_test.go
+++ b/middleware/static_test.go
@@ -29,7 +29,7 @@ func TestStatic(t *testing.T) {
 	rec = httptest.NewRecorder()
 	c = e.NewContext(req, rec)
 	if assert.NoError(t, h(c)) {
-		assert.Equal(t, http.StatusMovedPermanently, rec.Code)
+		assert.Equal(t, http.StatusFound, rec.Code)
 	}
 
 	// File found

--- a/middleware/static_test.go
+++ b/middleware/static_test.go
@@ -24,6 +24,14 @@ func TestStatic(t *testing.T) {
 		assert.Contains(t, rec.Body.String(), "Echo")
 	}
 
+	// Directory-redirecting
+	req = httptest.NewRequest(echo.GET, "/folder", nil)
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec)
+	if assert.NoError(t, h(c)) {
+		assert.Equal(t, http.StatusMovedPermanently, rec.Code)
+	}
+
 	// File found
 	req = httptest.NewRequest(echo.GET, "/images/walle.png", nil)
 	rec = httptest.NewRecorder()


### PR DESCRIPTION
When the "/" suffix not added, the static resources related to html won't be served correctly, like this screenshot:
![3](https://user-images.githubusercontent.com/11156348/42820358-89b49d48-8a08-11e8-8c11-be3d3310b119.png)
When the "/" suffix added, the page loaded normally.
![2](https://user-images.githubusercontent.com/11156348/42820364-8d25deb0-8a08-11e8-9cd3-3640b531e875.png)


