### PR TITLE
fixing unbalanced double-quotes in logger json format

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -70,7 +70,7 @@ var (
 		Skipper: DefaultSkipper,
 		Format: `{"time":"${time_rfc3339_nano}","id":"${id}","remote_ip":"${remote_ip}",` +
 			`"host":"${host}","method":"${method}","uri":"${uri}","user_agent":"${user_agent}",` +
-			`"status":${status},"error":"${error}","latency":${latency}","latency_human":"${latency_human}"` +
+			`"status":${status},"error":"${error}","latency":${latency},"latency_human":"${latency_human}"` +
 			`,"bytes_in":${bytes_in},"bytes_out":${bytes_out}}` + "\n",
 		CustomTimeFormat: "2006-01-02 15:04:05.00000",
 		Output:           os.Stdout,


### PR DESCRIPTION
Fixed malformed middleware.DefaultLoggerConfig.Format introduced in  https://github.com/labstack/echo/commit/c54d9e8eed6ce2dfb8446ae6f9ac4eac800570bf#diff-861e7cdef93e8a1268975900051bead9 