### PR TITLE
Create IpFilter middleware

### DIFF
--- a/middleware/ip_filter.go
+++ b/middleware/ip_filter.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"net"
+	"net/http"
 	"strings"
 
 	"github.com/labstack/echo"
@@ -121,7 +122,10 @@ func IpFilterWithConfig(config IpFilterConfig) echo.MiddlewareFunc {
 				return next(c)
 			}
 
-			ip := c.Request().RemoteAddr
+			ip, _, err := net.SplitHostPort(c.Request().RemoteAddr)
+			if err != nil {
+				return echo.NewHTTPError(http.StatusBadRequest, err)
+			}
 
 			for _, filter := range config.IpFilters {
 				if filter(ip) {

--- a/middleware/ip_filter.go
+++ b/middleware/ip_filter.go
@@ -1,0 +1,150 @@
+package middleware
+
+import (
+	"net"
+	"strings"
+
+	"github.com/labstack/echo"
+)
+
+type (
+	// IpFilterConfig defines the config for IpFilter middleware.
+	IpFilterConfig struct {
+		// Skipper defines a function to skip middleware.
+		Skipper Skipper
+
+		// IpFilters is FilterFunc list that filter with custom logic.
+		IpFilters []IpFilterFunc
+
+		// WhiteList is an allowed ip list.
+		WhiteList []string
+
+		// BlackList is a disallowed ip list.
+		BlackList []string
+	}
+
+	// FilterFunc defines a function to filter ip with custom logic.
+	// If FilterFunc returns true, that ip will be blocked.
+	IpFilterFunc func(string) bool
+)
+
+var (
+	// DefaultIpFilterConfig is the default IpFilter middleware config.
+	DefaultIpFilterConfig = IpFilterConfig{
+		Skipper: DefaultSkipper,
+		WhiteList: []string{
+			"0.0.0.0/32",
+		},
+	}
+)
+
+// IpFilter returns a IpFilter middleware.
+//
+// IpFilter middleware filters requests by ip matching.
+// IpFilter filters ip with `IpFilters []IpFilterFunc` field first.
+// And then, It checks `WhiteList []string` and `BlackList []string` to filtering requests.
+func IpFilter() echo.MiddlewareFunc {
+	return IpFilterWithConfig(DefaultIpFilterConfig)
+}
+
+// IpFilterWithConfig returns a IpFilter middleware with config.
+// See: `IpFilter()`.
+func IpFilterWithConfig(config IpFilterConfig) echo.MiddlewareFunc {
+	// Defaults
+	if config.Skipper == nil {
+		config.Skipper = DefaultIpFilterConfig.Skipper
+	}
+
+	whiteList := make([]*net.IPNet, 0, len(config.WhiteList))
+	for _, allowed := range config.WhiteList {
+		if strings.ContainsRune(allowed, '/') {
+			_, ipNet, err := net.ParseCIDR(allowed)
+			if err != nil {
+				panic(err)
+			}
+
+			whiteList = append(whiteList, ipNet)
+		} else {
+			ipNet := &net.IPNet{
+				IP: net.ParseIP(allowed),
+			}
+			if ipNet.IP == nil {
+				panic((&net.ParseError{Type: "IP address", Text: allowed}).Error())
+			}
+
+			switch len(ipNet.IP) {
+			case net.IPv4len:
+				ipNet.Mask = net.CIDRMask(32, 32)
+			case net.IPv6len:
+				ipNet.Mask = net.CIDRMask(128, 128)
+			default:
+				panic((&net.ParseError{Type: "IP address", Text: allowed}).Error())
+			}
+
+			whiteList = append(whiteList, ipNet)
+		}
+	}
+
+	blackList := make([]*net.IPNet, 0, len(config.BlackList))
+	for _, disallowed := range config.BlackList {
+		if strings.ContainsRune(disallowed, '/') {
+			_, ipNet, err := net.ParseCIDR(disallowed)
+			if err != nil {
+				panic(err)
+			}
+
+			whiteList = append(whiteList, ipNet)
+		} else {
+			ipNet := &net.IPNet{
+				IP: net.ParseIP(disallowed),
+			}
+			if ipNet.IP == nil {
+				panic((&net.ParseError{Type: "IP address", Text: disallowed}).Error())
+			}
+
+			switch len(ipNet.IP) {
+			case net.IPv4len:
+				ipNet.Mask = net.CIDRMask(32, 32)
+			case net.IPv6len:
+				ipNet.Mask = net.CIDRMask(128, 128)
+			default:
+				panic((&net.ParseError{Type: "IP address", Text: disallowed}).Error())
+			}
+
+			whiteList = append(whiteList, ipNet)
+		}
+	}
+
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if config.Skipper(c) {
+				return next(c)
+			}
+
+			ip := c.RealIP()
+
+			for _, filter := range config.IpFilters {
+				if filter(ip) {
+					return echo.ErrForbidden
+				}
+			}
+
+			parsedIp := net.ParseIP(ip)
+
+			for _, allowed := range whiteList {
+				if allowed.Contains(parsedIp) {
+
+					for _, disallowed := range blackList {
+						if disallowed.Contains(parsedIp) {
+							return echo.ErrForbidden
+						}
+					}
+
+					return next(c)
+				}
+			}
+
+			return echo.ErrForbidden
+		}
+	}
+}

