### PR TITLE
Logger middleware to make a Skip decision after the request handler

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -108,16 +108,17 @@ func LoggerWithConfig(config LoggerConfig) echo.MiddlewareFunc {
 
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) (err error) {
-			if config.Skipper(c) {
-				return next(c)
-			}
-
 			req := c.Request()
 			res := c.Response()
 			start := time.Now()
 			if err = next(c); err != nil {
 				c.Error(err)
 			}
+
+			if config.Skipper(c) {
+				return
+			}
+
 			stop := time.Now()
 			buf := config.pool.Get().(*bytes.Buffer)
 			buf.Reset()


### PR DESCRIPTION
The high-level problem:
- it is required to reduce default middleware logging volume by only logging unsuccessful requests/responses. 

The logging volume can easily reach several gigs per day and significantly contribute to operational costs.

In the desired state, the vast majority of requests are responded with 2xx (+3xx) codes and should be logged only under verbose logging levels. 4xx and above should be logged under _warn_/_error_ levels.

The code-level problem prevents doing that:
- default logging middleware does not have access to results of request handling as Skipper is called before the handler. 

Proposed change:
- move Skipper check after the handler so it can access the response code.