### PR TITLE
Add back exported HTTP method constants

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -128,6 +128,21 @@ type (
 	}
 )
 
+// HTTP methods
+// NOTE: Deprecated, please use the stdlib constants directly instead.
+const (
+	CONNECT = http.MethodConnect
+	DELETE  = http.MethodDelete
+	GET     = http.MethodGet
+	HEAD    = http.MethodHead
+	OPTIONS = http.MethodOptions
+	PATCH   = http.MethodPatch
+	POST    = http.MethodPost
+	//PROPFIND = "PROPFIND"
+	PUT   = http.MethodPut
+	TRACE = http.MethodTrace
+)
+
 // MIME types
 const (
 	MIMEApplicationJSON                  = "application/json"


### PR DESCRIPTION
As per the comment in here: https://github.com/labstack/echo/pull/1205#discussion_r225053309 - the constants are used in the documentation, so adding them back.