--- a/middleware/ip_filter.go
+++ b/middleware/ip_filter.go
@@ -93,7 +93,7 @@ func IpFilterWithConfig(config IpFilterConfig) echo.MiddlewareFunc {
 				panic(err)
 			}
 
-			whiteList = append(whiteList, ipNet)
+			blackList = append(blackList, ipNet)
 		} else {
 			ipNet := &net.IPNet{
 				IP: net.ParseIP(disallowed),
@@ -111,7 +111,7 @@ func IpFilterWithConfig(config IpFilterConfig) echo.MiddlewareFunc {
 				panic((&net.ParseError{Type: "IP address", Text: disallowed}).Error())
 			}
 
-			whiteList = append(whiteList, ipNet)
+			blackList = append(blackList, ipNet)
 		}
 	}
 
@@ -121,7 +121,7 @@ func IpFilterWithConfig(config IpFilterConfig) echo.MiddlewareFunc {
 				return next(c)
 			}
 
-			ip := c.RealIP()
+			ip := c.Request().RemoteAddr
 
 			for _, filter := range config.IpFilters {
 				if filter(ip) {

--- a/middleware/ip_filter_test.go
+++ b/middleware/ip_filter_test.go
@@ -1,11 +1,12 @@
 package middleware
 
 import (
-	"github.com/labstack/echo"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIpFilterWithConfig(t *testing.T) {
@@ -27,7 +28,7 @@ func TestIpFilterWithConfig(t *testing.T) {
 					},
 				},
 			},
-			Ip: "123.123.123.123",
+			Ip: "123.123.123.123:1234",
 			// Blocked by IpFilters.
 			Expect: echo.ErrForbidden,
 		},
@@ -45,7 +46,7 @@ func TestIpFilterWithConfig(t *testing.T) {
 					"123.123.123.123",
 				},
 			},
-			Ip: "223.123.123.123",
+			Ip: "223.123.123.123:1234",
 			// Blocked by WhiteList.
 			Expect: echo.ErrForbidden,
 		},
@@ -63,7 +64,7 @@ func TestIpFilterWithConfig(t *testing.T) {
 					"223.123.123.123",
 				},
 			},
-			Ip: "223.123.123.123",
+			Ip: "223.123.123.123:1234",
 			// Not blocked.
 			Expect: nil,
 		},
@@ -81,7 +82,7 @@ func TestIpFilterWithConfig(t *testing.T) {
 					"223.123.123.0/24",
 				},
 			},
-			Ip: "223.123.123.230",
+			Ip: "223.123.123.230:1234",
 			// Not blocked.
 			Expect: nil,
 		},
@@ -102,7 +103,7 @@ func TestIpFilterWithConfig(t *testing.T) {
 					"223.123.123.230",
 				},
 			},
-			Ip: "223.123.123.230",
+			Ip: "223.123.123.230:1234",
 			// Blocked by BlackList.
 			Expect: echo.ErrForbidden,
 		},
@@ -110,7 +111,7 @@ func TestIpFilterWithConfig(t *testing.T) {
 			// It will be DefaultIpFilterConfig.
 			Config: IpFilterConfig{},
 			// Blocked by WhiteList.
-			Ip: "123.123.123.123",
+			Ip: "123.123.123.123:1234",
 			Expect: echo.ErrForbidden,
 		},
 	}

