### PR TITLE
Use Max-Age for the cookie in the CSRF middleware

### DIFF
--- a/middleware/csrf.go
+++ b/middleware/csrf.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/gommon/random"
@@ -157,7 +156,7 @@ func CSRFWithConfig(config CSRFConfig) echo.MiddlewareFunc {
 			if config.CookieDomain != "" {
 				cookie.Domain = config.CookieDomain
 			}
-			cookie.Expires = time.Now().Add(time.Duration(config.CookieMaxAge) * time.Second)
+			cookie.MaxAge = config.CookieMaxAge
 			cookie.Secure = config.CookieSecure
 			cookie.HttpOnly = config.CookieHTTPOnly
 			c.SetCookie(cookie)


### PR DESCRIPTION
Using Expires for the cookie in the CSRF middleware can lead to some issues, that Max-Age doesn't have. With Expires, the server defines the expiration date, and this date will be interpreted by the client. The client and the server can be in different timezones, or the client can be misconfigured (no NTP). If the MaxAge configuration from the middleware is short (let's say hours, not days), it can happen that some clients throw the cookie as expired when they received it. That's why I would suggest using a MaxAge instead of Expires for this cookie.