### PR TITLE
make slash middleware more powerful

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,12 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190531175056-4c3a928424d2 h1:T5DasATyLQfmbTpfEXx/IOL9vfjzW6up+ZDkmHvIf2s=
+golang.org/x/sys v0.0.0-20190531175056-4c3a928424d2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190602015325-4c4f7f33c9ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190609082536-301114b31cce h1:CQakrGkKbydnUmt7cFIlmQ4lNQiqdTPt6xzXij4nYCc=
+golang.org/x/sys v0.0.0-20190609082536-301114b31cce/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/middleware/slash_test.go
+++ b/middleware/slash_test.go
@@ -67,6 +67,20 @@ func TestAddTrailingSlash(t *testing.T) {
 	is.NoError(h(c))
 	is.Equal(http.StatusMovedPermanently, rec.Code)
 	is.Equal("/add-slash/?key=value", rec.Header().Get(echo.HeaderLocation))
+
+	// With skipper
+	req = httptest.NewRequest(http.MethodGet, "///add-slash?key=value", nil)
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec)
+	h = AddTrailingSlashWithConfig(TrailingSlashConfig{
+		Skipper: func(c echo.Context) bool {
+			return true
+		},
+	})(func(c echo.Context) error {
+		is.Equal("///add-slash?key=value", c.Request().RequestURI)
+		return nil
+	})
+	is.NoError(h(c))
 }
 
 func TestRemoveTrailingSlash(t *testing.T) {
@@ -137,4 +151,19 @@ func TestRemoveTrailingSlash(t *testing.T) {
 	})
 	is.NoError(h(c))
 	is.Equal("", req.URL.Path)
+
+	// With skipper
+	req = httptest.NewRequest(http.MethodGet, "///remove-slash?key=value", nil)
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec)
+	h = RemoveTrailingSlashWithConfig(TrailingSlashConfig{
+		Skipper: func(c echo.Context) bool {
+			return true
+		},
+	})(func(c echo.Context) error {
+		is.Equal("///remove-slash?key=value", c.Request().RequestURI)
+		return nil
+	})
+	is.NoError(h(c))
+
 }

--- a/middleware/slash_test.go
+++ b/middleware/slash_test.go
@@ -22,6 +22,28 @@ func TestAddTrailingSlash(t *testing.T) {
 	is.Equal("/add-slash/", req.URL.Path)
 	is.Equal("/add-slash/", req.RequestURI)
 
+	// Very dirty slash addition
+	req = httptest.NewRequest(http.MethodConnect, "/something///add-a-slash", nil)
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec)
+	h = AddTrailingSlash()(func(c echo.Context) error {
+		return nil
+	})
+	is.NoError(h(c))
+	is.Equal("/something/add-a-slash/", req.URL.Path)
+	is.Equal("/something/add-a-slash/", req.RequestURI)
+
+	// Very dirty slash addition with querystring
+	req = httptest.NewRequest(http.MethodConnect, "/something///add-a-slash?key=value", nil)
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec)
+	h = AddTrailingSlash()(func(c echo.Context) error {
+		return nil
+	})
+	is.NoError(h(c))
+	is.Equal("/something/add-a-slash/", req.URL.Path)
+	is.Equal("/something/add-a-slash/?key=value", req.RequestURI)
+
 	// Method Connect must not fail:
 	req = httptest.NewRequest(http.MethodConnect, "", nil)
 	rec = httptest.NewRecorder()
@@ -59,6 +81,28 @@ func TestRemoveTrailingSlash(t *testing.T) {
 	is.NoError(h(c))
 	is.Equal("/remove-slash", req.URL.Path)
 	is.Equal("/remove-slash", req.RequestURI)
+
+	// Very dirty slash removal
+	req = httptest.NewRequest(http.MethodGet, "/something//remove-slash//", nil)
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec)
+	h = RemoveTrailingSlash()(func(c echo.Context) error {
+		return nil
+	})
+	is.NoError(h(c))
+	is.Equal("/something/remove-slash", req.URL.Path)
+	is.Equal("/something/remove-slash", req.RequestURI)
+
+	// Very dirty with querystring
+	req = httptest.NewRequest(http.MethodGet, "/something//remove-slash//?key=value", nil)
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec)
+	h = RemoveTrailingSlash()(func(c echo.Context) error {
+		return nil
+	})
+	is.NoError(h(c))
+	is.Equal("/something/remove-slash", req.URL.Path)
+	is.Equal("/something/remove-slash?key=value", req.RequestURI)
 
 	// Method Connect must not fail:
 	req = httptest.NewRequest(http.MethodConnect, "", nil)


### PR DESCRIPTION
The current implementation of both slash middleware didn't fit our use
case where users of our webservice sometimes send us "dirty" queries
with e.g. several trailing slashes.

This commit remedies the problem by refactoring both AddTrailingSlash
and RemoveTrailingSlash to use a common "normalizer", that passes the
path component of the URL to the path.Clean function of the standard
library.

Signed-off-by: Chris Glass <chris@exoscale.ch>