### PR TITLE
Assign new ResponseWriter after calling http.HandlerFunc

### DIFF
--- a/context.go
+++ b/context.go
@@ -26,6 +26,9 @@ type (
 		// SetRequest sets `*http.Request`.
 		SetRequest(r *http.Request)
 
+		// SetResponse sets `*Response`.
+		SetResponse(r *Response)
+
 		// Response returns `*Response`.
 		Response() *Response
 
@@ -226,6 +229,10 @@ func (c *context) SetRequest(r *http.Request) {
 
 func (c *context) Response() *Response {
 	return c.response
+}
+
+func (c *context) SetResponse(r *Response) {
+	c.response = r
 }
 
 func (c *context) IsTLS() bool {

--- a/echo.go
+++ b/echo.go
@@ -768,6 +768,7 @@ func WrapMiddleware(m func(http.Handler) http.Handler) MiddlewareFunc {
 		return func(c Context) (err error) {
 			m(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				c.SetRequest(r)
+				c.SetResponse(NewResponse(w, c.Echo()))
 				err = next(c)
 			})).ServeHTTP(c.Response(), c.Request())
 			return


### PR DESCRIPTION
Otherwise, the `http.ResponseWriter` passed to `next()` within the
middleware is unused. This precludes middlewares from wrapping the
http.ResponseWriter to do things like record the status code.

Fixes #1257 

There was a workaround mentioned in the linked issue to set the `echo.Response.Writer` in the middleware, but I think this is still an improvement as:

* the current behavior is, in my opinion, pretty suprising. I expected the `rw` I passed to `next()` to get passed to the next middleware. In practice, I can just pass `nil` here and have the same effect as `echo` doesn't capture and use the `rw`
* the mentioned workaround only works if you wrote the middleware. It precludes using 3rd-party HTTP middlewares