### PR TITLE
[extend #1191] Unnecessary alloc for XML, JSON, JSONP

### DIFF
--- a/context.go
+++ b/context.go
@@ -423,9 +423,9 @@ func (c *context) jsonPBlob(code int, callback string, i interface{}) (err error
 	return
 }
 
-func (c *context) jsonBlob(code int, i interface{}, pretty bool, indent string) error {
+func (c *context) jsonBlob(code int, i interface{}, indent string) error {
 	enc := json.NewEncoder(c.response)
-	if pretty {
+	if indent != "" {
 		enc.SetIndent("", indent)
 	}
 	c.writeContentType(MIMEApplicationJSONCharsetUTF8)
@@ -439,14 +439,13 @@ func (c *context) JSON(code int, i interface{}) (err error) {
 		indent string
 	)
 	if _, pretty = c.QueryParams()["pretty"]; c.echo.Debug || pretty {
-		pretty = true
 		indent = "  "
 	}
-	return c.jsonBlob(code, i, pretty, indent)
+	return c.jsonBlob(code, i, indent)
 }
 
 func (c *context) JSONPretty(code int, i interface{}, indent string) (err error) {
-	return c.jsonBlob(code, i, true, indent)
+	return c.jsonBlob(code, i, indent)
 }
 
 func (c *context) JSONBlob(code int, b []byte) (err error) {
@@ -470,11 +469,11 @@ func (c *context) JSONPBlob(code int, callback string, b []byte) (err error) {
 	return
 }
 
-func (c *context) xmlBlob(code int, i interface{}, pretty bool, indent string) (err error) {
+func (c *context) xmlBlob(code int, i interface{}, indent string) (err error) {
 	c.writeContentType(MIMEApplicationXMLCharsetUTF8)
 	c.response.WriteHeader(code)
 	enc := xml.NewEncoder(c.response)
-	if pretty {
+	if indent != "" {
 		enc.Indent("", "  ")
 	}
 	if _, err = c.response.Write([]byte(xml.Header)); err != nil {
@@ -489,14 +488,13 @@ func (c *context) XML(code int, i interface{}) (err error) {
 		indent string
 	)
 	if _, pretty = c.QueryParams()["pretty"]; c.echo.Debug || pretty {
-		pretty = true
 		indent = "  "
 	}
-	return c.xmlBlob(code, i, pretty, indent)
+	return c.xmlBlob(code, i, indent)
 }
 
 func (c *context) XMLPretty(code int, i interface{}, indent string) (err error) {
-	return c.xmlBlob(code, i, true, indent)
+	return c.xmlBlob(code, i, indent)
 }
 
 func (c *context) XMLBlob(code int, b []byte) (err error) {

--- a/context.go
+++ b/context.go
@@ -206,6 +206,8 @@ const (
 	indexPage     = "index.html"
 )
 
+var defaultIndent = "  "
+
 func (c *context) writeContentType(value string) {
 	header := c.Response().Header()
 	if header.Get(HeaderContentType) == "" {
@@ -423,10 +425,10 @@ func (c *context) jsonPBlob(code int, callback string, i interface{}) (err error
 	return
 }
 
-func (c *context) jsonBlob(code int, i interface{}, indent string) error {
+func (c *context) jsonBlob(code int, i interface{}, indent *string) error {
 	enc := json.NewEncoder(c.response)
-	if indent != "" {
-		enc.SetIndent("", indent)
+	if indent != nil {
+		enc.SetIndent("", *indent)
 	}
 	c.writeContentType(MIMEApplicationJSONCharsetUTF8)
 	c.response.WriteHeader(code)
@@ -434,18 +436,15 @@ func (c *context) jsonBlob(code int, i interface{}, indent string) error {
 }
 
 func (c *context) JSON(code int, i interface{}) (err error) {
-	var (
-		pretty bool
-		indent string
-	)
-	if _, pretty = c.QueryParams()["pretty"]; c.echo.Debug || pretty {
-		indent = "  "
+	var indent *string
+	if _, pretty := c.QueryParams()["pretty"]; c.echo.Debug || pretty {
+		indent = &defaultIndent
 	}
 	return c.jsonBlob(code, i, indent)
 }
 
 func (c *context) JSONPretty(code int, i interface{}, indent string) (err error) {
-	return c.jsonBlob(code, i, indent)
+	return c.jsonBlob(code, i, &indent)
 }
 
 func (c *context) JSONBlob(code int, b []byte) (err error) {
@@ -469,12 +468,12 @@ func (c *context) JSONPBlob(code int, callback string, b []byte) (err error) {
 	return
 }
 
-func (c *context) xmlBlob(code int, i interface{}, indent string) (err error) {
+func (c *context) xmlBlob(code int, i interface{}, indent *string) (err error) {
 	c.writeContentType(MIMEApplicationXMLCharsetUTF8)
 	c.response.WriteHeader(code)
 	enc := xml.NewEncoder(c.response)
-	if indent != "" {
-		enc.Indent("", "  ")
+	if indent != nil {
+		enc.Indent("", *indent)
 	}
 	if _, err = c.response.Write([]byte(xml.Header)); err != nil {
 		return
@@ -483,18 +482,15 @@ func (c *context) xmlBlob(code int, i interface{}, indent string) (err error) {
 }
 
 func (c *context) XML(code int, i interface{}) (err error) {
-	var (
-		pretty bool
-		indent string
-	)
-	if _, pretty = c.QueryParams()["pretty"]; c.echo.Debug || pretty {
-		indent = "  "
+	var indent *string
+	if _, pretty := c.QueryParams()["pretty"]; c.echo.Debug || pretty {
+		indent = &defaultIndent
 	}
 	return c.xmlBlob(code, i, indent)
 }
 
 func (c *context) XMLPretty(code int, i interface{}, indent string) (err error) {
-	return c.xmlBlob(code, i, indent)
+	return c.xmlBlob(code, i, &indent)
 }
 
 func (c *context) XMLBlob(code int, b []byte) (err error) {

--- a/context.go
+++ b/context.go
@@ -404,24 +404,22 @@ func (c *context) String(code int, s string) (err error) {
 }
 
 func (c *context) jsonPBlob(code int, callback string, i interface{}) (err error) {
-	buf := new(bytes.Buffer)
-	enc := json.NewEncoder(buf)
+	enc := json.NewEncoder(c.response)
 	_, pretty := c.QueryParams()["pretty"]
 	if c.echo.Debug || pretty {
 		enc.SetIndent("", "  ")
 	}
 	c.writeContentType(MIMEApplicationJavaScriptCharsetUTF8)
 	c.response.WriteHeader(code)
-	if _, err = buf.WriteString(callback + "("); err != nil {
-
+	if _, err = c.response.Write([]byte(callback + "(")); err != nil {
+		return
 	}
 	if err = enc.Encode(i); err != nil {
 		return
 	}
-	if _, err = buf.WriteString(");"); err != nil {
+	if _, err = c.response.Write([]byte(");")); err != nil {
 		return
 	}
-	_, err = buf.WriteTo(c.response)
 	return
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -160,7 +160,7 @@ func TestContext(t *testing.T) {
 		assert.Equal(t, userJSON, rec.Body.String())
 	}
 
-	// Legacy JSONP
+	// Legacy JSONPBlob
 	rec = httptest.NewRecorder()
 	c = e.NewContext(req, rec).(*context)
 	callback = "callback"
@@ -173,7 +173,7 @@ func TestContext(t *testing.T) {
 		assert.Equal(t, callback+"("+userJSON+");", rec.Body.String())
 	}
 
-	// Legacy XML
+	// Legacy XMLBlob
 	rec = httptest.NewRecorder()
 	c = e.NewContext(req, rec).(*context)
 	data, err = xml.Marshal(user{1, "Jon Snow"})

--- a/context_test.go
+++ b/context_test.go
@@ -2,6 +2,7 @@ package echo
 
 import (
 	"bytes"
+	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"io"
@@ -145,6 +146,43 @@ func TestContext(t *testing.T) {
 		assert.Equal(t, http.StatusOK, rec.Code)
 		assert.Equal(t, MIMEApplicationXMLCharsetUTF8, rec.Header().Get(HeaderContentType))
 		assert.Equal(t, xml.Header+userXMLPretty, rec.Body.String())
+	}
+
+	// Legacy JSONBlob
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec).(*context)
+	data, err := json.Marshal(user{1, "Jon Snow"})
+	assert.NoError(t, err)
+	err = c.JSONBlob(http.StatusOK, data)
+	if assert.NoError(t, err) {
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, MIMEApplicationJSONCharsetUTF8, rec.Header().Get(HeaderContentType))
+		assert.Equal(t, userJSON, rec.Body.String())
+	}
+
+	// Legacy JSONP
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec).(*context)
+	callback = "callback"
+	data, err = json.Marshal(user{1, "Jon Snow"})
+	assert.NoError(t, err)
+	err = c.JSONPBlob(http.StatusOK, callback, data)
+	if assert.NoError(t, err) {
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, MIMEApplicationJavaScriptCharsetUTF8, rec.Header().Get(HeaderContentType))
+		assert.Equal(t, callback+"("+userJSON+");", rec.Body.String())
+	}
+
+	// Legacy XML
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec).(*context)
+	data, err = xml.Marshal(user{1, "Jon Snow"})
+	assert.NoError(t, err)
+	err = c.XMLBlob(http.StatusOK, data)
+	if assert.NoError(t, err) {
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, MIMEApplicationXMLCharsetUTF8, rec.Header().Get(HeaderContentType))
+		assert.Equal(t, xml.Header+userXML, rec.Body.String())
 	}
 
 	// String

--- a/context_test.go
+++ b/context_test.go
@@ -67,7 +67,7 @@ func TestContext(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.Equal(t, http.StatusOK, rec.Code)
 		assert.Equal(t, MIMEApplicationJSONCharsetUTF8, rec.Header().Get(HeaderContentType))
-		assert.Equal(t, userJSON, rec.Body.String())
+		assert.Equal(t, userJSON+"\n", rec.Body.String())
 	}
 
 	// JSON with "?pretty"
@@ -78,7 +78,7 @@ func TestContext(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.Equal(t, http.StatusOK, rec.Code)
 		assert.Equal(t, MIMEApplicationJSONCharsetUTF8, rec.Header().Get(HeaderContentType))
-		assert.Equal(t, userJSONPretty, rec.Body.String())
+		assert.Equal(t, userJSONPretty+"\n", rec.Body.String())
 	}
 	req = httptest.NewRequest(GET, "/", nil) // reset
 
@@ -89,7 +89,7 @@ func TestContext(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.Equal(t, http.StatusOK, rec.Code)
 		assert.Equal(t, MIMEApplicationJSONCharsetUTF8, rec.Header().Get(HeaderContentType))
-		assert.Equal(t, userJSONPretty, rec.Body.String())
+		assert.Equal(t, userJSONPretty+"\n", rec.Body.String())
 	}
 
 	// JSON (error)
@@ -106,7 +106,7 @@ func TestContext(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.Equal(t, http.StatusOK, rec.Code)
 		assert.Equal(t, MIMEApplicationJavaScriptCharsetUTF8, rec.Header().Get(HeaderContentType))
-		assert.Equal(t, callback+"("+userJSON+");", rec.Body.String())
+		assert.Equal(t, callback+"("+userJSON+"\n);", rec.Body.String())
 	}
 
 	// XML


### PR DESCRIPTION
Implement methods for
- JSON
- JSONP
- XML

fixes for tests
cc @vishr @ribice

#### Benchmark:
```go
var testUser = user{1, "Jon Snow"}

func BenchmarkAllocJSONP(b *testing.B) {
	e := New()
	req := httptest.NewRequest(POST, "/", strings.NewReader(userJSON))
	rec := httptest.NewRecorder()
	c := e.NewContext(req, rec).(*context)

	b.ResetTimer()
	b.ReportAllocs()

	for i := 0; i < b.N; i++ {
		c.JSONP(http.StatusOK, "callback", testUser)
	}
}

func BenchmarkAllocJSON(b *testing.B) {
	e := New()
	req := httptest.NewRequest(POST, "/", strings.NewReader(userJSON))
	rec := httptest.NewRecorder()
	c := e.NewContext(req, rec).(*context)

	b.ResetTimer()
	b.ReportAllocs()

	for i := 0; i < b.N; i++ {
		c.JSON(http.StatusOK, testUser)
	}
}

func BenchmarkAllocXML(b *testing.B) {
	e := New()
	req := httptest.NewRequest(POST, "/", strings.NewReader(userJSON))
	rec := httptest.NewRecorder()
	c := e.NewContext(req, rec).(*context)

	b.ResetTimer()
	b.ReportAllocs()

	for i := 0; i < b.N; i++ {
		c.XML(http.StatusOK, testUser)
	}
}
```

#### Result
```
# git checkout PR-branch
→ go test -test.v -test.run ^$ -test.bench ^BenchmarkAlloc* -count 10 > new.txt
# git checkout master-branch
→ go test -test.v -test.run ^$ -test.bench ^BenchmarkAlloc* -count 10 > old.txt

→ benchstat old.txt new.txt
name          old time/op    new time/op    delta
AllocJSONP-8    1.98µs ±17%    1.50µs ±12%  -24.11%  (p=0.000 n=10+9)
AllocJSON-8     1.82µs ±20%    1.73µs ± 6%     ~     (p=0.481 n=10+10)
AllocXML-8      4.27µs ±27%    4.27µs ±10%     ~     (p=0.549 n=10+9)

name          old alloc/op   new alloc/op   delta
AllocJSONP-8      193B ± 0%      162B ± 0%  -16.06%  (p=0.000 n=10+10)
AllocJSON-8       174B ± 0%      143B ± 0%  -17.82%  (p=0.000 n=10+10)
AllocXML-8      4.88kB ± 0%    4.77kB ± 0%   -2.30%  (p=0.019 n=6+8)

name          old allocs/op  new allocs/op  delta
AllocJSONP-8      5.00 ± 0%      4.00 ± 0%  -20.00%  (p=0.000 n=10+10)
AllocJSON-8       3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.000 n=10+10)
AllocXML-8        11.0 ± 0%      10.0 ± 0%   -9.09%  (p=0.000 n=10+10)
```