### PR TITLE
Fix inconsistency while using RewriteWithConfig middleware

### DIFF
--- a/middleware/rewrite.go
+++ b/middleware/rewrite.go
@@ -58,6 +58,7 @@ func RewriteWithConfig(config RewriteConfig) echo.MiddlewareFunc {
 	// Initialize
 	for k, v := range config.Rules {
 		k = strings.Replace(k, "*", "(.*)", -1)
+		k = k + "$"
 		config.rulesRegex[regexp.MustCompile(k)] = v
 	}
 
@@ -74,9 +75,9 @@ func RewriteWithConfig(config RewriteConfig) echo.MiddlewareFunc {
 				replacer := captureTokens(k, req.URL.Path)
 				if replacer != nil {
 					req.URL.Path = replacer.Replace(v)
+					break
 				}
 			}
-
 			return next(c)
 		}
 	}


### PR DESCRIPTION
Fix issue #1143 

For similar rules regexes it is random which one will be matched, because
rules are stored in map which don't preserve order. Adding end of line symbol to regexe pattern resolve this issue because now only one regular expression matches.