### PR TITLE
Accept middleware on Static route

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -459,11 +459,11 @@ func (e *Echo) Match(methods []string, path string, handler HandlerFunc, middlew
 
 // Static registers a new route with path prefix to serve static files from the
 // provided root directory.
-func (e *Echo) Static(prefix, root string) *Route {
+func (e *Echo) Static(prefix, root string, m ...MiddlewareFunc) *Route {
 	if root == "" {
 		root = "." // For security we want to restrict to CWD.
 	}
-	return e.static(prefix, root, e.GET)
+	return e.static(prefix, root, e.GET, m...)
 }
 
 func (common) static(prefix, root string, get func(string, HandlerFunc, ...MiddlewareFunc) *Route) *Route {
@@ -476,9 +476,9 @@ func (common) static(prefix, root string, get func(string, HandlerFunc, ...Middl
 		return c.File(name)
 	}
 	if prefix == "/" {
-		return get(prefix+"*", h)
+		return get(prefix+"*", h, m...)
 	}
-	return get(prefix+"/*", h)
+	return get(prefix+"/*", h, m...)
 }
 
 func (common) file(path, file string, get func(string, HandlerFunc, ...MiddlewareFunc) *Route,

--- a/echo.go
+++ b/echo.go
@@ -466,7 +466,8 @@ func (e *Echo) Static(prefix, root string, m ...MiddlewareFunc) *Route {
 	return e.static(prefix, root, e.GET, m...)
 }
 
-func (common) static(prefix, root string, get func(string, HandlerFunc, ...MiddlewareFunc) *Route) *Route {
+func (common) static(prefix, root string, get func(string, HandlerFunc, ...MiddlewareFunc) *Route,
+	m ...MiddlewareFunc) *Route {
 	h := func(c Context) error {
 		p, err := url.PathUnescape(c.Param("*"))
 		if err != nil {


### PR DESCRIPTION
For some reason, `echo.Static()` doesn't accept middleware.

To be consistent with other routes (including `File()`) I've not added a specific test for handling middleware. I guess if a test was added, there should probably be one for each route.

`File()` doesn't explicitly mention that it can handle middleware in the [docs](https://github.com/labstack/echox/blob/master/website/content/guide/static-files.md), so I'll assume the generic route level middleware [docs](https://github.com/labstack/echox/blob/master/website/content/middleware.md#route-level) is enough still.

Let me know if there's any tests or docs that you feel should be updated.