### PR TITLE
Run logger skipper after inner middleware

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -108,10 +108,6 @@ func LoggerWithConfig(config LoggerConfig) echo.MiddlewareFunc {
 
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) (err error) {
-			if config.Skipper(c) {
-				return next(c)
-			}
-
 			req := c.Request()
 			res := c.Response()
 			start := time.Now()
@@ -119,6 +115,11 @@ func LoggerWithConfig(config LoggerConfig) echo.MiddlewareFunc {
 				c.Error(err)
 			}
 			stop := time.Now()
+
+			if config.Skipper(c) {
+				return nil
+			}
+
 			buf := config.pool.Get().(*bytes.Buffer)
 			buf.Reset()
 			defer config.pool.Put(buf)


### PR DESCRIPTION
As per [this gist](https://gist.github.com/mozey/aca264f9c03e6fdd977a7d9e0ac86cbe), the logger skipper cannot be used to check HTTP status unless it is called after the inner middleware.

I would like to use the logger middleware for success responses, but errors must be logged by a customHTTPErrorHandler. To do that the logger skipper needs a check like this
```
res := c.Response()
status := res.Status
// Skips request logging if not success status,
// those are logged by customHTTPErrorHandler
if status > 299 {
	return true
```

But the status code is incorrect unless the skipper runs after the inner middleware.


