### PR TITLE
Add ReferrerPolicy to Secure middleware

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -222,6 +222,7 @@ const (
 	HeaderContentSecurityPolicy           = "Content-Security-Policy"
 	HeaderContentSecurityPolicyReportOnly = "Content-Security-Policy-Report-Only"
 	HeaderXCSRFToken                      = "X-CSRF-Token"
+	HeaderReferrerPolicy                  = "Referrer-Policy"
 )
 
 const (

--- a/middleware/secure.go
+++ b/middleware/secure.go
@@ -66,6 +66,11 @@ type (
 		// maintained by Chrome (and used by Firefox and Safari): https://hstspreload.org/
 		// Optional.  Default value false.
 		HSTSPreloadEnabled bool `yaml:"hsts_preload_enabled"`
+
+		// ReferrerPolicy sets the `Referrer-Policy` header providing security against
+		// leaking potentially sensitive request paths to third parties.
+		// Optional. Default value "".
+		ReferrerPolicy string `yaml:"referrer_policy"`
 	}
 )
 
@@ -130,6 +135,9 @@ func SecureWithConfig(config SecureConfig) echo.MiddlewareFunc {
 				} else {
 					res.Header().Set(echo.HeaderContentSecurityPolicy, config.ContentSecurityPolicy)
 				}
+			}
+			if config.ReferrerPolicy != "" {
+				res.Header().Set(echo.HeaderReferrerPolicy, config.ReferrerPolicy)
 			}
 			return next(c)
 		}

--- a/middleware/secure_test.go
+++ b/middleware/secure_test.go
@@ -25,6 +25,7 @@ func TestSecure(t *testing.T) {
 	assert.Equal(t, "SAMEORIGIN", rec.Header().Get(echo.HeaderXFrameOptions))
 	assert.Equal(t, "", rec.Header().Get(echo.HeaderStrictTransportSecurity))
 	assert.Equal(t, "", rec.Header().Get(echo.HeaderContentSecurityPolicy))
+	assert.Equal(t, "", rec.Header().Get(echo.HeaderReferrerPolicy))
 
 	// Custom
 	req.Header.Set(echo.HeaderXForwardedProto, "https")
@@ -36,6 +37,7 @@ func TestSecure(t *testing.T) {
 		XFrameOptions:         "",
 		HSTSMaxAge:            3600,
 		ContentSecurityPolicy: "default-src 'self'",
+		ReferrerPolicy:        "origin",
 	})(h)(c)
 	assert.Equal(t, "", rec.Header().Get(echo.HeaderXXSSProtection))
 	assert.Equal(t, "", rec.Header().Get(echo.HeaderXContentTypeOptions))
@@ -43,6 +45,7 @@ func TestSecure(t *testing.T) {
 	assert.Equal(t, "max-age=3600; includeSubdomains", rec.Header().Get(echo.HeaderStrictTransportSecurity))
 	assert.Equal(t, "default-src 'self'", rec.Header().Get(echo.HeaderContentSecurityPolicy))
 	assert.Equal(t, "", rec.Header().Get(echo.HeaderContentSecurityPolicyReportOnly))
+	assert.Equal(t, "origin", rec.Header().Get(echo.HeaderReferrerPolicy))
 
 	// Custom with CSPReportOnly flag
 	req.Header.Set(echo.HeaderXForwardedProto, "https")
@@ -55,6 +58,7 @@ func TestSecure(t *testing.T) {
 		HSTSMaxAge:            3600,
 		ContentSecurityPolicy: "default-src 'self'",
 		CSPReportOnly:         true,
+		ReferrerPolicy:        "origin",
 	})(h)(c)
 	assert.Equal(t, "", rec.Header().Get(echo.HeaderXXSSProtection))
 	assert.Equal(t, "", rec.Header().Get(echo.HeaderXContentTypeOptions))
@@ -62,6 +66,7 @@ func TestSecure(t *testing.T) {
 	assert.Equal(t, "max-age=3600; includeSubdomains", rec.Header().Get(echo.HeaderStrictTransportSecurity))
 	assert.Equal(t, "default-src 'self'", rec.Header().Get(echo.HeaderContentSecurityPolicyReportOnly))
 	assert.Equal(t, "", rec.Header().Get(echo.HeaderContentSecurityPolicy))
+	assert.Equal(t, "origin", rec.Header().Get(echo.HeaderReferrerPolicy))
 
 	// Custom, with preload option enabled
 	req.Header.Set(echo.HeaderXForwardedProto, "https")


### PR DESCRIPTION
This Pull Request adds [`Referrer-Policy`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy) to the Secure middleware.

The goal of this header is to hide potentially sensitive referrer information (such as the origin or path of the original request).

Example:

If a user visits the hypothetical `https://echo.labstack.com/?some_secure_token=foobarbaz`, a request is made to `https://use.fontawesome.com/releases/v5.0.8/js/all.js`. This request contains a header `Referer: https://echo.labstack.com/?some_secure_token=foobarbaz`. FontAwesome does not need to know `some_secure_token` to give us icons, so we should limit the information they get from us in the Referer header. This can be done by setting a `Referrer-Policy` header.