### PR TITLE
Fixed #1435

### DIFF
--- a/context.go
+++ b/context.go
@@ -348,7 +348,9 @@ func (c *context) FormParams() (url.Values, error) {
 
 func (c *context) FormFile(name string) (*multipart.FileHeader, error) {
 	f, fh, err := c.request.FormFile(name)
-	defer f.Close()
+	if f != nil {
+		defer f.Close()
+	}
 	return fh, err
 }
 


### PR DESCRIPTION
Fixes possible nil pointer dereference when net.http.FormFile does not return a file pointer.