### PR TITLE
Debug mode does not clear the error buffer #1387

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -354,6 +354,7 @@ func (e *Echo) DefaultHTTPErrorHandler(err error, c Context) {
 			Message: http.StatusText(http.StatusInternalServerError),
 		}
 	}
+	defer func(message interface{}) { he.Message = message }(he.Message)
 	if e.Debug {
 		he.Message = err.Error()
 	} else if m, ok := he.Message.(string); ok {

--- a/echo_test.go
+++ b/echo_test.go
@@ -57,6 +57,24 @@ func TestEcho(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
+func TestEchoDebug(t *testing.T) {
+	e := New()
+	e.Debug = true
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	// Router
+	assert.NotNil(t, e.Router())
+
+	// DefaultHTTPErrorHandler In Debug Mode
+	// DefaultHTTPErrorHandler should not modify global vars
+	preErrMsg := ErrNotFound.Error()
+	e.DefaultHTTPErrorHandler(ErrNotFound, c)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Equal(t, preErrMsg, ErrNotFound.Error())
+}
+
 func TestEchoStatic(t *testing.T) {
 	e := New()
 


### PR DESCRIPTION
The DefaultHTTPErrorHandler should not modify global error vars (such as ErrNotFound).