### PR TITLE
Added support for the REPORT method

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -170,6 +170,8 @@ const (
 	charsetUTF8 = "charset=UTF-8"
 	// PROPFIND Method can be used on collection and property resources.
 	PROPFIND = "PROPFIND"
+	// REPORT Method can be used to get information about a resource, see rfc 3253
+	REPORT = "REPORT"
 )
 
 // Headers
@@ -251,6 +253,7 @@ var (
 		PROPFIND,
 		http.MethodPut,
 		http.MethodTrace,
+		REPORT,
 	}
 )
 

--- a/router.go
+++ b/router.go
@@ -33,6 +33,7 @@ type (
 		propfind HandlerFunc
 		put      HandlerFunc
 		trace    HandlerFunc
+		report   HandlerFunc
 	}
 )
 
@@ -247,6 +248,8 @@ func (n *node) addHandler(method string, h HandlerFunc) {
 		n.methodHandler.put = h
 	case http.MethodTrace:
 		n.methodHandler.trace = h
+	case REPORT:
+		n.methodHandler.report = h
 	}
 }
 
@@ -272,6 +275,8 @@ func (n *node) findHandler(method string) HandlerFunc {
 		return n.methodHandler.put
 	case http.MethodTrace:
 		return n.methodHandler.trace
+	case REPORT:
+		return n.methodHandler.report
 	default:
 		return nil
 	}


### PR DESCRIPTION
This pr adds support for the http `REPORT` method specified in [RFC 3253](https://tools.ietf.org/html/rfc3253#section-3.6).