### PR TITLE
feat: Add a new ErrorHandlerWithContext

### DIFF
--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -25,6 +25,9 @@ type (
 		// ErrorHandler defines a function which is executed for an invalid token.
 		// It may be used to define a custom JWT error.
 		ErrorHandler JWTErrorHandler
+		
+		// Same as ErrorHandler, but it's passed the current context.
+		ErrorHandlerWithContext JWTErrorHandlerWithContext
 
 		// Signing key to validate token.
 		// Required.
@@ -64,6 +67,9 @@ type (
 	// JWTErrorHandler defines a function which is executed for an invalid token.
 	JWTErrorHandler func(error) error
 
+	// Same as JWTErrorHandler, but it's passed the current context.
+	JWTErrorHandlerWithContext func(error, echo.Context) error
+	
 	jwtExtractor func(echo.Context) (string, error)
 )
 
@@ -161,6 +167,10 @@ func JWTWithConfig(config JWTConfig) echo.MiddlewareFunc {
 				if config.ErrorHandler != nil {
 					return config.ErrorHandler(err)
 				}
+				
+				if config.ErrorHandlerWithContext != nil {
+					return config.ErrorHandlerWithContext(err, c)
+				}
 				return err
 			}
 			token := new(jwt.Token)
@@ -182,6 +192,9 @@ func JWTWithConfig(config JWTConfig) echo.MiddlewareFunc {
 			}
 			if config.ErrorHandler != nil {
 				return config.ErrorHandler(err)
+			}
+			if config.ErrorHandlerWithContext != nil {
+					return config.ErrorHandlerWithContext(err, c)
 			}
 			return &echo.HTTPError{
 				Code:     http.StatusUnauthorized,

--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -26,7 +26,7 @@ type (
 		// It may be used to define a custom JWT error.
 		ErrorHandler JWTErrorHandler
 		
-		// Same as ErrorHandler, but it's passed the current context.
+		// ErrorHandlerWithContext is almost identical to ErrorHandler, but it's passed the current context.
 		ErrorHandlerWithContext JWTErrorHandlerWithContext
 
 		// Signing key to validate token.
@@ -67,7 +67,7 @@ type (
 	// JWTErrorHandler defines a function which is executed for an invalid token.
 	JWTErrorHandler func(error) error
 
-	// Same as JWTErrorHandler, but it's passed the current context.
+	// JWTErrorHandlerWithContext is almost identical to JWTErrorHandler, but it's passed the current context.
 	JWTErrorHandlerWithContext func(error, echo.Context) error
 	
 	jwtExtractor func(echo.Context) (string, error)


### PR DESCRIPTION
This commit adds a new error handler, which is passed the 
current context, so that you can add custom redirects or even
other kinds of responses. For example:

```go
e.Use(middleware.JWTWithConfig(middleware.JWTConfig{
	SigningKey: []byte("secret"),
	TokenLookup: "query:token",
	ErrorHandlerWithContext: func(err error, c echo.Context) error {
		// do stuff with context and err
		switch err.(type) {
		case jwt.ValidationError:
			return c.Redirect(http.StatusSeeOther, "/login")
		}
		return err
	},
}))
```


What needs to be done, to get this merged?