### PR TITLE
Add new json function on echo.Context

### DIFF
--- a/context.go
+++ b/context.go
@@ -140,6 +140,9 @@ type (
 		// to construct the JSONP payload.
 		JSONPBlob(code int, callback string, b []byte) error
 
+		// JSONMessage sends a JSON message response with status code
+		JSONMessage(code int, message string) error
+
 		// XML sends an XML response with status code.
 		XML(code int, i interface{}) error
 
@@ -479,6 +482,12 @@ func (c *context) JSONPBlob(code int, callback string, b []byte) (err error) {
 	}
 	_, err = c.response.Write([]byte(");"))
 	return
+}
+
+func (c *context) JSONMessage(code int, message string) (err error) {
+	return c.JSON(code, Map{
+		"message": message,
+	})
 }
 
 func (c *context) xml(code int, i interface{}, indent string) (err error) {

--- a/context_test.go
+++ b/context_test.go
@@ -135,6 +135,14 @@ func TestContext(t *testing.T) {
 		assert.Equal(userJSON+"\n", rec.Body.String())
 	}
 
+	// JSONMessage
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec).(*context)
+	err = c.JSONMessage(http.StatusOK, "Json Snow")
+	if assert.NoError(err) {
+		assert.Equal(http.StatusOK, rec.Code)
+	}
+
 	// JSON with "?pretty"
 	req = httptest.NewRequest(http.MethodGet, "/?pretty", nil)
 	rec = httptest.NewRecorder()

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,7 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Usually when I validate some parameters I always end up returning a message with json, so I wanted to propose to put a new function so that already returns me a json with message without always having to use c.Json and assemble a map.