### PR TITLE
Fix flushing in Gzip middleware

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -111,6 +111,9 @@ func (w *gzipResponseWriter) Write(b []byte) (int, error) {
 
 func (w *gzipResponseWriter) Flush() {
 	w.Writer.(*gzip.Writer).Flush()
+	if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
 }
 
 func (w *gzipResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {


### PR DESCRIPTION
This Pull Request makes the `Flush()` method of response writer in the Gzip middleware call `Flush` on the underlying response writer, instead of only on the gzip writer.

I also added an extra test case that asserts that the headers and first bytes are written and flushed after `Flush()` is called for the first time.