### PR TITLE
Refactor DefaultProxyConfig Skipper & WebSocket Check in Context

### DIFF
--- a/context.go
+++ b/context.go
@@ -234,7 +234,7 @@ func (c *context) IsTLS() bool {
 
 func (c *context) IsWebSocket() bool {
 	upgrade := c.request.Header.Get(HeaderUpgrade)
-	return upgrade == "websocket" || upgrade == "Websocket"
+	return strings.ToLower(upgrade) == "websocket"
 }
 
 func (c *context) Scheme() string {

--- a/middleware/proxy.go
+++ b/middleware/proxy.go
@@ -200,7 +200,7 @@ func Proxy(balancer ProxyBalancer) echo.MiddlewareFunc {
 func ProxyWithConfig(config ProxyConfig) echo.MiddlewareFunc {
 	// Defaults
 	if config.Skipper == nil {
-		config.Skipper = DefaultLoggerConfig.Skipper
+		config.Skipper = DefaultProxyConfig.Skipper
 	}
 	if config.Balancer == nil {
 		panic("echo: proxy middleware requires balancer")


### PR DESCRIPTION
1. When _Skipper Config_ is not provided for _Proxy_, currently it is set to _DefaultLoggerConfig.Skipper_. That has been replaced with _DefaultProxyConfig.Skipper_ instead. Even though both refer to the same, it's better to use the one with the same semantics.

2. Modified _IsWebSocket()_ to convert the header to lower-case before comparing, rather than checking for multiple cases of the same string.

@vishr Your thoughts?