### PR TITLE
Proxy: Better errors + remote custom TLS

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -260,6 +260,7 @@ var (
 	ErrBadGateway                  = NewHTTPError(http.StatusBadGateway)
 	ErrInternalServerError         = NewHTTPError(http.StatusInternalServerError)
 	ErrRequestTimeout              = NewHTTPError(http.StatusRequestTimeout)
+	ErrServiceUnavailable          = NewHTTPError(http.StatusServiceUnavailable)
 	ErrValidatorNotRegistered      = errors.New("validator not registered")
 	ErrRendererNotRegistered       = errors.New("renderer not registered")
 	ErrInvalidRedirectCode         = errors.New("invalid redirect status code")

--- a/middleware/proxy.go
+++ b/middleware/proxy.go
@@ -6,7 +6,6 @@ import (
 	"math/rand"
 	"net"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"regexp"
 	"strings"
@@ -82,23 +81,6 @@ var (
 		Skipper: DefaultSkipper,
 	}
 )
-
-func proxyHTTP(t *ProxyTarget, c echo.Context, config ProxyConfig) http.Handler {
-	proxy := httputil.NewSingleHostReverseProxy(t.URL)
-	proxy.ErrorHandler = func(resp http.ResponseWriter, req *http.Request, err error) {
-		descr := t.URL.String()
-		if len(t.Name) > 0 {
-			descr = fmt.Sprintf("%s(%s)", t.Name, t.URL.String())
-		}
-		c.Logger().Warnf("remote %s unreachable, could not forward: %v", descr, err)
-		c.Error(echo.NewHTTPError(
-			http.StatusServiceUnavailable,
-			http.StatusText(http.StatusServiceUnavailable),
-		))
-	}
-	proxy.Transport = config.Transport
-	return proxy
-}
 
 func proxyRaw(t *ProxyTarget, c echo.Context) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/middleware/proxy_1_11.go
+++ b/middleware/proxy_1_11.go
@@ -16,7 +16,7 @@ func proxyHTTP(tgt *ProxyTarget, c echo.Context, config ProxyConfig) http.Handle
 		if tgt.Name != "" {
 			descr = fmt.Sprintf("%s(%s)", tgt.Name, tgt.URL.String())
 		}
-		c.Logger().Warnf("remote %s unreachable, could not forward: %v", descr, err)
+		c.Logger().Errorf("remote %s unreachable, could not forward: %v", descr, err)
 		c.Error(echo.ErrServiceUnavailable)
 	}
 	proxy.Transport = config.Transport

