### PR TITLE
Exposing KeyFunc

### DIFF
--- a/middleware/jwt_test.go
+++ b/middleware/jwt_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 )
@@ -183,6 +183,14 @@ func TestJWT(t *testing.T) {
 			},
 			expErrCode: http.StatusBadRequest,
 			info:       "Empty cookie",
+		},
+		{
+			config: JWTConfig{
+				SigningKey:    validKey,
+				SigningMethod: "RS256",
+			},
+			expErrCode: http.StatusBadRequest,
+			info:       "Invalid algorithm",
 		},
 	} {
 		if tc.reqURL == "" {


### PR DESCRIPTION
When using auth servers that have more than one key that they sign the token with. It is useful to be able to validate the keys from outside the middle ware., e.g. provide a key fetch function.  
 
Feel free to provide alternative solutions. Or if I should add some tests for this.