### PR TITLE
add allow header to method not allowed handler

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -52,6 +52,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -284,8 +285,11 @@ var (
 		return ErrNotFound
 	}
 
-	MethodNotAllowedHandler = func(c Context) error {
-		return ErrMethodNotAllowed
+	MethodNotAllowedHandler = func(a []string) func(c Context) error {
+		return func(c Context) error {
+			c.Response().Header().Set("Allow", strings.Join(a, ", "))
+			return ErrMethodNotAllowed
+		}
 	}
 )
 

--- a/echo.go
+++ b/echo.go
@@ -287,7 +287,7 @@ var (
 
 	MethodNotAllowedHandler = func(a []string) func(c Context) error {
 		return func(c Context) error {
-			c.Response().Header().Set("Allow", strings.Join(a, ", "))
+			c.Response().Header().Set(HeaderAllow, strings.Join(a, ", "))
 			return ErrMethodNotAllowed
 		}
 	}

--- a/echo_test.go
+++ b/echo_test.go
@@ -399,6 +399,7 @@ func TestEchoMethodNotAllowed(t *testing.T) {
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+	assert.Equal(t, "GET", rec.Header().Get("Allow"))
 }
 
 func TestEchoContext(t *testing.T) {

--- a/echo_test.go
+++ b/echo_test.go
@@ -399,7 +399,7 @@ func TestEchoMethodNotAllowed(t *testing.T) {
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
-	assert.Equal(t, "GET", rec.Header().Get("Allow"))
+	assert.Equal(t, "GET", rec.Header().Get(HeaderAllow))
 }
 
 func TestEchoContext(t *testing.T) {

--- a/router.go
+++ b/router.go
@@ -282,10 +282,33 @@ func (n *node) findHandler(method string) HandlerFunc {
 	}
 }
 
+func (n *node) findAllowedMethods() []string {
+	r := []string{}
+	cs := []string{
+		http.MethodConnect,
+		http.MethodDelete,
+		http.MethodGet,
+		http.MethodHead,
+		http.MethodOptions,
+		http.MethodPatch,
+		http.MethodPost,
+		PROPFIND,
+		http.MethodPut,
+		http.MethodTrace,
+		REPORT,
+	}
+	for _, c := range cs {
+		if n.findHandler(c) != nil {
+			r = append(r, c)
+		}
+	}
+	return r
+}
+
 func (n *node) checkMethodNotAllowed() HandlerFunc {
 	for _, m := range methods {
 		if h := n.findHandler(m); h != nil {
-			return MethodNotAllowedHandler
+			return MethodNotAllowedHandler(n.findAllowedMethods())
 		}
 	}
 	return NotFoundHandler

--- a/router.go
+++ b/router.go
@@ -282,22 +282,9 @@ func (n *node) findHandler(method string) HandlerFunc {
 	}
 }
 
-func (n *node) findAllowedMethods() []string {
+func (n *node) listAllowedMethods() []string {
 	r := []string{}
-	cs := []string{
-		http.MethodConnect,
-		http.MethodDelete,
-		http.MethodGet,
-		http.MethodHead,
-		http.MethodOptions,
-		http.MethodPatch,
-		http.MethodPost,
-		PROPFIND,
-		http.MethodPut,
-		http.MethodTrace,
-		REPORT,
-	}
-	for _, c := range cs {
+	for _, c := range methods {
 		if n.findHandler(c) != nil {
 			r = append(r, c)
 		}
@@ -308,7 +295,7 @@ func (n *node) findAllowedMethods() []string {
 func (n *node) checkMethodNotAllowed() HandlerFunc {
 	for _, m := range methods {
 		if h := n.findHandler(m); h != nil {
-			return MethodNotAllowedHandler(n.findAllowedMethods())
+			return MethodNotAllowedHandler(n.listAllowedMethods())
 		}
 	}
 	return NotFoundHandler


### PR DESCRIPTION
I noticed that the Allow header is missing from 405 responses, so I added it according to the registered handlers.

Tests are updated.