### PR TITLE
Fix node's parameter names assignment problem

### DIFF
--- a/router.go
+++ b/router.go
@@ -79,7 +79,7 @@ func (r *Router) Add(method, path string, h HandlerFunc) {
 				r.insert(method, path[:i], h, pkind, ppath, pnames)
 				return
 			}
-			r.insert(method, path[:i], nil, pkind, ppath, pnames)
+			r.insert(method, path[:i], nil, pkind, "", nil)
 		} else if path[i] == '*' {
 			r.insert(method, path[:i], nil, skind, "", nil)
 			pnames = append(pnames, "*")

--- a/router_test.go
+++ b/router_test.go
@@ -874,6 +874,42 @@ func TestRouterParamAlias(t *testing.T) {
 	testRouterAPI(t, api)
 }
 
+// Issue #1052
+func TestRouterParamOrdering(t *testing.T) {
+	api := []*Route{
+		{GET, "/:a/:b/:c/:id", ""},
+		{GET, "/:a/:id", ""},
+		{GET, "/:a/:e/:id", ""},
+	}
+	testRouterAPI(t, api)
+	api2 := []*Route{
+		{GET, "/:a/:id", ""},
+		{GET, "/:a/:e/:id", ""},
+		{GET, "/:a/:b/:c/:id", ""},
+	}
+	testRouterAPI(t, api2)
+	api3 := []*Route{
+		{GET, "/:a/:b/:c/:id", ""},
+		{GET, "/:a/:e/:id", ""},
+		{GET, "/:a/:id", ""},
+	}
+	testRouterAPI(t, api3)
+}
+
+// Issue #1139
+func TestRouterMixedParams(t *testing.T) {
+	api := []*Route{
+		{GET, "/teacher/:tid/room/suggestions", ""},
+		{GET, "/teacher/:id", ""},
+	}
+	testRouterAPI(t, api)
+	api2 := []*Route{
+		{GET, "/teacher/:id", ""},
+		{GET, "/teacher/:tid/room/suggestions", ""},
+	}
+	testRouterAPI(t, api2)
+}
+
 func benchmarkRouterRoutes(b *testing.B, routes []*Route) {
 	e := New()
 	r := e.router
@@ -914,7 +950,7 @@ func BenchmarkRouterGooglePlusAPI(b *testing.B) {
 
 func (n *node) printTree(pfx string, tail bool) {
 	p := prefix(tail, pfx, "└── ", "├── ")
-	fmt.Printf("%s%s, %p: type=%d, parent=%p, handler=%v\n", p, n.prefix, n, n.kind, n.parent, n.methodHandler)
+	fmt.Printf("%s%s, %p: type=%d, parent=%p, handler=%v, pnames=%v\n", p, n.prefix, n, n.kind, n.parent, n.methodHandler, n.pnames)
 
 	children := n.children
 	l := len(children)


### PR DESCRIPTION
This commit fixed the issues(#1052, #1139) on which the parameters cannot be obtained on some paths defined as having the same prefix but with different parameter names.
This issue is caused because the `node.pnames` of shorter paths is overwritten by the node of longer paths inserted.
With this change, I managed to apply the changes to the `pnames` of a specific node only when the appending node corresponds to the end of URL's path.

I added the following test cases (#1052 and #1139). We have confirmed that the behavior is as expected.
However, this commit does not fix the case (#1139) found below because it needs to store `ppath` and `pnames` for each HTTP method like a `methodHandler`.

```go
func main() {
    e := echo.New()
    e.GET("/order/:shopid", func(c echo.Context) error {
        return c.NoContent(http.StatusOK)
    })
    e.DELETE("/order/:ref", func(c echo.Context) error {
        log.Printf("params %v", c.ParamNames())
        foo := c.Param("ref")
        return c.String(http.StatusOK, foo)
    })
    e.Logger.Fatal(e.Start("127.0.0.1:8080"))
}
```
