### PR TITLE
Add ability to return JSON without escaping

### DIFF
--- a/echo_test.go
+++ b/echo_test.go
@@ -25,6 +25,7 @@ type (
 
 const (
 	userJSON                    = `{"id":1,"name":"Jon Snow"}`
+	userJSONUnescaped           = `{"id":2,"name":"Johnson&Johnson"}`
 	userXML                     = `<user><id>1</id><name>Jon Snow</name></user>`
 	userForm                    = `id=1&name=Jon Snow`
 	invalidContent              = "invalid content"
@@ -36,6 +37,11 @@ const (
 const userJSONPretty = `{
   "id": 1,
   "name": "Jon Snow"
+}`
+
+const userJSONPrettyUnescaped = `{
+  "id": 2,
+  "name": "Johnson&Johnson"
 }`
 
 const userXMLPretty = `<user>


### PR DESCRIPTION
Since Go 1.7 by default all JSON marshaling escapes some HTML characters (like <, > or &). In some tasks some third-party software consuming API wants unescaped data from response. Before this change there was no possibility to tell echo not to escape outcoming data.

If you want to pass unescaped JSON, use JSONUnescaped() functions instead of JSON().