--- a/middleware/proxy_1_11.go
+++ b/middleware/proxy_1_11.go
@@ -12,15 +12,12 @@ import (
 func proxyHTTP(t *ProxyTarget, c echo.Context, config ProxyConfig) http.Handler {
 	proxy := httputil.NewSingleHostReverseProxy(t.URL)
 	proxy.ErrorHandler = func(resp http.ResponseWriter, req *http.Request, err error) {
-		descr := t.URL.String()
-		if len(t.Name) > 0 {
-			descr = fmt.Sprintf("%s(%s)", t.Name, t.URL.String())
+		tgt := t.URL.String()
+		if t.Name != "" {
+			tgt = fmt.Sprintf("%s(%s)", t.Name, t.URL.String())
 		}
-		c.Logger().Warnf("remote %s unreachable, could not forward: %v", descr, err)
-		c.Error(echo.NewHTTPError(
-			http.StatusServiceUnavailable,
-			http.StatusText(http.StatusServiceUnavailable),
-		))
+		c.Logger().Warnf("remote %s unreachable, could not forward: %v", tgt, err)
+		c.Error(echo.ErrServiceUnavailable)
 	}
 	proxy.Transport = config.Transport
 	return proxy

--- a/middleware/proxy_1_11.go
+++ b/middleware/proxy_1_11.go
@@ -1,0 +1,27 @@
+// +build go1.11
+
+package middleware
+
+import (
+	"fmt"
+	"github.com/labstack/echo"
+	"net/http"
+	"net/http/httputil"
+)
+
+func proxyHTTP(t *ProxyTarget, c echo.Context, config ProxyConfig) http.Handler {
+	proxy := httputil.NewSingleHostReverseProxy(t.URL)
+	proxy.ErrorHandler = func(resp http.ResponseWriter, req *http.Request, err error) {
+		descr := t.URL.String()
+		if len(t.Name) > 0 {
+			descr = fmt.Sprintf("%s(%s)", t.Name, t.URL.String())
+		}
+		c.Logger().Warnf("remote %s unreachable, could not forward: %v", descr, err)
+		c.Error(echo.NewHTTPError(
+			http.StatusServiceUnavailable,
+			http.StatusText(http.StatusServiceUnavailable),
+		))
+	}
+	proxy.Transport = config.Transport
+	return proxy
+}

--- a/middleware/proxy_1_11.go
+++ b/middleware/proxy_1_11.go
@@ -9,14 +9,14 @@ import (
 	"net/http/httputil"
 )
 
-func proxyHTTP(t *ProxyTarget, c echo.Context, config ProxyConfig) http.Handler {
-	proxy := httputil.NewSingleHostReverseProxy(t.URL)
+func proxyHTTP(tgt *ProxyTarget, c echo.Context, config ProxyConfig) http.Handler {
+	proxy := httputil.NewSingleHostReverseProxy(tgt.URL)
 	proxy.ErrorHandler = func(resp http.ResponseWriter, req *http.Request, err error) {
-		tgt := t.URL.String()
-		if t.Name != "" {
-			tgt = fmt.Sprintf("%s(%s)", t.Name, t.URL.String())
+		descr := tgt.URL.String()
+		if tgt.Name != "" {
+			descr = fmt.Sprintf("%s(%s)", tgt.Name, tgt.URL.String())
 		}
-		c.Logger().Warnf("remote %s unreachable, could not forward: %v", tgt, err)
+		c.Logger().Warnf("remote %s unreachable, could not forward: %v", descr, err)
 		c.Error(echo.ErrServiceUnavailable)
 	}
 	proxy.Transport = config.Transport

--- a/middleware/proxy_1_11_n.go
+++ b/middleware/proxy_1_11_n.go
@@ -1,0 +1,13 @@
+// +build !go1.11
+
+package middleware
+
+import (
+	"github.com/labstack/echo"
+	"net/http"
+	"net/http/httputil"
+)
+
+func proxyHTTP(t *ProxyTarget, c echo.Context, config ProxyConfig) http.Handler {
+	return httputil.NewSingleHostReverseProxy(t.URL)
+}

--- a/middleware/proxy_1_11_test.go
+++ b/middleware/proxy_1_11_test.go
@@ -1,0 +1,52 @@
+// +build go1.11
+
+package middleware
+
+import (
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestProxy_1_11(t *testing.T) {
+	// Setup
+	url1, _ := url.Parse("http://127.0.0.1:27121")
+	url2, _ := url.Parse("http://127.0.0.1:27122")
+
+	targets := []*ProxyTarget{
+		{
+			Name: "target 1",
+			URL:  url1,
+		},
+		{
+			Name: "target 2",
+			URL:  url2,
+		},
+	}
+	rb := NewRandomBalancer(nil)
+	// must add targets:
+	for _, target := range targets {
+		assert.True(t, rb.AddTarget(target))
+	}
+
+	// must ignore duplicates:
+	for _, target := range targets {
+		assert.False(t, rb.AddTarget(target))
+	}
+
+	// Random
+	e := echo.New()
+	e.Use(Proxy(rb))
+	req := httptest.NewRequest(echo.GET, "/", nil)
+	rec := newCloseNotifyRecorder()
+
+	// Remote unreachable
+	rec = newCloseNotifyRecorder()
+	req.URL.Path = "/api/users"
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, "/api/users", req.URL.Path)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}

--- a/middleware/proxy_test.go
+++ b/middleware/proxy_test.go
@@ -125,13 +125,4 @@ func TestProxy(t *testing.T) {
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, "/user/jack/order/1", req.URL.Path)
 	assert.Equal(t, http.StatusOK, rec.Code)
-
-	// Remote unreachable
-	rec = newCloseNotifyRecorder()
-	t1.Close()
-	t2.Close()
-	req.URL.Path = "/api/users"
-	e.ServeHTTP(rec, req)
-	assert.Equal(t, "/users", req.URL.Path)
-	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
 }

--- a/middleware/proxy_test.go
+++ b/middleware/proxy_test.go
@@ -124,4 +124,14 @@ func TestProxy(t *testing.T) {
 	req.URL.Path = "/users/jack/orders/1"
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, "/user/jack/order/1", req.URL.Path)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Remote unreachable
+	rec = newCloseNotifyRecorder()
+	t1.Close()
+	t2.Close()
+	req.URL.Path = "/api/users"
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, "/users", req.URL.Path)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
 }


### PR DESCRIPTION
1. Added better logging on connection issues to remote hosts.
2. Make transport customization to enable (for example) custom remote TLS certificates.