### PR TITLE
Expose stdLogger in Echo

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -62,7 +62,7 @@ import (
 type (
 	// Echo is the top-level framework instance.
 	Echo struct {
-		stdLogger        *stdLog.Logger
+		StdLogger        *stdLog.Logger
 		colorer          *color.Color
 		premiddleware    []MiddlewareFunc
 		middleware       []MiddlewareFunc
@@ -289,7 +289,7 @@ func New() (e *Echo) {
 	e.HTTPErrorHandler = e.DefaultHTTPErrorHandler
 	e.Binder = &DefaultBinder{}
 	e.Logger.SetLevel(log.ERROR)
-	e.stdLogger = stdLog.New(e.Logger.Output(), e.Logger.Prefix()+": ", 0)
+	e.StdLogger = stdLog.New(e.Logger.Output(), e.Logger.Prefix()+": ", 0)
 	e.pool.New = func() interface{} {
 		return e.NewContext(nil, nil)
 	}
@@ -634,7 +634,7 @@ func (e *Echo) startTLS(address string) error {
 func (e *Echo) StartServer(s *http.Server) (err error) {
 	// Setup
 	e.colorer.SetOutput(e.Logger.Output())
-	s.ErrorLog = e.stdLogger
+	s.ErrorLog = e.StdLogger
 	s.Handler = e
 	if e.Debug {
 		e.Logger.SetLevel(log.DEBUG)


### PR DESCRIPTION
Given that we use a our own copy of the standard logger to pass to the HTTP server, we should at least expose it so that we can manipulate it.

This PR is in response to my own issues (whereby my console is being flooded with TLS handshake errors) as well as a similarly asked question in the forums: https://forum.labstack.com/t/how-to-hide-tls-errors-from-console/131

Although we don't have fine-grain controls for the standard logging, we will at least be able to completely mute it by setting output to `ioutil.Discard`:

```
echo.StdLogger.SetOutput(ioutil.Discard)
```