### PR TITLE
fix #1260 change middleware.Logger's default output

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -74,7 +73,7 @@ var (
 			`"status":${status},"error":"${error}","latency":${latency},"latency_human":"${latency_human}"` +
 			`,"bytes_in":${bytes_in},"bytes_out":${bytes_out}}` + "\n",
 		CustomTimeFormat: "2006-01-02 15:04:05.00000",
-		Output:           os.Stdout,
+		Output:           nil,
 		colorer:          color.New(),
 	}
 )
@@ -214,6 +213,10 @@ func LoggerWithConfig(config LoggerConfig) echo.MiddlewareFunc {
 				return
 			}
 
+			if config.Output == nil {
+				_, err = c.Logger().Output().Write(buf.Bytes())
+				return
+			}
 			_, err = config.Output.Write(buf.Bytes())
 			return
 		}

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -73,7 +73,6 @@ var (
 			`"status":${status},"error":"${error}","latency":${latency},"latency_human":"${latency_human}"` +
 			`,"bytes_in":${bytes_in},"bytes_out":${bytes_out}}` + "\n",
 		CustomTimeFormat: "2006-01-02 15:04:05.00000",
-		Output:           nil,
 		colorer:          color.New(),
 	}
 )

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -70,18 +70,18 @@ func TestLoggerIPAddress(t *testing.T) {
 	// With X-Real-IP
 	req.Header.Add(echo.HeaderXRealIP, ip)
 	h(c)
-	assert.Contains(t, ip, buf.String())
+	assert.Contains(t, buf.String(), ip)
 
 	// With X-Forwarded-For
 	buf.Reset()
 	req.Header.Del(echo.HeaderXRealIP)
 	req.Header.Add(echo.HeaderXForwardedFor, ip)
 	h(c)
-	assert.Contains(t, ip, buf.String())
+	assert.Contains(t, buf.String(), ip)
 
 	buf.Reset()
 	h(c)
-	assert.Contains(t, ip, buf.String())
+	assert.Contains(t, buf.String(), ip)
 }
 
 func TestLoggerTemplate(t *testing.T) {


### PR DESCRIPTION
Fixes #1260 
- change default logger to use context.Logger()
- fix unit test: wrong assertion

