### PR TITLE
Don't make router parse duplicated param when backtracing happens

### DIFF
--- a/router.go
+++ b/router.go
@@ -398,6 +398,9 @@ func (r *Router) Find(method, path string, c Context) {
 			if nn != nil {
 				cn = nn
 				nn = cn.parent // Next (Issue #954)
+				if nn != nil {
+					nk = nn.kind
+				}
 				search = ns
 				if nk == pkind {
 					goto Param

--- a/router_test.go
+++ b/router_test.go
@@ -839,6 +839,47 @@ func TestRouterStaticDynamicConflict(t *testing.T) {
 	assert.Equal(t, 3, c.Get("c"))
 }
 
+// Issue #1348
+func TestRouterParamBacktraceNotFound(t *testing.T) {
+	e := New()
+	r := e.router
+
+	// Add
+	r.Add(http.MethodGet, "/:param1", func(c Context) error {
+		return nil
+	})
+	r.Add(http.MethodGet, "/:param1/foo", func(c Context) error {
+		return nil
+	})
+	r.Add(http.MethodGet, "/:param1/bar", func(c Context) error {
+		return nil
+	})
+	r.Add(http.MethodGet, "/:param1/bar/:param2", func(c Context) error {
+		return nil
+	})
+
+	c := e.NewContext(nil, nil).(*context)
+
+	//Find
+	r.Find(http.MethodGet, "/a", c)
+	assert.Equal(t, "a", c.Param("param1"))
+
+	r.Find(http.MethodGet, "/a/foo", c)
+	assert.Equal(t, "a", c.Param("param1"))
+
+	r.Find(http.MethodGet, "/a/bar", c)
+	assert.Equal(t, "a", c.Param("param1"))
+
+	r.Find(http.MethodGet, "/a/bar/b", c)
+	assert.Equal(t, "a", c.Param("param1"))
+	assert.Equal(t, "b", c.Param("param2"))
+
+	c = e.NewContext(nil, nil).(*context)
+	r.Find(http.MethodGet, "/a/bbbbb", c)
+	he := c.handler(c).(*HTTPError)
+	assert.Equal(t, http.StatusNotFound, he.Code)
+}
+
 func testRouterAPI(t *testing.T, api []*Route) {
 	e := New()
 	r := e.router


### PR DESCRIPTION
fix #1368