--- a/middleware/ip_filter_test.go
+++ b/middleware/ip_filter_test.go
@@ -1,0 +1,153 @@
+package middleware
+
+import (
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIpFilterWithConfig(t *testing.T) {
+	a := assert.New(t)
+
+	testTable := []struct{
+		Config IpFilterConfig
+		Ip string
+		Expect error
+	}{
+		{
+			Config: IpFilterConfig{
+				IpFilters: []IpFilterFunc{
+					func (ip string) bool {
+						if ip[0] == '1' {
+							return true
+						}
+						return false
+					},
+				},
+			},
+			Ip: "123.123.123.123",
+			// Blocked by IpFilters.
+			Expect: echo.ErrForbidden,
+		},
+		{
+			Config: IpFilterConfig{
+				IpFilters: []IpFilterFunc{
+					func (ip string) bool {
+						if ip[0] == '1' {
+							return true
+						}
+						return false
+					},
+				},
+				WhiteList: []string{
+					"123.123.123.123",
+				},
+			},
+			Ip: "223.123.123.123",
+			// Blocked by WhiteList.
+			Expect: echo.ErrForbidden,
+		},
+		{
+			Config: IpFilterConfig{
+				IpFilters: []IpFilterFunc{
+					func (ip string) bool {
+						if ip[0] == '1' {
+							return true
+						}
+						return false
+					},
+				},
+				WhiteList: []string{
+					"223.123.123.123",
+				},
+			},
+			Ip: "223.123.123.123",
+			// Not blocked.
+			Expect: nil,
+		},
+		{
+			Config: IpFilterConfig{
+				IpFilters: []IpFilterFunc{
+					func (ip string) bool {
+						if ip[0] == '1' {
+							return true
+						}
+						return false
+					},
+				},
+				WhiteList: []string{
+					"223.123.123.0/24",
+				},
+			},
+			Ip: "223.123.123.230",
+			// Not blocked.
+			Expect: nil,
+		},
+		{
+			Config: IpFilterConfig{
+				IpFilters: []IpFilterFunc{
+					func (ip string) bool {
+						if ip[0] == '1' {
+							return true
+						}
+						return false
+					},
+				},
+				WhiteList: []string{
+					"223.123.123.0/24",
+				},
+				BlackList: []string{
+					"223.123.123.230",
+				},
+			},
+			Ip: "223.123.123.230",
+			// Blocked by BlackList.
+			Expect: echo.ErrForbidden,
+		},
+		{
+			// It will be DefaultIpFilterConfig.
+			Config: IpFilterConfig{},
+			// Blocked by WhiteList.
+			Ip: "123.123.123.123",
+			Expect: echo.ErrForbidden,
+		},
+	}
+
+	e := echo.New()
+
+	for idx, testCase := range testTable {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.RemoteAddr = testCase.Ip
+		res := httptest.NewRecorder()
+		c := e.NewContext(req, res)
+		h := IpFilterWithConfig(testCase.Config)(func(c echo.Context) error {
+			return c.NoContent(http.StatusOK)
+		})
+
+		switch err := h(c); err.(type) {
+		case nil:
+			a.EqualValues(testCase.Expect, err, "testTable[%d]", idx)
+		case *echo.HTTPError:
+			a.EqualValues(testCase.Expect, err, "testTable[%d]", idx)
+		}
+	}
+}
+
+func TestIpFilter(t *testing.T) {
+	a := assert.New(t)
+
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "123.123.123.123"
+	res := httptest.NewRecorder()
+	c := e.NewContext(req, res)
+	h := IpFilter()(func(c echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	})
+
+	// Blocked by WhiteList.
+	a.Error(h(c))
+}


### PR DESCRIPTION
I saw the ip filter in Echo's [kanban](https://github.com/labstack/echo/projects/2#card-7179901). I'm not sure if that means ip filter middleware. 

```go
// IpFilter returns a IpFilter middleware.
//
// IpFilter middleware filters requests by ip matching.
// IpFilter filters ip with `IpFilters []IpFilterFunc` field first.
// And then, It checks `WhiteList []string` and `BlackList []string` to filtering requests.
func IpFilter() echo.MiddlewareFunc {
	return IpFilterWithConfig(DefaultIpFilterConfig)
}
```

This code is exactly not perfect.
But if ip filter middleware is what you want, I hope that start developing that middleware.
