### PR TITLE
Add ability to set the logger on echo.Context

### DIFF
--- a/context.go
+++ b/context.go
@@ -180,6 +180,9 @@ type (
 		// Logger returns the `Logger` instance.
 		Logger() Logger
 
+		// Set the logger
+		SetLogger(l Logger)
+
 		// Echo returns the `Echo` instance.
 		Echo() *Echo
 
@@ -199,6 +202,7 @@ type (
 		handler  HandlerFunc
 		store    Map
 		echo     *Echo
+		logger   Logger
 		lock     sync.RWMutex
 	}
 )
@@ -590,7 +594,15 @@ func (c *context) SetHandler(h HandlerFunc) {
 }
 
 func (c *context) Logger() Logger {
+	res := c.logger
+	if res != nil {
+		return res
+	}
 	return c.echo.Logger
+}
+
+func (c *context) SetLogger(l Logger) {
+	c.logger = l
 }
 
 func (c *context) Reset(r *http.Request, w http.ResponseWriter) {
@@ -601,6 +613,7 @@ func (c *context) Reset(r *http.Request, w http.ResponseWriter) {
 	c.store = nil
 	c.path = ""
 	c.pnames = nil
+	c.logger = nil
 	// NOTE: Don't reset because it has to have length c.echo.maxParam at all times
 	// c.pvalues = nil
 }

--- a/context_test.go
+++ b/context_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"github.com/labstack/gommon/log"
 	"io"
 	"math"
 	"mime/multipart"
@@ -800,7 +801,16 @@ func TestContext_Logger(t *testing.T) {
 	e := New()
 	c := e.NewContext(nil, nil)
 
-	testify.NotNil(t, c.Logger())
+	log1 := c.Logger()
+	testify.NotNil(t, log1)
+
+	log2 := log.New("echo2")
+	c.SetLogger(log2)
+	testify.Equal(t, log2, c.Logger())
+
+	// Resetting the context returns the initial logger
+	c.Reset(nil, nil)
+	testify.Equal(t, log1, c.Logger())
 }
 
 func TestContext_RealIP(t *testing.T) {


### PR DESCRIPTION
This change allows middleware to replace the logger on the echo.Context
with a customized per-request logger with additional fields. The logger
is reset to default on every Reset() call.