### PR TITLE
logs the internal error message instead of returning it

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -326,7 +326,7 @@ func (e *Echo) DefaultHTTPErrorHandler(err error, c Context) {
 		code = he.Code
 		msg = he.Message
 		if he.Internal != nil {
-			msg = fmt.Sprintf("%v, %v", err, he.Internal)
+			err = fmt.Errorf("%v, %v", err, he.Internal)
 		}
 	} else if e.Debug {
 		msg = err.Error()


### PR DESCRIPTION
Previously, if Echo#HTTPError had Internal set to something, it would be returned as a response to the client. This change will cause Internal to get logged instead of returned to the user.