### PR TITLE
I changed getting method point after overriding method in premiddleware.

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -557,18 +557,17 @@ func (e *Echo) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	c := e.pool.Get().(*context)
 	c.Reset(r, w)
 
-	m := r.Method
 	h := NotFoundHandler
 
 	if e.premiddleware == nil {
-		e.router.Find(m, getPath(r), c)
+		e.router.Find(r.Method, getPath(r), c)
 		h = c.Handler()
 		for i := len(e.middleware) - 1; i >= 0; i-- {
 			h = e.middleware[i](h)
 		}
 	} else {
 		h = func(c Context) error {
-			e.router.Find(m, getPath(r), c)
+			e.router.Find(r.Method, getPath(r), c)
 			h := c.Handler()
 			for i := len(e.middleware) - 1; i >= 0; i-- {
 				h = e.middleware[i](h)


### PR DESCRIPTION
I used method override in echo.Pre() method.
I have error "MethodNotAllowed".

I think you got method too early in ServeHTTP.

```go
package main

import (
	"github.com/labstack/echo"
	"github.com/labstack/echo/middleware"
	"net/http"
)

func main() {
	e := echo.New()

	// method override
	e.Pre(middleware.MethodOverrideWithConfig(middleware.MethodOverrideConfig{
		Getter: middleware.MethodFromForm("_method"),
	}))

	e.Use(middleware.Logger())
	e.Use(middleware.Recover())

	// delete method
	e.DELETE("/", func(c echo.Context) error {
		return c.String(http.StatusOK, "hello world")
	})

	e.Logger.Fatal(e.Start("127.0.0.1:1323"))
}
```

I executed curl command.
```sh
curl -X POST -d "_method=DELETE" http://localhost:1323/
#> {"message":"Method Not Allowed"}

curl -X DELETE http://localhost:1323/
#> hello world
```

After I fixed.
```sh
curl -X POST -d "_method=DELETE" http://localhost:1323/
#> hello world

curl -X DELETE http://localhost:1323/
#> hello world
```

