### PR TITLE
echo: use HTTP status codes constants where applicable

### DIFF
--- a/echo_test.go
+++ b/echo_test.go
@@ -457,7 +457,7 @@ func request(method, path string, e *Echo) (int, string) {
 }
 
 func TestHTTPError(t *testing.T) {
-	err := NewHTTPError(400, map[string]interface{}{
+	err := NewHTTPError(http.StatusBadRequest, map[string]interface{}{
 		"code": 12,
 	})
 	assert.Equal(t, "code=400, message=map[code:12]", err.Error())


### PR DESCRIPTION
Use HTTP status codes constants to improve readability.