### PR TITLE
Middleware JWT customisation

### DIFF
--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -59,7 +59,7 @@ type (
 	}
 
 	// JWTSuccessHandler defines a function which is executed for a valid token.
-	JWTSuccessHandler func(echo.Context)
+	JWTSuccessHandler func(echo.Context) error
 
 	// JWTErrorHandler defines a function which is executed for an invalid token.
 	JWTErrorHandler func(error) error
@@ -176,7 +176,9 @@ func JWTWithConfig(config JWTConfig) echo.MiddlewareFunc {
 				// Store user information from token into context.
 				c.Set(config.ContextKey, token)
 				if config.SuccessHandler != nil {
-					config.SuccessHandler(c)
+					if err = config.SuccessHandler(c); err != nil {
+						return config.ErrorHandler(err)
+					}
 				}
 				return next(c)
 			}

--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -22,6 +22,10 @@ type (
 		// SuccessHandler defines a function which is executed for a valid token.
 		SuccessHandler JWTSuccessHandler
 
+		// SuccessHandler defines a function which is executed for a valid token.
+		// It allows to exit from middleware with an error.
+		SuccessHandlerError JWTSuccessHandlerWithError
+
 		// ErrorHandler defines a function which is executed for an invalid token.
 		// It may be used to define a custom JWT error.
 		ErrorHandler JWTErrorHandler
@@ -59,7 +63,9 @@ type (
 	}
 
 	// JWTSuccessHandler defines a function which is executed for a valid token.
-	JWTSuccessHandler func(echo.Context) error
+	JWTSuccessHandler func(echo.Context)
+
+	JWTSuccessHandlerWithError func(echo.Context) error
 
 	// JWTErrorHandler defines a function which is executed for an invalid token.
 	JWTErrorHandler func(error) error
@@ -176,7 +182,10 @@ func JWTWithConfig(config JWTConfig) echo.MiddlewareFunc {
 				// Store user information from token into context.
 				c.Set(config.ContextKey, token)
 				if config.SuccessHandler != nil {
-					if err = config.SuccessHandler(c); err != nil {
+					config.SuccessHandler(c)
+				}
+				if config.SuccessHandlerError != nil {
+					if err = config.SuccessHandlerError(c); err != nil {
 						return config.ErrorHandler(err)
 					}
 				}


### PR DESCRIPTION
The JWT middleware using `JWTWithConfig` is quite good, because it is possible to custom almost everything. But there is an important missing feature in this customisation.
If you want to use `SuccessHandler` to make other checks besides **Validation Signature** is not possible to retrieve an error and stop the middleware.
This backward-compatible change adds the method `SuccessHandlerError` which gives the possibility to retrieve an error and stop the middleware triggering the `ErrorHandler`.