### PR TITLE
Fixed nil pointer exception occuring when net.http.request.FormFile fails

### DIFF
--- a/context.go
+++ b/context.go
@@ -348,7 +348,9 @@ func (c *context) FormParams() (url.Values, error) {
 
 func (c *context) FormFile(name string) (*multipart.FileHeader, error) {
 	f, fh, err := c.request.FormFile(name)
-	defer f.Close()
+	if c != nil {
+		defer f.Close()
+	}
 	return fh, err
 }
 


### PR DESCRIPTION
Fixes issue #1435 introduced by PR #1411 