### PR TITLE
Fixed failing tests from param binder

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -40,8 +40,11 @@ func (b *DefaultBinder) Bind(i interface{}, c Context) (err error) {
 	for in, name := range paramNames {
 		params[name] = []string{paramValues[in]}
 	}
-	if err := b.bindData(i, params, "param"); err != nil {
-		return NewHTTPError(http.StatusBadRequest, err.Error()).SetInternal(err)
+	// Only bind the params to the struct if there is something to bind
+	if len(params) > 0 {
+		if err := b.bindData(i, params, "param"); err != nil {
+			return NewHTTPError(http.StatusBadRequest, err.Error()).SetInternal(err)
+		}
 	}
 
 	if req.ContentLength == 0 {
@@ -88,12 +91,6 @@ func (b *DefaultBinder) Bind(i interface{}, c Context) (err error) {
 }
 
 func (b *DefaultBinder) bindData(ptr interface{}, data map[string][]string, tag string) error {
-
-	// Directly exit if we don't have any data to bind
-	if len(data) == 0 {
-		return nil
-	}
-
 	typ := reflect.TypeOf(ptr).Elem()
 	val := reflect.ValueOf(ptr).Elem()
 

--- a/bind.go
+++ b/bind.go
@@ -37,8 +37,8 @@ func (b *DefaultBinder) Bind(i interface{}, c Context) (err error) {
 	paramNames := c.ParamNames()
 	paramValues := c.ParamValues()
 	params := make(map[string][]string)
-	for i, name := range paramNames {
-		params[name] = []string{paramValues[i]}
+	for in, name := range paramNames {
+		params[name] = []string{paramValues[in]}
 	}
 	if err := b.bindData(i, params, "param"); err != nil {
 		return NewHTTPError(http.StatusBadRequest, err.Error()).SetInternal(err)
@@ -88,6 +88,12 @@ func (b *DefaultBinder) Bind(i interface{}, c Context) (err error) {
 }
 
 func (b *DefaultBinder) bindData(ptr interface{}, data map[string][]string, tag string) error {
+
+	// Directly exit if we don't have any data to bind
+	if len(data) == 0 {
+		return nil
+	}
+
 	typ := reflect.TypeOf(ptr).Elem()
 	val := reflect.ValueOf(ptr).Elem()
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
@@ -44,6 +45,7 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190531175056-4c3a928424d2 h1:T5DasATyLQfmbTpfEXx/IOL9vfjzW6up+ZDkmHvIf2s=
 golang.org/x/sys v0.0.0-20190531175056-4c3a928424d2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190602015325-4c4f7f33c9ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190609082536-301114b31cce h1:CQakrGkKbydnUmt7cFIlmQ4lNQiqdTPt6xzXij4nYCc=
 golang.org/x/sys v0.0.0-20190609082536-301114b31cce/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
This pr fixes the failing tests from  #1165. When I removed my param binder stuff, that specific test worked again, so think I can be sure my code is the problem here.

I'm not 100% sure why this fix works or why this even failed in the first place, any ideas are appreciated.

The tests were failing because of the call to `val.Field(i)` in `bind.go:106`. When this was called and the passed `ptr` variable was `nil` this function panicked. I don't understand enough of Go's `reflect` mechanisms to be able to tell why exactly this was the case, so my "fix" is more a workaround for the fact that the tests are failing.