### PR TITLE
Adding 'After' method which runs middleware after the route handler

### DIFF
--- a/context.go
+++ b/context.go
@@ -177,6 +177,9 @@ type (
 		// Handler returns the matched handler by router.
 		Handler() HandlerFunc
 
+		// Middleware returns the matched middleware by router.
+		Middleware() MiddlewareFunc
+
 		// SetHandler sets the matched handler by router.
 		SetHandler(h HandlerFunc)
 
@@ -590,6 +593,18 @@ func (c *context) Echo() *Echo {
 
 func (c *context) Handler() HandlerFunc {
 	return c.handler
+}
+
+func (c *context) Middleware() MiddlewareFunc {
+	return func(next HandlerFunc) HandlerFunc {
+		return func(c1 Context) error {
+			err := c.handler(c1)
+			if err != nil {
+				return err
+			}
+			return next(c1)
+		}
+	}
 }
 
 func (c *context) SetHandler(h HandlerFunc) {

--- a/echo.go
+++ b/echo.go
@@ -384,7 +384,7 @@ func (e *Echo) Use(middleware ...MiddlewareFunc) {
 	e.middleware = append(e.middleware, middleware...)
 }
 
-// Use adds middleware to the chain which is run after response.
+// After adds middleware to the chain which is run after response.
 func (e *Echo) After(middleware ...MiddlewareFunc) {
 	e.aftermiddleware = append(e.aftermiddleware, middleware...)
 }


### PR DESCRIPTION
the echo code says the `Use` run after router, But it doesn't happened.( in `echo.go` in line 382)
```
// Use adds middleware to the chain which is run after router.
func (e *Echo) Use(middleware ...MiddlewareFunc) {
	e.middleware = append(e.middleware, middleware...)
}

```

So, I write a test to show it( in `echo_test.go` in line 145).
```
func TestEchoMiddlewareUseRunsBeforeHandler(t *testing.T) {...}
```

hence, I wrote a code that apply a middleware after route handler and I wrote a test for it.  I do not change the `Use` method for the backward compatibility. This new method name is `After` and you can find it in  `echo.go` in line 388.
```
func (e *Echo) After(middleware ...MiddlewareFunc) {..}
```

and you can find my test in `echo_test.go` in line 190.
```
func TestEchoAfterMiddleware(t *testing.T) {...}
```
