### PR TITLE
Added environment variable GO111MODULE on trivis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: go
+env:
+  global:
+    - GO111MODULE=on
 go:
   - 1.12.x
   - 1.13.x


### PR DESCRIPTION
# Description
-  Environment variable GO111MODULE is off by default when go 1.12 or lower, GO111MODULE = on was added to the environment variable of trivis ci.
