### PR TITLE
Add IntParam context function.

### DIFF
--- a/context.go
+++ b/context.go
@@ -51,9 +51,9 @@ type (
 		// Param returns path parameter by name.
 		Param(name string) string
 
-		// IntParam returns integer value of path parameter by name.
-		// 0 is returned if parameter value cannot be converted to an int.
-		IntParam(name string) int
+		// IntParam returns integer value of path parameter by name
+		// and a boolean to indicate if a valid integer was found.
+		IntParam(name string) (int, bool)
 
 		// ParamNames returns path parameter names.
 		ParamNames() []string
@@ -290,9 +290,9 @@ func (c *context) Param(name string) string {
 	return ""
 }
 
-func (c *context) IntParam(name string) int {
-	val, _ := strconv.Atoi(c.Param(name))
-	return val
+func (c *context) IntParam(name string) (int, bool) {
+	val, err := strconv.Atoi(c.Param(name))
+	return val, err == nil
 }
 
 func (c *context) ParamNames() []string {

--- a/context.go
+++ b/context.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -49,6 +50,10 @@ type (
 
 		// Param returns path parameter by name.
 		Param(name string) string
+
+		// IntParam returns integer value of path parameter by name.
+		// 0 is returned if parameter value cannot be converted to an int.
+		IntParam(name string) int
 
 		// ParamNames returns path parameter names.
 		ParamNames() []string
@@ -283,6 +288,11 @@ func (c *context) Param(name string) string {
 		}
 	}
 	return ""
+}
+
+func (c *context) IntParam(name string) int {
+	val, _ := strconv.Atoi(c.Param(name))
+	return val
 }
 
 func (c *context) ParamNames() []string {

--- a/context_test.go
+++ b/context_test.go
@@ -307,6 +307,21 @@ func TestContextPathParam(t *testing.T) {
 	assert.Equal(t, "501", c.Param("fid"))
 }
 
+func TestContextPathIntParam(t *testing.T) {
+	e := New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	c := e.NewContext(req, nil)
+
+	c.SetParamNames("id", "dir", "notint")
+	c.SetParamValues("1", "-1", "1a")
+
+	// IntParam
+	assert.Equal(t, 1, c.IntParam("id"))
+	assert.Equal(t, -1, c.IntParam("dir"))
+	assert.Equal(t, 0, c.IntParam("notint"))
+	assert.Equal(t, 0, c.IntParam("notset"))
+}
+
 func TestContextFormValue(t *testing.T) {
 	f := make(url.Values)
 	f.Set("name", "Jon Snow")

--- a/context_test.go
+++ b/context_test.go
@@ -315,11 +315,38 @@ func TestContextPathIntParam(t *testing.T) {
 	c.SetParamNames("id", "dir", "notint")
 	c.SetParamValues("1", "-1", "1a")
 
-	// IntParam
-	assert.Equal(t, 1, c.IntParam("id"))
-	assert.Equal(t, -1, c.IntParam("dir"))
-	assert.Equal(t, 0, c.IntParam("notint"))
-	assert.Equal(t, 0, c.IntParam("notset"))
+	tests := []struct {
+		Param         string
+		ExpectedValue int
+		ExpectedOK    bool
+	}{
+		{
+			Param:         "id",
+			ExpectedValue: 1,
+			ExpectedOK:    true,
+		},
+		{
+			Param:         "dir",
+			ExpectedValue: -1,
+			ExpectedOK:    true,
+		},
+		{
+			Param:         "notint",
+			ExpectedValue: 0,
+			ExpectedOK:    false,
+		},
+		{
+			Param:         "notset",
+			ExpectedValue: 0,
+			ExpectedOK:    false,
+		},
+	}
+
+	for _, test := range tests {
+		val, ok := c.IntParam(test.Param)
+		assert.Equal(t, test.ExpectedValue, val)
+		assert.Equal(t, test.ExpectedOK, ok)
+	}
 }
 
 func TestContextFormValue(t *testing.T) {


### PR DESCRIPTION
Returns the integer value of parameter by name.

**Later edit:**

Returns the integer value and the `ok` bool value to indicate if the conversion was successful or not.

```
func handler(c echo.Context) error {
	id, ok := c.IntParam("id")
	println(id, ok)
	return nil
}
```


**First version**

The function's name is straightforward of what it's doing, so if the path parameter cannot be converted to an int, the conversion error is dropped and the zero value is returned.

I find the need of integer parameters to be common in most applications. Converting the string value to an int in each handler or using a middleware becomes too verbose.

```
func handler(c echo.Context) error {
	id := c.IntParam("id")
	println(id)
	return nil
}
```