### PR TITLE
Fix proxy middleware bug: custom transport doesn't work when go version isn't 1.11

### DIFF
--- a/middleware/proxy_1_11_n.go
+++ b/middleware/proxy_1_11_n.go
@@ -3,11 +3,14 @@
 package middleware
 
 import (
-	"github.com/labstack/echo"
 	"net/http"
 	"net/http/httputil"
+
+	"github.com/labstack/echo"
 )
 
 func proxyHTTP(t *ProxyTarget, c echo.Context, config ProxyConfig) http.Handler {
-	return httputil.NewSingleHostReverseProxy(t.URL)
+	proxy := httputil.NewSingleHostReverseProxy(t.URL)
+	proxy.Transport = config.Transport
+	return proxy
 }


### PR DESCRIPTION
The config.Transport should be assigned to proxy.Transport.