### PR TITLE
extend proxy middleware. closes #1202

### DIFF
--- a/middleware/proxy.go
+++ b/middleware/proxy.go
@@ -39,7 +39,7 @@ type (
 		Rewrite map[string]string
 
 		// Context key to store selected ProxyTarget into context.
-		// Optional. Default value "proxyTarget".
+		// Optional. Default value "target".
 		ContextKey string
 
 		rewriteRegex map[*regexp.Regexp]string
@@ -81,7 +81,7 @@ var (
 	// DefaultProxyConfig is the default Proxy middleware config.
 	DefaultProxyConfig = ProxyConfig{
 		Skipper:    DefaultSkipper,
-		ContextKey: "proxyTarget",
+		ContextKey: "target",
 	}
 )
 

--- a/middleware/proxy.go
+++ b/middleware/proxy.go
@@ -49,7 +49,7 @@ type (
 	ProxyTarget struct {
 		Name string
 		URL  *url.URL
-		Meta map[string]interface{}
+		Meta echo.Map
 	}
 
 	// ProxyBalancer defines an interface to implement a load balancing technique.

--- a/middleware/proxy_test.go
+++ b/middleware/proxy_test.go
@@ -129,7 +129,7 @@ func TestProxy(t *testing.T) {
 	contextObserver := func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) (err error) {
 			next(c)
-			assert.Contains(t, targets, c.Get("proxyTarget"), "proxyTarget is not set in context")
+			assert.Contains(t, targets, c.Get("target"), "target is not set in context")
 			return nil
 		}
 	}


### PR DESCRIPTION
Extend proxy middleware to support more complicated workflows to resolve #1202.

Implements:
- Forward context to ProxyBalancer on Next() call
- Expand ProxyTarget to include meta-data
- Inject selected ProxyTarget into returned Context