### PR TITLE
rate limiter as middleware

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,6 @@ require (
 	github.com/stretchr/testify v1.3.0
 	github.com/valyala/fasttemplate v1.0.1
 	golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734
+	github.com/alicebob/miniredis   // indirect , just fake redis for rate limiter tests
+  gopkg.in/redis.v5               // indirect , just fake redis for rate limiter tests
 )

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,4 @@ require (
 	github.com/stretchr/testify v1.3.0
 	github.com/valyala/fasttemplate v1.0.1
 	golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734
-	github.com/alicebob/miniredis   // indirect , just fake redis for rate limiter tests
-  gopkg.in/redis.v5               // indirect , just fake redis for rate limiter tests
 )

--- a/middleware/ratelimiter.go
+++ b/middleware/ratelimiter.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"errors"
-	"fmt"
 	"github.com/labstack/echo/v4"
 	"net/http"
 	"strconv"

--- a/middleware/ratelimiter.go
+++ b/middleware/ratelimiter.go
@@ -2,7 +2,7 @@ package middleware
 
 import (
 	"errors"
-	"github.com/labstack/echo"
+	"github.com/labstack/echo/v4"
 	"net/http"
 	"strconv"
 	"sync"

--- a/middleware/ratelimiter.go
+++ b/middleware/ratelimiter.go
@@ -67,7 +67,7 @@ func RateLimiter() echo.MiddlewareFunc {
 func RateLimiterWithConfig(config RateLimiterConfig) echo.MiddlewareFunc {
 	// Defaults
 	if config.Skipper == nil {
-		config.Skipper = DefaultCORSConfig.Skipper
+		config.Skipper = DefaultRateLimiterConfig.Skipper
 	}
 
 	if config.Prefix == "" {
@@ -81,6 +81,7 @@ func RateLimiterWithConfig(config RateLimiterConfig) echo.MiddlewareFunc {
 	}
 	limiterImp = newMemoryLimiter(&config)
 	/*
+	TODO: limiter storage should be conventinal.
 	if config.Client == nil {
 
 	}else{
@@ -88,8 +89,6 @@ func RateLimiterWithConfig(config RateLimiterConfig) echo.MiddlewareFunc {
 		//limiter = newRedisLimiter(&config)
 	}
 	*/
-
-	fmt.Printf("Max:%d",config.Max)
 
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {

--- a/middleware/ratelimiter.go
+++ b/middleware/ratelimiter.go
@@ -1,0 +1,329 @@
+package middleware
+
+import (
+	"errors"
+	"fmt"
+	"github.com/labstack/echo/v4"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+)
+
+type (
+	// RateLimiterConfig defines the config for RateLimiter middleware.
+	RateLimiterConfig struct {
+		// Skipper defines a function to skip middleware.
+		Skipper Skipper
+
+		// The max count in duration for no policy, default is 100.
+		Max      int
+
+		// Count duration for no policy, default is 1 Minute.
+		Duration time.Duration
+		//key prefix, default is "LIMIT:".
+		Prefix   string
+
+	}
+
+	limiter struct {
+		abstractLimiter
+		prefix string
+	}
+
+	// Result of limiter.Get
+	Result struct {
+		Total     int           // It Equals Options.Max, or policy max
+		Remaining int           // It will always >= -1
+		Duration  time.Duration // It Equals Options.Duration, or policy duration
+		Reset     time.Time     // The limit record reset time
+	}
+
+	abstractLimiter interface {
+		getLimit(key string, policy ...int) ([]interface{}, error)
+		removeLimit(key string) error
+	}
+
+)
+
+var (
+	// DefaultRateLimiterConfig is the default rate limit middleware config.
+	DefaultRateLimiterConfig = RateLimiterConfig{
+		Skipper:      DefaultSkipper,
+		Max:100,
+		Duration: time.Minute * 1,
+		Prefix:"LIMIT",
+	}
+	limiterImp *limiter
+)
+
+// RateLimiter returns a rate limit middleware.
+func RateLimiter() echo.MiddlewareFunc {
+	return RateLimiterWithConfig(DefaultRateLimiterConfig)
+}
+
+// RateLimiterWithConfig returns a RateLimiter middleware with config.
+// See: `RateLimiter()`.
+func RateLimiterWithConfig(config RateLimiterConfig) echo.MiddlewareFunc {
+	// Defaults
+	if config.Skipper == nil {
+		config.Skipper = DefaultCORSConfig.Skipper
+	}
+
+	if config.Prefix == "" {
+		config.Prefix = "LIMIT:"
+	}
+	if config.Max <= 0 {
+		config.Max = 100
+	}
+	if config.Duration <= 0 {
+		config.Duration = time.Minute *1
+	}
+	limiterImp = newMemoryLimiter(&config)
+	/*
+	if config.Client == nil {
+
+	}else{
+		//setup redis client
+		//limiter = newRedisLimiter(&config)
+	}
+	*/
+
+	fmt.Printf("Max:%d",config.Max)
+
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if config.Skipper(c) {
+				return next(c)
+			}
+			response := c.Response()
+
+			result, err := limiterImp.Get(c.Path())
+
+			if err != nil {
+				return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+			}
+
+			response.Header().Set("X-Ratelimit-Limit", strconv.FormatInt(int64(result.Total), 10))
+			response.Header().Set("X-Ratelimit-Remaining", strconv.FormatInt(int64(result.Remaining), 10))
+			response.Header().Set("X-Ratelimit-Reset", strconv.FormatInt(result.Reset.Unix(), 10))
+
+			if result.Remaining < 0 {
+
+				after := int64(result.Reset.Sub(time.Now())) / 1e9
+				response.Header().Set("Retry-After", strconv.FormatInt(after, 10))
+				return echo.NewHTTPError(http.StatusTooManyRequests, "Rate limit exceeded, retry in %d seconds.\n", after)
+			}
+			return next(c)
+		}
+	}
+}
+
+// get & remove
+
+func (l *limiter) Get(id string, policy ...int) (Result, error) {
+	var result Result
+	key := l.prefix + id
+
+	if odd := len(policy) % 2; odd == 1 {
+		return result, errors.New("ratelimiter: must be paired values")
+	}
+
+	res, err := l.getLimit(key, policy...)
+	if err != nil {
+		return result, err
+	}
+
+	result = Result{}
+	switch res[3].(type) {
+	case time.Time: // result from memory limiter
+		result.Remaining = res[0].(int)
+		result.Total = res[1].(int)
+		result.Duration = res[2].(time.Duration)
+		result.Reset = res[3].(time.Time)
+	default: // result from redis limiter
+		result.Remaining = int(res[0].(int64))
+		result.Total = int(res[1].(int64))
+		result.Duration = time.Duration(res[2].(int64) * 1e6)
+
+		timestamp := res[3].(int64)
+		sec := timestamp / 1000
+		result.Reset = time.Unix(sec, (timestamp-(sec*1000))*1e6)
+	}
+	return result, nil
+}
+
+// Remove remove limiter record for id
+func (l *limiter) Remove(id string) error {
+	return l.removeLimit(l.prefix + id)
+}
+
+
+// Inmemory Limiter imp
+
+// policy status
+type (
+	statusCacheItem struct {
+		index  int
+		expire time.Time
+	}
+
+	// limit status
+	limiterCacheItem struct {
+		total     int
+		remaining int
+		duration  time.Duration
+		expire    time.Time
+	}
+
+	memoryLimiter struct {
+		max      int
+		duration time.Duration
+		status   map[string]*statusCacheItem
+		store    map[string]*limiterCacheItem
+		ticker   *time.Ticker
+		lock     sync.Mutex
+	}
+)
+
+func newMemoryLimiter(opts *RateLimiterConfig) *limiter {
+	m := &memoryLimiter{
+		max:      opts.Max,
+		duration: opts.Duration,
+		store:    make(map[string]*limiterCacheItem),
+		status:   make(map[string]*statusCacheItem),
+		ticker:   time.NewTicker(time.Second),
+	}
+	go m.cleanCache()
+	return &limiter{m, opts.Prefix}
+}
+
+// abstractLimiter interface
+func (m *memoryLimiter) getLimit(key string, policy ...int) ([]interface{}, error) {
+	length := len(policy)
+	var args []int
+	if length == 0 {
+		args = []int{m.max, int(m.duration / time.Millisecond)}
+	} else {
+		args = make([]int, length)
+		for i, val := range policy {
+			if val <= 0 {
+				return nil, errors.New("ratelimiter: must be positive integer")
+			}
+			args[i] = policy[i]
+		}
+	}
+
+	res := m.getItem(key, args...)
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	return []interface{}{res.remaining, res.total, res.duration, res.expire}, nil
+}
+
+// abstractLimiter interface
+func (m *memoryLimiter) removeLimit(key string) error {
+	statusKey := "{" + key + "}:S"
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	delete(m.store, key)
+	delete(m.status, statusKey)
+	return nil
+}
+
+func (m *memoryLimiter) clean() {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	start := time.Now()
+	expireTime := start.Add(time.Millisecond * 100)
+	frequency := 24
+	var expired int
+	for {
+	label:
+		for i := 0; i < frequency; i++ {
+			for key, value := range m.store {
+				if value.expire.Add(value.duration).Before(start) {
+					statusKey := "{" + key + "}:S"
+					delete(m.store, key)
+					delete(m.status, statusKey)
+					expired++
+				}
+				break
+			}
+		}
+		if expireTime.Before(time.Now()) {
+			return
+		}
+		if expired > frequency/4 {
+			expired = 0
+			goto label
+		}
+		return
+	}
+}
+
+func (m *memoryLimiter) getItem(key string, args ...int) (res *limiterCacheItem) {
+	policyCount := len(args) / 2
+	statusKey := "{" + key + "}:S"
+
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	var ok bool
+	if res, ok = m.store[key]; !ok {
+		res = &limiterCacheItem{
+			total:     args[0],
+			remaining: args[0] - 1,
+			duration:  time.Duration(args[1]) * time.Millisecond,
+			expire:    time.Now().Add(time.Duration(args[1]) * time.Millisecond),
+		}
+		m.store[key] = res
+		return
+	}
+	if res.expire.After(time.Now()) {
+		if policyCount > 1 && res.remaining-1 == -1 {
+			statusItem, ok := m.status[statusKey]
+			if ok {
+				statusItem.expire = time.Now().Add(res.duration * 2)
+				statusItem.index++
+			} else {
+				statusItem := &statusCacheItem{
+					index:  2,
+					expire: time.Now().Add(time.Duration(args[1]) * time.Millisecond * 2),
+				}
+				m.status[statusKey] = statusItem
+			}
+		}
+		if res.remaining >= 0 {
+			res.remaining--
+		} else {
+			res.remaining = -1
+		}
+	} else {
+		index := 1
+		if policyCount > 1 {
+			if statusItem, ok := m.status[statusKey]; ok {
+				if statusItem.expire.Before(time.Now()) {
+					index = 1
+				} else if statusItem.index > policyCount {
+					index = policyCount
+				} else {
+					index = statusItem.index
+				}
+				statusItem.index = index
+			}
+		}
+		total := args[(index*2)-2]
+		duration := args[(index*2)-1]
+		res.total = total
+		res.remaining = total - 1
+		res.duration = time.Duration(duration) * time.Millisecond
+		res.expire = time.Now().Add(time.Duration(duration) * time.Millisecond)
+	}
+	return
+}
+
+func (m *memoryLimiter) cleanCache() {
+	for range m.ticker.C {
+		m.clean()
+	}
+}
+

--- a/middleware/ratelimiter.go
+++ b/middleware/ratelimiter.go
@@ -364,7 +364,7 @@ type redisLimiter struct {
 }
 
 func newRedisLimiter(options *RateLimiterConfig) *limiter {
-	sha1, err := options.Client.LuaScriptLoad(LuaScriptForRedis)
+	sha1, err := options.Client.LuaScriptLoad(luaScriptForRedis)
 	if err != nil {
 		panic(err)
 	}
@@ -407,7 +407,7 @@ func (r *redisLimiter) getLimit(key string, policy ...int) ([]interface{}, error
 	res, err := r.rc.EvalulateSha(r.sha1, keys, args...)
 	if err != nil && isNoScriptErr(err) {
 		// try to load lua for cluster client and ring client for nodes changing.
-		_, err = r.rc.LuaScriptLoad(LuaScriptForRedis)
+		_, err = r.rc.LuaScriptLoad(luaScriptForRedis)
 		if err == nil {
 			res, err = r.rc.EvalulateSha(r.sha1, keys, args...)
 		}
@@ -431,8 +431,8 @@ func isNoScriptErr(err error) bool {
 	return strings.HasPrefix(err.Error(), "NOSCRIPT ")
 }
 
-
-const LuaScriptForRedis string = `
+//luaScriptForRedis
+const luaScriptForRedis string = `
 -- KEYS[1] target hash key
 -- KEYS[2] target status hash key
 -- ARGV[n >= 3] current timestamp, max count, duration, max count, duration, ...

--- a/middleware/ratelimiter.go
+++ b/middleware/ratelimiter.go
@@ -28,7 +28,7 @@ type (
 
 		//TODO: WhiteList
 	}
-
+	// LimiterConfig defines the limitation of middleware
 	LimiterConfig struct {
 		//The max count in duration for no policy, default is 100.
 		Max      int

--- a/middleware/ratelimiter.go
+++ b/middleware/ratelimiter.go
@@ -106,7 +106,7 @@ func RateLimiterWithConfig(config RateLimiterConfig) echo.MiddlewareFunc {
 			response.Header().Set("X-Ratelimit-Remaining", strconv.FormatInt(int64(result.Remaining), 10))
 			response.Header().Set("X-Ratelimit-Reset", strconv.FormatInt(result.Reset.Unix(), 10))
 
-			if result.Remaining < 0 {
+			if result.Remaining <= 0 {
 
 				after := int64(result.Reset.Sub(time.Now())) / 1e9
 				response.Header().Set("Retry-After", strconv.FormatInt(after, 10))
@@ -139,7 +139,7 @@ func (l *limiter) Get(id string, policy ...int) (Result, error) {
 		result.Total = res[1].(int)
 		result.Duration = res[2].(time.Duration)
 		result.Reset = res[3].(time.Time)
-	default: // result from redis limiter
+	default: // result from disteributed limiter
 		result.Remaining = int(res[0].(int64))
 		result.Total = int(res[1].(int64))
 		result.Duration = time.Duration(res[2].(int64) * 1e6)

--- a/middleware/ratelimiter_test.go
+++ b/middleware/ratelimiter_test.go
@@ -1,7 +1,5 @@
 package middleware
-
 import (
-	"github.com/alperhankendi/echo"
 	"github.com/labstack/echo/v4"
 	"net/http"
 	"net/http/httptest"
@@ -16,8 +14,6 @@ import (
 	"github.com/alicebob/miniredis"
 	"errors"
 	"fmt"
-
-
 )
 
 func TestRateLimiter(t *testing.T) {

--- a/middleware/ratelimiter_test.go
+++ b/middleware/ratelimiter_test.go
@@ -219,7 +219,7 @@ func TestRedisRatelimiter(t *testing.T) {
 				assert.Contains(t, rec.Header().Get("X-Ratelimit-Remaining"), "-1")
 				assert.Equal(t, http.StatusTooManyRequests, expectedErrorStatus.Code)
 			}	else {
-				assert.Error(t,errors.New("it should throw too many ruqest exception!"))
+				assert.Error(t,errors.New("it should throw too many ruqest exception"))
 			}
 		})
 

--- a/middleware/ratelimiter_test.go
+++ b/middleware/ratelimiter_test.go
@@ -1,11 +1,10 @@
 package middleware
 
 import (
+	"github.com/labstack/echo"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 
 	"crypto/rand"
@@ -45,7 +44,9 @@ func TestRateLimiter(t *testing.T) {
 
 			//ratelimit with config
 			rateLimitWithConfig := RateLimiterWithConfig(RateLimiterConfig{
-				Max: 2,
+				LimitConfig:LimiterConfig{
+					Max: 2,
+				},
 			})
 
 			rec := httptest.NewRecorder()
@@ -68,8 +69,10 @@ func TestRateLimiter(t *testing.T) {
 
 			//ratelimit with config; expected result getting 429 after 5 second it should return 200
 			rateLimitWithConfig := RateLimiterWithConfig(RateLimiterConfig{
-				Max:      2,
-				Duration: expectedDuration,
+				LimitConfig:LimiterConfig{
+					Max: 2,
+					Duration: expectedDuration,
+				},
 			})
 
 			rec := httptest.NewRecorder()
@@ -181,9 +184,11 @@ func TestRedisRatelimiter(t *testing.T) {
 			c := e.NewContext(req, rec)
 
 			rateLimitWithConfig := RateLimiterWithConfig(RateLimiterConfig{
-				Max:100,
+				LimitConfig:LimiterConfig{
+					Max:100,
+					Duration:time.Minute*1,
+				},
 				Client:&redisClient{client},
-				Duration:time.Minute *1,
 			})
 
 			hx := rateLimitWithConfig(func(c echo.Context) error {
@@ -203,9 +208,11 @@ func TestRedisRatelimiter(t *testing.T) {
 			c := e.NewContext(req, rec)
 
 			xx := RateLimiterWithConfig(RateLimiterConfig{
-				Max:2,
 				Client:&redisClient{client},
-				Duration:time.Minute *1,
+				LimitConfig:LimiterConfig{
+					Max:2,
+					Duration:time.Minute *1,
+				},
 			})
 
 			hx := xx(func(c echo.Context) error {
@@ -232,8 +239,10 @@ func TestRedisRatelimiter(t *testing.T) {
 		redisLimiter = newRedisLimiter(&RateLimiterConfig{
 
 			Client:   &redisClient{client},
-			Max:      100,
-			Duration: duration,
+			LimitConfig:LimiterConfig{
+				Max:      100,
+				Duration: duration,
+			},
 		})
 
 		t.Run("New instance running with failedClient should be", func(t *testing.T) {
@@ -324,8 +333,10 @@ func TestMemoryRateLimiter(t *testing.T) {
 		assert := assert.New(t)
 
 		limiter := newMemoryLimiter(&RateLimiterConfig{
-			Max:100,
-			Duration:time.Minute,
+			LimitConfig:LimiterConfig{
+				Max:100,
+				Duration:time.Minute,
+			},
 			Prefix:"Test",
 		})
 
@@ -347,8 +358,10 @@ func TestMemoryRateLimiter(t *testing.T) {
 		assert := assert.New(t)
 
 		limiter := newMemoryLimiter(&RateLimiterConfig{
-			Max:100,
-			Duration:time.Minute,
+			LimitConfig:LimiterConfig{
+				Max:100,
+				Duration:time.Minute,
+			},
 			Prefix:"Test",
 		})
 
@@ -373,8 +386,10 @@ func TestMemoryRateLimiter(t *testing.T) {
 		assert := assert.New(t)
 
 		limiter := newMemoryLimiter(&RateLimiterConfig{
-			Max:100,
-			Duration:time.Minute,
+			LimitConfig:LimiterConfig{
+				Max:100,
+				Duration:time.Minute,
+			},
 			Prefix:"Test",
 		})
 		policy := []int{10, 500}
@@ -403,8 +418,10 @@ func TestMemoryRateLimiter(t *testing.T) {
 		assert := assert.New(t)
 
 		limiter := newMemoryLimiter(&RateLimiterConfig{
-			Max:100,
-			Duration:time.Minute,
+			LimitConfig:LimiterConfig{
+				Max:100,
+				Duration:time.Minute,
+			},
 			Prefix:"Test",
 		})
 		id := genID()
@@ -446,8 +463,10 @@ func TestMemoryRateLimiter(t *testing.T) {
 		assert := assert.New(t)
 
 		limiter := newMemoryLimiter(&RateLimiterConfig{
-			Max:100,
-			Duration:time.Minute,
+			LimitConfig:LimiterConfig{
+				Max:100,
+				Duration:time.Minute,
+			},
 			Prefix:"Test",
 		})
 		id := genID()
@@ -467,8 +486,10 @@ func TestMemoryRateLimiter(t *testing.T) {
 		assert := assert.New(t)
 
 		limiter := newMemoryLimiter(&RateLimiterConfig{
-			Max:100,
-			Duration:time.Minute,
+			LimitConfig:LimiterConfig{
+				Max:100,
+				Duration:time.Minute,
+			},
 			Prefix:"Test",
 		})
 		id := genID()
@@ -484,8 +505,10 @@ func TestMemoryRateLimiter(t *testing.T) {
 		assert := assert.New(t)
 
 		limiter := newMemoryLimiter(&RateLimiterConfig{
-			Max:100,
-			Duration:time.Minute,
+			LimitConfig:LimiterConfig{
+				Max:100,
+				Duration:time.Minute,
+			},
 			Prefix:"Test",
 		})
 		id := genID()
@@ -501,8 +524,10 @@ func TestMemoryRateLimiter(t *testing.T) {
 		assert := assert.New(t)
 
 		limiter := newMemoryLimiter(&RateLimiterConfig{
-			Max:100,
-			Duration:time.Minute,
+			LimitConfig:LimiterConfig{
+				Max:100,
+				Duration:time.Minute,
+			},
 			Prefix:"Test",
 		})
 		id := genID()
@@ -559,8 +584,10 @@ func TestMemoryRateLimiter(t *testing.T) {
 		assert := assert.New(t)
 
 		limiter := newMemoryLimiter(&RateLimiterConfig{
-			Max:100,
-			Duration:time.Minute,
+			LimitConfig:LimiterConfig{
+				Max:100,
+				Duration:time.Minute,
+			},
 			Prefix:"Test",
 		})
 		policy := []int{1000, 1000}
@@ -587,8 +614,10 @@ func TestMemoryRateLimiter(t *testing.T) {
 		assert := assert.New(t)
 
 		limiter := newMemoryLimiter(&RateLimiterConfig{
-			Max:100,
-			Duration:time.Minute,
+			LimitConfig:LimiterConfig{
+				Max:100,
+				Duration:time.Minute,
+			},
 			Prefix:"Test",
 		})
 
@@ -706,8 +735,10 @@ func TestMemoryRateLimiter(t *testing.T) {
 
 		var id = genID()
 		limiter := newMemoryLimiter(&RateLimiterConfig{
-			Max:100,
-			Duration:time.Minute,
+			LimitConfig:LimiterConfig{
+				Max:100,
+				Duration:time.Minute,
+			},
 			Prefix:"Test",
 		})
 		policy := []int{2, 150, 2, 200, 3, 300, 3, 400}
@@ -823,8 +854,10 @@ func TestMemoryRateLimiter(t *testing.T) {
 
 		var id = genID()
 		limiter := newMemoryLimiter(&RateLimiterConfig{
-			Max:100,
-			Duration:time.Minute,
+			LimitConfig:LimiterConfig{
+				Max:100,
+				Duration:time.Minute,
+			},
 			Prefix:"Test",
 		})
 		policy := []int{2, 300, 3, 100}
@@ -921,8 +954,10 @@ func TestMemoryRateLimiter(t *testing.T) {
 
 		var id = genID()
 		limiter := newMemoryLimiter(&RateLimiterConfig{
-			Max:100,
-			Duration:time.Minute,
+			LimitConfig:LimiterConfig{
+				Max:100,
+				Duration:time.Minute,
+			},
 			Prefix:"Test",
 		})
 		policy := []int{3, 300, 2, 200}

--- a/middleware/ratelimiter_test.go
+++ b/middleware/ratelimiter_test.go
@@ -1,0 +1,707 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+
+	"crypto/rand"
+	"encoding/hex"
+	"time"
+
+	"sync"
+)
+
+func TestRateLimiter(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	rateLimit := RateLimiter()
+
+	h := rateLimit(func(c echo.Context) error {
+		return c.String(http.StatusOK, "test")
+	})
+
+	// g
+	h(c)
+	assert.Contains(t, rec.Header().Get("X-Ratelimit-Remaining"), "99")
+	assert.Contains(t, rec.Header().Get("X-Ratelimit-Limit"), "100")
+
+
+	//ratelimit with config
+	rateLimitWithConfig := RateLimiterWithConfig(RateLimiterConfig{
+		Max:2,
+	})
+
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec)
+	hx := rateLimitWithConfig(func(c echo.Context) error {
+		return c.String(http.StatusOK, "test")
+	})
+	hx(c)
+	hx(c)
+	hx(c)
+
+	assert.Contains(t, rec.Header().Get("X-Ratelimit-Remaining"), "-1")
+	//assert.Equal(t, http.StatusTooManyRequests, rec.Code)
+
+}
+
+func TestMemoryRateLimiter(t *testing.T) {
+	t.Run("ratelimiter with default Options should be", func(t *testing.T) {
+		assert := assert.New(t)
+
+		limiter := newMemoryLimiter(&RateLimiterConfig{
+			Max:100,
+			Duration:time.Minute,
+			Prefix:"Test",
+		})
+
+		id := genID()
+		policy := []int{10, 1000}
+
+		res, err := limiter.Get(id, policy...)
+		assert.Nil(err)
+		assert.Equal(10, res.Total)
+		assert.Equal(9, res.Remaining)
+		assert.Equal(1000, int(res.Duration/time.Millisecond))
+		assert.True(res.Reset.After(time.Now()))
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(10, res.Total)
+		assert.Equal(8, res.Remaining)
+	})
+
+	t.Run("ratelimiter with expire should be", func(t *testing.T) {
+		assert := assert.New(t)
+
+		limiter := newMemoryLimiter(&RateLimiterConfig{
+			Max:100,
+			Duration:time.Minute,
+			Prefix:"Test",
+		})
+
+		id := genID()
+		policy := []int{10, 100}
+
+		res, err := limiter.Get(id, policy...)
+		assert.Nil(err)
+		assert.Equal(10, res.Total)
+		assert.Equal(9, res.Remaining)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(8, res.Remaining)
+
+		time.Sleep(100 * time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Nil(err)
+		assert.Equal(10, res.Total)
+		assert.Equal(9, res.Remaining)
+	})
+
+	t.Run("ratelimiter with goroutine should be", func(t *testing.T) {
+		assert := assert.New(t)
+
+		limiter := newMemoryLimiter(&RateLimiterConfig{
+			Max:100,
+			Duration:time.Minute,
+			Prefix:"Test",
+		})
+		policy := []int{10, 500}
+		id := genID()
+		res, err := limiter.Get(id, policy...)
+		assert.Nil(err)
+		assert.Equal(10, res.Total)
+		assert.Equal(9, res.Remaining)
+		var wait sync.WaitGroup
+		wait.Add(100)
+		for i := 0; i < 100; i++ {
+			go func() {
+				limiter.Get(id, policy...)
+				wait.Done()
+			}()
+		}
+		wait.Wait()
+		time.Sleep(200 * time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Nil(err)
+		assert.Equal(10, res.Total)
+		assert.Equal(-1, res.Remaining)
+	})
+
+	t.Run("ratelimiter with multi-policy should be", func(t *testing.T) {
+		assert := assert.New(t)
+
+		limiter := newMemoryLimiter(&RateLimiterConfig{
+			Max:100,
+			Duration:time.Minute,
+			Prefix:"Test",
+		})
+		id := genID()
+		policy := []int{3, 100, 2, 200}
+
+		res, err := limiter.Get(id, policy...)
+		assert.Nil(err)
+		assert.Equal(3, res.Total)
+		assert.Equal(2, res.Remaining)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(1, res.Remaining)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(0, res.Remaining)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(-1, res.Remaining)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(-1, res.Remaining)
+		assert.True(res.Reset.After(time.Now()))
+
+		time.Sleep(res.Duration + time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(2, res.Total)
+		assert.Equal(1, res.Remaining)
+		assert.Equal(time.Millisecond*200, res.Duration)
+
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(0, res.Remaining)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(-1, res.Remaining)
+
+		time.Sleep(res.Duration + time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(2, res.Total)
+		assert.Equal(1, res.Remaining)
+		assert.Equal(time.Millisecond*200, res.Duration)
+	})
+
+	t.Run("ratelimiter with Remove id should be", func(t *testing.T) {
+		assert := assert.New(t)
+
+		limiter := newMemoryLimiter(&RateLimiterConfig{
+			Max:100,
+			Duration:time.Minute,
+			Prefix:"Test",
+		})
+		id := genID()
+		policy := []int{10, 1000}
+
+		res, err := limiter.Get(id, policy...)
+		assert.Nil(err)
+		assert.Equal(10, res.Total)
+		assert.Equal(9, res.Remaining)
+		limiter.Remove(id)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(10, res.Total)
+		assert.Equal(9, res.Remaining)
+	})
+
+	t.Run("ratelimiter with wrong policy id should be", func(t *testing.T) {
+		assert := assert.New(t)
+
+		limiter := newMemoryLimiter(&RateLimiterConfig{
+			Max:100,
+			Duration:time.Minute,
+			Prefix:"Test",
+		})
+		id := genID()
+		policy := []int{10, 1000, 1}
+
+		res, err := limiter.Get(id, policy...)
+		assert.Error(err)
+		assert.Equal(0, res.Total)
+		assert.Equal(0, res.Remaining)
+	})
+
+	t.Run("ratelimiter with empty policy id should be", func(t *testing.T) {
+		assert := assert.New(t)
+
+		limiter := newMemoryLimiter(&RateLimiterConfig{
+			Max:100,
+			Duration:time.Minute,
+			Prefix:"Test",
+		})
+		id := genID()
+		policy := []int{}
+
+		res, _ := limiter.Get(id, policy...)
+		assert.Equal(100, res.Total)
+		assert.Equal(99, res.Remaining)
+		assert.Equal(time.Minute, res.Duration)
+	})
+
+	t.Run("limiter.Get with invalid args", func(t *testing.T) {
+		assert := assert.New(t)
+
+		limiter := newMemoryLimiter(&RateLimiterConfig{
+			Max:100,
+			Duration:time.Minute,
+			Prefix:"Test",
+		})
+		id := genID()
+		_, err := limiter.Get(id, 10)
+		assert.Equal("ratelimiter: must be paired values", err.Error())
+
+		_, err2 := limiter.Get(id, -1, 10)
+		assert.Equal("ratelimiter: must be positive integer", err2.Error())
+
+		_, err3 := limiter.Get(id, 10, 0)
+		assert.Equal("ratelimiter: must be positive integer", err3.Error())
+	})
+
+	t.Run("ratelimiter with Clean cache should be", func(t *testing.T) {
+		assert := assert.New(t)
+
+
+		limiter := &memoryLimiter{
+			max:      100,
+			duration: time.Minute,
+			store:    make(map[string]*limiterCacheItem),
+			status:   make(map[string]*statusCacheItem),
+			ticker:   time.NewTicker(time.Minute),
+		}
+
+		id := genID()
+		policy := []int{10, 100}
+
+		res, _ := limiter.getLimit(id, policy...)
+
+		assert.Equal(10, res[1].(int))
+		assert.Equal(9, res[0].(int))
+
+		time.Sleep(res[2].(time.Duration) + time.Millisecond)
+		limiter.clean()
+		res, _ = limiter.getLimit(id, policy...)
+		assert.Equal(10, res[1].(int))
+		assert.Equal(9, res[0].(int))
+
+		time.Sleep(res[2].(time.Duration)*2 + time.Millisecond)
+		limiter.clean()
+		res, _ = limiter.getLimit(id, policy...)
+		assert.Equal(10, res[1].(int))
+		assert.Equal(9, res[0].(int))
+		limiter.ticker = time.NewTicker(time.Millisecond)
+		go limiter.cleanCache()
+		time.Sleep(2 * time.Millisecond)
+		res, _ = limiter.getLimit(id, policy...)
+		assert.Equal(10, res[1].(int))
+		assert.Equal(8, res[0].(int))
+	})
+
+	t.Run("ratelimiter with big goroutine should be", func(t *testing.T) {
+		assert := assert.New(t)
+
+		limiter := newMemoryLimiter(&RateLimiterConfig{
+			Max:100,
+			Duration:time.Minute,
+			Prefix:"Test",
+		})
+		policy := []int{1000, 1000}
+		id := genID()
+
+		var wg sync.WaitGroup
+		wg.Add(1000)
+		for i := 0; i < 1000; i++ {
+			go func() {
+				newid := genID()
+				limiter.Get(newid, policy...)
+				limiter.Get(id, policy...)
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+		res, err := limiter.Get(id, policy...)
+		assert.Nil(err)
+		assert.Equal(1000, res.Total)
+		assert.Equal(-1, res.Remaining)
+	})
+
+	t.Run("limiter.Get with multi-policy for expired", func(t *testing.T) {
+		assert := assert.New(t)
+
+		limiter := newMemoryLimiter(&RateLimiterConfig{
+			Max:100,
+			Duration:time.Minute,
+			Prefix:"Test",
+		})
+
+		id := genID()
+		policy := []int{2, 100, 2, 200, 3, 300, 3, 400}
+
+		//First policy
+		res, err := limiter.Get(id, policy...)
+		assert.Nil(err)
+		assert.Equal(2, res.Total)
+		assert.Equal(1, res.Remaining)
+		assert.Equal(time.Millisecond*100, res.Duration)
+
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(0, res.Remaining)
+
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(-1, res.Remaining)
+		assert.Equal(time.Millisecond*100, res.Duration)
+
+		//Second policy
+		time.Sleep(res.Duration + time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(2, res.Total)
+		assert.Equal(1, res.Remaining)
+		assert.Equal(time.Millisecond*200, res.Duration)
+
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(0, res.Remaining)
+
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(-1, res.Remaining)
+
+		//Third policy
+		time.Sleep(res.Duration + time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(3, res.Total)
+		assert.Equal(2, res.Remaining)
+		assert.Equal(time.Millisecond*300, res.Duration)
+
+		res, err = limiter.Get(id, policy...)
+		res, err = limiter.Get(id, policy...)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(-1, res.Remaining)
+
+		// restore to First policy after Third policy*2 Duration
+		time.Sleep(res.Duration*2 + time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Nil(err)
+		assert.Equal(2, res.Total)
+		assert.Equal(1, res.Remaining)
+		assert.Equal(time.Millisecond*100, res.Duration)
+		res, err = limiter.Get(id, policy...)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(-1, res.Remaining)
+
+		//Second policy
+		time.Sleep(res.Duration + time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(2, res.Total)
+		assert.Equal(1, res.Remaining)
+
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(0, res.Remaining)
+
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(-1, res.Remaining)
+		assert.Equal(time.Millisecond*200, res.Duration)
+
+		//Third policy
+		time.Sleep(res.Duration + time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(3, res.Total)
+		assert.Equal(2, res.Remaining)
+		assert.Equal(time.Millisecond*300, res.Duration)
+
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(1, res.Remaining)
+		assert.Equal(time.Millisecond*300, res.Duration)
+
+		res, err = limiter.Get(id, policy...)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(-1, res.Remaining)
+
+		//Fourth policy
+		time.Sleep(res.Duration + time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(3, res.Total)
+		assert.Equal(2, res.Remaining)
+		assert.Equal(time.Millisecond*400, res.Duration)
+
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(3, res.Total)
+		assert.Equal(1, res.Remaining)
+
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(3, res.Total)
+		assert.Equal(0, res.Remaining)
+
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(3, res.Total)
+		assert.Equal(-1, res.Remaining)
+
+		// restore to First policy after Fourth policy*2 Duration
+		time.Sleep(res.Duration*2 + time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Nil(err)
+		assert.Equal(2, res.Total)
+		assert.Equal(1, res.Remaining)
+		assert.Equal(time.Millisecond*100, res.Duration)
+	})
+	t.Run("limiter.Get with multi-policy situation for expired", func(t *testing.T) {
+		assert := assert.New(t)
+
+		var id = genID()
+		limiter := newMemoryLimiter(&RateLimiterConfig{
+			Max:100,
+			Duration:time.Minute,
+			Prefix:"Test",
+		})
+		policy := []int{2, 150, 2, 200, 3, 300, 3, 400}
+
+		res, err := limiter.Get(id, policy...)
+		assert.Nil(err)
+		assert.Equal(2, res.Total)
+		assert.Equal(1, res.Remaining)
+		assert.Equal(time.Millisecond*150, res.Duration)
+
+		time.Sleep(res.Duration + time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(2, res.Total)
+		assert.Equal(1, res.Remaining)
+		assert.Equal(time.Millisecond*150, res.Duration)
+
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(2, res.Total)
+		assert.Equal(0, res.Remaining)
+		assert.Equal(time.Millisecond*150, res.Duration)
+
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(2, res.Total)
+		assert.Equal(-1, res.Remaining)
+		assert.Equal(time.Millisecond*150, res.Duration)
+
+		time.Sleep(res.Duration + time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(2, res.Total)
+		assert.Equal(1, res.Remaining)
+		assert.Equal(time.Millisecond*200, res.Duration)
+
+		time.Sleep(res.Duration + time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(2, res.Total)
+		assert.Equal(1, res.Remaining)
+		assert.Equal(time.Millisecond*150, res.Duration)
+
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(2, res.Total)
+		assert.Equal(0, res.Remaining)
+		assert.Equal(time.Millisecond*150, res.Duration)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(2, res.Total)
+		assert.Equal(-1, res.Remaining)
+		assert.Equal(time.Millisecond*150, res.Duration)
+
+		time.Sleep(res.Duration + time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(2, res.Total)
+		assert.Equal(1, res.Remaining)
+		assert.Equal(time.Millisecond*200, res.Duration)
+
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(2, res.Total)
+		assert.Equal(0, res.Remaining)
+		assert.Equal(time.Millisecond*200, res.Duration)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(-1, res.Remaining)
+
+		time.Sleep(res.Duration + time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(3, res.Total)
+		assert.Equal(2, res.Remaining)
+		assert.Equal(time.Millisecond*300, res.Duration)
+
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(3, res.Total)
+		assert.Equal(1, res.Remaining)
+		assert.Equal(time.Millisecond*300, res.Duration)
+		res, err = limiter.Get(id, policy...)
+
+		assert.Equal(3, res.Total)
+		assert.Equal(0, res.Remaining)
+		assert.Equal(time.Millisecond*300, res.Duration)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(-1, res.Remaining)
+
+		time.Sleep(res.Duration + time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(3, res.Total)
+		assert.Equal(2, res.Remaining)
+		assert.Equal(time.Millisecond*400, res.Duration)
+
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(3, res.Total)
+		assert.Equal(1, res.Remaining)
+
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(3, res.Total)
+		assert.Equal(0, res.Remaining)
+
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(3, res.Total)
+		assert.Equal(-1, res.Remaining)
+
+		time.Sleep(res.Duration + time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(3, res.Total)
+		assert.Equal(2, res.Remaining)
+		assert.Equal(time.Millisecond*400, res.Duration)
+
+		time.Sleep(res.Duration + time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(2, res.Total)
+		assert.Equal(1, res.Remaining)
+		assert.Equal(time.Millisecond*150, res.Duration)
+
+	})
+	t.Run("limiter.Get with different policy time situation for expired", func(t *testing.T) {
+		assert := assert.New(t)
+
+		var id = genID()
+		limiter := newMemoryLimiter(&RateLimiterConfig{
+			Max:100,
+			Duration:time.Minute,
+			Prefix:"Test",
+		})
+		policy := []int{2, 300, 3, 100}
+
+		res, err := limiter.Get(id, policy...)
+		assert.Nil(err)
+		assert.Equal(2, res.Total)
+		assert.Equal(1, res.Remaining)
+		assert.Equal(time.Millisecond*300, res.Duration)
+
+		res, err = limiter.Get(id, policy...)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(-1, res.Remaining)
+		assert.Equal(time.Millisecond*300, res.Duration)
+
+		time.Sleep(res.Duration + time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(3, res.Total)
+		assert.Equal(2, res.Remaining)
+		assert.Equal(time.Millisecond*100, res.Duration)
+
+		time.Sleep(res.Duration + time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(3, res.Total)
+		assert.Equal(2, res.Remaining)
+		assert.Equal(time.Millisecond*100, res.Duration)
+
+		time.Sleep(res.Duration + time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(3, res.Total)
+		assert.Equal(2, res.Remaining)
+		assert.Equal(time.Millisecond*100, res.Duration)
+
+		time.Sleep(res.Duration + time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Nil(err)
+		assert.Equal(2, res.Total)
+		assert.Equal(1, res.Remaining)
+		assert.Equal(time.Millisecond*300, res.Duration)
+
+		res, err = limiter.Get(id, policy...)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(-1, res.Remaining)
+		assert.Equal(time.Millisecond*300, res.Duration)
+
+		time.Sleep(res.Duration + time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(3, res.Total)
+		assert.Equal(2, res.Remaining)
+		assert.Equal(time.Millisecond*100, res.Duration)
+
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(3, res.Total)
+		assert.Equal(1, res.Remaining)
+		assert.Equal(time.Millisecond*100, res.Duration)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(3, res.Total)
+		assert.Equal(0, res.Remaining)
+		assert.Equal(time.Millisecond*100, res.Duration)
+
+		time.Sleep(res.Duration + time.Millisecond)
+
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(3, res.Total)
+		assert.Equal(2, res.Remaining)
+		assert.Equal(time.Millisecond*100, res.Duration)
+
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(3, res.Total)
+		assert.Equal(1, res.Remaining)
+		assert.Equal(time.Millisecond*100, res.Duration)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(3, res.Total)
+		assert.Equal(0, res.Remaining)
+		assert.Equal(time.Millisecond*100, res.Duration)
+
+		time.Sleep(res.Duration + time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(3, res.Total)
+		assert.Equal(2, res.Remaining)
+		assert.Equal(time.Millisecond*100, res.Duration)
+
+		time.Sleep(res.Duration + time.Millisecond)
+		time.Sleep(res.Duration + time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Nil(err)
+		assert.Equal(2, res.Total)
+		assert.Equal(1, res.Remaining)
+		assert.Equal(time.Millisecond*300, res.Duration)
+	})
+	t.Run("limiter.Get with normal situation for expired", func(t *testing.T) {
+		assert := assert.New(t)
+
+		var id = genID()
+		limiter := newMemoryLimiter(&RateLimiterConfig{
+			Max:100,
+			Duration:time.Minute,
+			Prefix:"Test",
+		})
+		policy := []int{3, 300, 2, 200}
+
+		res, err := limiter.Get(id, policy...)
+		assert.Nil(err)
+		assert.Equal(3, res.Total)
+		assert.Equal(2, res.Remaining)
+		assert.Equal(time.Millisecond*300, res.Duration)
+
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(3, res.Total)
+		assert.Equal(1, res.Remaining)
+		assert.Equal(time.Millisecond*300, res.Duration)
+
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(3, res.Total)
+		assert.Equal(0, res.Remaining)
+		assert.Equal(time.Millisecond*300, res.Duration)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(-1, res.Remaining)
+
+		time.Sleep(res.Duration + time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(2, res.Total)
+		assert.Equal(1, res.Remaining)
+		assert.Equal(time.Millisecond*200, res.Duration)
+
+		time.Sleep(res.Duration + time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(2, res.Total)
+		assert.Equal(1, res.Remaining)
+		assert.Equal(time.Millisecond*200, res.Duration)
+
+		time.Sleep(res.Duration + time.Millisecond)
+		res, err = limiter.Get(id, policy...)
+		assert.Equal(3, res.Total)
+		assert.Equal(2, res.Remaining)
+		assert.Equal(time.Millisecond*300, res.Duration)
+
+	})
+}
+
+func genID() string {
+	buf := make([]byte, 12)
+	_, err := rand.Read(buf)
+	if err != nil {
+		panic(err)
+	}
+	return hex.EncodeToString(buf)
+}
+

--- a/middleware/ratelimiter_test.go
+++ b/middleware/ratelimiter_test.go
@@ -46,6 +46,7 @@ func TestRateLimiter(t *testing.T) {
 			rateLimitWithConfig := RateLimiterWithConfig(RateLimiterConfig{
 				LimitConfig:LimiterConfig{
 					Max: 2,
+					Strategy:"ip",
 				},
 			})
 
@@ -72,6 +73,7 @@ func TestRateLimiter(t *testing.T) {
 				LimitConfig:LimiterConfig{
 					Max: 2,
 					Duration: expectedDuration,
+					Strategy:"ip",
 				},
 			})
 
@@ -100,6 +102,9 @@ func TestRateLimiter(t *testing.T) {
 			c := e.NewContext(req, rec)
 			rateLimitWithConfig := RateLimiterWithConfig(RateLimiterConfig{
 				SkipRateLimiterInternalError:true,
+				LimitConfig:LimiterConfig{
+					Strategy:"ip",
+				},
 			})
 
 			h := rateLimitWithConfig(func(c echo.Context) error {
@@ -172,6 +177,9 @@ func TestRedisRatelimiter(t *testing.T) {
 
 			rateLimitWithConfig := RateLimiterWithConfig(RateLimiterConfig{
 				Client:&redisClient{client},
+				LimitConfig:LimiterConfig{
+					Strategy:"ip",
+				},
 			})
 			assert.NotNil(t,rateLimitWithConfig)
 		})
@@ -187,6 +195,7 @@ func TestRedisRatelimiter(t *testing.T) {
 				LimitConfig:LimiterConfig{
 					Max:100,
 					Duration:time.Minute*1,
+					Strategy:"ip",
 				},
 				Client:&redisClient{client},
 			})
@@ -212,6 +221,7 @@ func TestRedisRatelimiter(t *testing.T) {
 				LimitConfig:LimiterConfig{
 					Max:2,
 					Duration:time.Minute *1,
+					Strategy:"ip",
 				},
 			})
 
@@ -242,6 +252,7 @@ func TestRedisRatelimiter(t *testing.T) {
 			LimitConfig:LimiterConfig{
 				Max:      100,
 				Duration: duration,
+				Strategy:"ip",
 			},
 		})
 
@@ -336,6 +347,7 @@ func TestMemoryRateLimiter(t *testing.T) {
 			LimitConfig:LimiterConfig{
 				Max:100,
 				Duration:time.Minute,
+				Strategy:"ip",
 			},
 			Prefix:"Test",
 		})
@@ -361,6 +373,7 @@ func TestMemoryRateLimiter(t *testing.T) {
 			LimitConfig:LimiterConfig{
 				Max:100,
 				Duration:time.Minute,
+				Strategy:"ip",
 			},
 			Prefix:"Test",
 		})
@@ -389,6 +402,7 @@ func TestMemoryRateLimiter(t *testing.T) {
 			LimitConfig:LimiterConfig{
 				Max:100,
 				Duration:time.Minute,
+				Strategy:"ip",
 			},
 			Prefix:"Test",
 		})
@@ -421,6 +435,7 @@ func TestMemoryRateLimiter(t *testing.T) {
 			LimitConfig:LimiterConfig{
 				Max:100,
 				Duration:time.Minute,
+				Strategy:"ip",
 			},
 			Prefix:"Test",
 		})
@@ -466,6 +481,7 @@ func TestMemoryRateLimiter(t *testing.T) {
 			LimitConfig:LimiterConfig{
 				Max:100,
 				Duration:time.Minute,
+				Strategy:"ip",
 			},
 			Prefix:"Test",
 		})
@@ -489,6 +505,7 @@ func TestMemoryRateLimiter(t *testing.T) {
 			LimitConfig:LimiterConfig{
 				Max:100,
 				Duration:time.Minute,
+				Strategy:"ip",
 			},
 			Prefix:"Test",
 		})
@@ -527,6 +544,7 @@ func TestMemoryRateLimiter(t *testing.T) {
 			LimitConfig:LimiterConfig{
 				Max:100,
 				Duration:time.Minute,
+				Strategy:"ip",
 			},
 			Prefix:"Test",
 		})
@@ -587,6 +605,7 @@ func TestMemoryRateLimiter(t *testing.T) {
 			LimitConfig:LimiterConfig{
 				Max:100,
 				Duration:time.Minute,
+				Strategy:"ip",
 			},
 			Prefix:"Test",
 		})
@@ -617,6 +636,7 @@ func TestMemoryRateLimiter(t *testing.T) {
 			LimitConfig:LimiterConfig{
 				Max:100,
 				Duration:time.Minute,
+				Strategy:"ip",
 			},
 			Prefix:"Test",
 		})
@@ -738,6 +758,7 @@ func TestMemoryRateLimiter(t *testing.T) {
 			LimitConfig:LimiterConfig{
 				Max:100,
 				Duration:time.Minute,
+				Strategy:"ip",
 			},
 			Prefix:"Test",
 		})
@@ -857,6 +878,7 @@ func TestMemoryRateLimiter(t *testing.T) {
 			LimitConfig:LimiterConfig{
 				Max:100,
 				Duration:time.Minute,
+				Strategy:"ip",
 			},
 			Prefix:"Test",
 		})
@@ -957,6 +979,7 @@ func TestMemoryRateLimiter(t *testing.T) {
 			LimitConfig:LimiterConfig{
 				Max:100,
 				Duration:time.Minute,
+				Strategy:"ip",
 			},
 			Prefix:"Test",
 		})

--- a/middleware/ratelimiter_test.go
+++ b/middleware/ratelimiter_test.go
@@ -45,13 +45,13 @@ func TestRateLimiter(t *testing.T) {
 
 		t.Run("should return real ip adress from ip token extractor", func(t *testing.T) {
 
-			 expectedRemoteIp := "192.168.100.100"
+			expectedRemoteIP := "192.168.100.100"
 			 tokenExtractorHandler := IPTokenExtractor()
-			 req.RemoteAddr = expectedRemoteIp+":6666"
+			 req.RemoteAddr = expectedRemoteIP+":6666"
 			 c := e.NewContext(req,nil)
 
 			 ip := tokenExtractorHandler(c)
-			 assert.Equal(t,ip,expectedRemoteIp)
+			 assert.Equal(t,ip,expectedRemoteIP)
 		})
 
 		t.Run("should return tokenized header key", func(t *testing.T) {

--- a/middleware/ratelimiter_test.go
+++ b/middleware/ratelimiter_test.go
@@ -126,10 +126,26 @@ func (c *redisClient) LuaScriptLoad(script string) (string, error) {
 	return c.ScriptLoad(script).Result()
 }
 
+// Implements RedisClient for redis.Client
+type failedClient struct {
+	*redis.Client
+}
+
+func (c *failedClient) DeleteKey(key string) error {
+	return c.Del(key).Err()
+}
+
+func (c *failedClient) EvalulateSha(sha1 string, keys []string, args ...interface{}) (interface{}, error) {
+	return nil, errors.New("noscript mock error")
+}
+
+func (c *failedClient) LuaScriptLoad(script string) (string, error) {
+	return c.ScriptLoad(script).Result()
+}
+
 func TestRedisRatelimiter(t *testing.T) {
 
 	e := echo.New()
-
 	s, err := miniredis.Run()
 	if err != nil {
 		panic(err)
@@ -203,11 +219,104 @@ func TestRedisRatelimiter(t *testing.T) {
 				assert.Contains(t, rec.Header().Get("X-Ratelimit-Remaining"), "-1")
 				assert.Equal(t, http.StatusTooManyRequests, expectedErrorStatus.Code)
 			}	else {
-				assert.Error(t,errors.New("it should throw too many ruqest exception"))
+				assert.Error(t,errors.New("it should throw too many ruqest exception!"))
 			}
 		})
+
 	})
 
+	t.Run("Redis ratelimiter implementation", func(t *testing.T) {
+		var id= genID()
+		var duration= time.Duration(60 * 1e9)
+		var redisLimiter *limiter
+		redisLimiter = newRedisLimiter(&RateLimiterConfig{
+
+			Client:   &redisClient{client},
+			Max:      100,
+			Duration: duration,
+		})
+
+		t.Run("New instance running with failedClient should be", func(t *testing.T) {
+
+			var limiter *limiter
+			limiter = newRedisLimiter(&RateLimiterConfig{
+
+				Client:&failedClient{client},
+			})
+			policy := []int{2, 100}
+			res, err := limiter.Get(id, policy...)
+
+			assert.Equal(t,"noscript mock error", err.Error())
+			assert.Equal(t,0, res.Total)
+			assert.Equal(t,0, res.Remaining)
+			assert.Equal(t,time.Duration(0), res.Duration)
+		})
+
+		t.Run("Redislimiter.Get method should be", func(t *testing.T) {
+
+			res, err := redisLimiter.Get(id)
+			assert.Nil(t, err)
+			assert.Equal(t, res.Total, 100)
+			assert.Equal(t, res.Remaining, 99)
+			assert.Equal(t, res.Duration, duration)
+			assert.True(t, res.Reset.UnixNano() > time.Now().UnixNano())
+
+			res, err = redisLimiter.Get(id)
+			assert.Nil(t, err)
+			assert.Equal(t, res.Total, 100)
+			assert.Equal(t, res.Remaining, 98)
+
+		})
+
+		t.Run("Redislimiter.Get with invalid args should throw error", func(t *testing.T) {
+			_, err := redisLimiter.Get(id, 10)
+			assert.Equal(t, "ratelimiter: must be paired values", err.Error())
+
+			_, err2 := redisLimiter.Get(id, -1, 10)
+			assert.Equal(t, "ratelimiter: must be positive integer", err2.Error())
+
+			_, err3 := redisLimiter.Get(id, 10, 0)
+			assert.Equal(t, "ratelimiter: must be positive integer", err3.Error())
+		})
+
+		t.Run("Redislimiter.Get with policy", func(t *testing.T) {
+
+			idx := genID()
+			assert := assert.New(t)
+
+			policy := []int{2, 100}
+
+			res, err := redisLimiter.Get(idx, policy...)
+			assert.Nil(err)
+			assert.Equal(2, res.Total)
+			assert.Equal(1, res.Remaining)
+			assert.Equal(time.Millisecond*100, res.Duration)
+
+			res, err = redisLimiter.Get(idx, policy...)
+			assert.Nil(err)
+			assert.Equal(0, res.Remaining)
+
+			res, err = redisLimiter.Get(idx, policy...)
+			assert.Nil(err)
+			assert.Equal(-1, res.Remaining)
+		})
+
+		t.Run("Redislimiter.Remove method should be", func(t *testing.T) {
+
+			err := redisLimiter.Remove(id)
+			assert.Nil(t, err)
+
+			err = redisLimiter.Remove(id)
+			assert.Nil(t, err)
+
+			res, err := redisLimiter.Get(id)
+			assert.Nil(t, err)
+			assert.Equal(t, res.Total, 100)
+			assert.Equal(t, res.Remaining, 99)
+
+		})
+
+	})
 }
 
 func TestMemoryRateLimiter(t *testing.T) {

--- a/middleware/ratelimiter_test.go
+++ b/middleware/ratelimiter_test.go
@@ -1,7 +1,7 @@
 package middleware
 
 import (
-	"github.com/labstack/echo"
+	"github.com/labstack/echo/v4"
 	"net/http"
 	"net/http/httptest"
 	"testing"

--- a/middleware/ratelimiter_test.go
+++ b/middleware/ratelimiter_test.go
@@ -74,10 +74,10 @@ func TestRateLimiter(t *testing.T) {
 		expectedErrorStatus := hx(c).(*echo.HTTPError)
 		assert.Equal(t, http.StatusTooManyRequests, expectedErrorStatus.Code)
 		time.Sleep(expectedDuration)
-		exceptedHttpStatusOk,ok :=hx(c).(*echo.HTTPError)
+		exceptedHTTPStatusOk,ok :=hx(c).(*echo.HTTPError)
 
 		if ok{
-			assert.Equal(t, http.StatusOK, exceptedHttpStatusOk.Code)
+			assert.Equal(t, http.StatusOK, exceptedHTTPStatusOk.Code)
 		}
 
 	})

--- a/middleware/ratelimiter_test.go
+++ b/middleware/ratelimiter_test.go
@@ -203,7 +203,7 @@ func TestRedisRatelimiter(t *testing.T) {
 				assert.Contains(t, rec.Header().Get("X-Ratelimit-Remaining"), "-1")
 				assert.Equal(t, http.StatusTooManyRequests, expectedErrorStatus.Code)
 			}	else {
-				assert.Error(t,errors.New("it should throw too many ruqest exception!"))
+				assert.Error(t,errors.New("it should throw too many ruqest exception"))
 			}
 		})
 	})

--- a/middleware/ratelimiter_test.go
+++ b/middleware/ratelimiter_test.go
@@ -11,7 +11,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"time"
-
 	"sync"
 )
 
@@ -45,10 +44,10 @@ func TestRateLimiter(t *testing.T) {
 	})
 	hx(c)
 	hx(c)
-	hx(c)
+	expectedErrorStatus := hx(c).(*echo.HTTPError)
 
 	assert.Contains(t, rec.Header().Get("X-Ratelimit-Remaining"), "-1")
-	//assert.Equal(t, http.StatusTooManyRequests, rec.Code)
+	assert.Equal(t, http.StatusTooManyRequests, expectedErrorStatus.Code)
 
 }
 


### PR DESCRIPTION
rate limiter middleware usage;    
The default config;
the same request is limited with 100 in a minute.

ps: Distributed RateLimiter implementation is in progress. I'm thinking about to use Redis for it. 

    e := echo.New()
    e.GET("/", func(c echo.Context) error {
        return c.String(http.StatusOK, "Hello, World!")
    })
    //e.Use(middleware.RateLimiter())
    e.Use(middleware.RateLimiterWithConfig(middleware.RateLimiterConfig{
        Max:2,
        Duration:time.Minute*1,
        Prefix:"test",
    }))
    e.Logger.Fatal(e.Start(":1323"))

for 200-response these fields will be added to the response header. 
```
x-ratelimit-limit →2
x-ratelimit-remaining →1
x-ratelimit-reset →1559074005
```

for 429 - to many request code these fields will be added to the response header.

```
retry-after →4
x-ratelimit-limit →2
x-ratelimit-remaining →-1
x-ratelimit-reset →1559074005
```

TODO:

- Distributed rate limiter
- IP, Header, Method and cookie-based limitation.
- Extensible rate limit policies