### PR TITLE
Added param:<name> lookup option to JWT Middleware

### DIFF
--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -48,6 +48,7 @@ type (
 		// Possible values:
 		// - "header:<name>"
 		// - "query:<name>"
+		// - "param:<name>"
 		// - "cookie:<name>"
 		TokenLookup string
 
@@ -142,6 +143,8 @@ func JWTWithConfig(config JWTConfig) echo.MiddlewareFunc {
 	switch parts[0] {
 	case "query":
 		extractor = jwtFromQuery(parts[1])
+	case "param":
+		extractor = jwtFromParam(parts[1])
 	case "cookie":
 		extractor = jwtFromCookie(parts[1])
 	}
@@ -208,6 +211,17 @@ func jwtFromHeader(header string, authScheme string) jwtExtractor {
 func jwtFromQuery(param string) jwtExtractor {
 	return func(c echo.Context) (string, error) {
 		token := c.QueryParam(param)
+		if token == "" {
+			return "", ErrJWTMissing
+		}
+		return token, nil
+	}
+}
+
+// jwtFromParam returns a `jwtExtractor` that extracts token from the url param string.
+func jwtFromParam(param string) jwtExtractor {
+	return func(c echo.Context) (string, error) {
+		token := c.Param(param)
 		if token == "" {
 			return "", ErrJWTMissing
 		}

--- a/middleware/jwt_test.go
+++ b/middleware/jwt_test.go
@@ -162,6 +162,14 @@ func TestJWT(t *testing.T) {
 		{
 			config: JWTConfig{
 				SigningKey:  validKey,
+				TokenLookup: "param:jwt",
+			},
+			reqURL: "/" + token,
+			info:   "Valid param method",
+		},
+		{
+			config: JWTConfig{
+				SigningKey:  validKey,
 				TokenLookup: "cookie:jwt",
 			},
 			hdrCookie: "jwt=" + token,
@@ -194,6 +202,11 @@ func TestJWT(t *testing.T) {
 		req.Header.Set(echo.HeaderAuthorization, tc.hdrAuth)
 		req.Header.Set(echo.HeaderCookie, tc.hdrCookie)
 		c := e.NewContext(req, res)
+
+		if tc.reqURL == "/" + token {
+			c.SetParamNames("jwt")
+			c.SetParamValues(token)
+		}
 
 		if tc.expPanic {
 			assert.Panics(t, func() {


### PR DESCRIPTION
I wanted to use JWTs as "tokenized" URLs and have the Middleware locate them from their URL param names:

https//example.com/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ

With a route like:
e := echo.New()
e.GET("/:token", MyHandler)

Where "token" is the `TokenLookup` option in the JWT config : `param:<name>`

The test(s) are a little naive since I can't route the tests thru an Echo Router, but the principal is still there, and it isn't really that big a change/addition.

Hopefully others will find this useful!
