### PR TITLE
Echo.StartTLS: return error from tls.LoadX509KeyPair

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -614,7 +614,7 @@ func (e *Echo) StartTLS(address string, certFile, keyFile string) (err error) {
 	s.TLSConfig.Certificates = make([]tls.Certificate, 1)
 	s.TLSConfig.Certificates[0], err = tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
-		return
+		return err
 	}
 	return e.startTLS(address)
 }


### PR DESCRIPTION
`echo.go` - `Echo.StartTLS`:

Don't discard `error` returned from `tls.LoadX509KeyPair`. Return it to the caller.