### PR TITLE
Close file returned by request.FormFile

### DIFF
--- a/context.go
+++ b/context.go
@@ -347,7 +347,8 @@ func (c *context) FormParams() (url.Values, error) {
 }
 
 func (c *context) FormFile(name string) (*multipart.FileHeader, error) {
-	_, fh, err := c.request.FormFile(name)
+	f, fh, err := c.request.FormFile(name)
+	defer f.Close()
 	return fh, err
 }
 


### PR DESCRIPTION
Adds the fix suggested by @jaby to resolve #1392.