### PR TITLE
format code (gofmt + trim trailing spaces)

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"github.com/labstack/gommon/log"
 	"io"
 	"math"
 	"mime/multipart"
@@ -19,6 +18,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/labstack/gommon/log"
 	testify "github.com/stretchr/testify/assert"
 )
 

--- a/middleware/cors_test.go
+++ b/middleware/cors_test.go
@@ -73,7 +73,7 @@ func TestCORS(t *testing.T) {
 	c = e.NewContext(req, rec)
 	req.Header.Set(echo.HeaderOrigin, "http://aaa.example.com")
 	cors = CORSWithConfig(CORSConfig{
-		AllowOrigins:     []string{"http://*.example.com"},
+		AllowOrigins: []string{"http://*.example.com"},
 	})
 	h = cors(echo.NotFoundHandler)
 	h(c)

--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -25,7 +25,7 @@ type (
 		// ErrorHandler defines a function which is executed for an invalid token.
 		// It may be used to define a custom JWT error.
 		ErrorHandler JWTErrorHandler
-		
+
 		// ErrorHandlerWithContext is almost identical to ErrorHandler, but it's passed the current context.
 		ErrorHandlerWithContext JWTErrorHandlerWithContext
 
@@ -74,7 +74,7 @@ type (
 
 	// JWTErrorHandlerWithContext is almost identical to JWTErrorHandler, but it's passed the current context.
 	JWTErrorHandlerWithContext func(error, echo.Context) error
-	
+
 	jwtExtractor func(echo.Context) (string, error)
 )
 
@@ -183,7 +183,7 @@ func JWTWithConfig(config JWTConfig) echo.MiddlewareFunc {
 				if config.ErrorHandler != nil {
 					return config.ErrorHandler(err)
 				}
-				
+
 				if config.ErrorHandlerWithContext != nil {
 					return config.ErrorHandlerWithContext(err, c)
 				}
@@ -210,7 +210,7 @@ func JWTWithConfig(config JWTConfig) echo.MiddlewareFunc {
 				return config.ErrorHandler(err)
 			}
 			if config.ErrorHandlerWithContext != nil {
-					return config.ErrorHandlerWithContext(err, c)
+				return config.ErrorHandlerWithContext(err, c)
 			}
 			return &echo.HTTPError{
 				Code:     http.StatusUnauthorized,

--- a/middleware/jwt_test.go
+++ b/middleware/jwt_test.go
@@ -205,7 +205,7 @@ func TestJWT(t *testing.T) {
 		req.Header.Set(echo.HeaderCookie, tc.hdrCookie)
 		c := e.NewContext(req, res)
 
-		if tc.reqURL == "/" + token {
+		if tc.reqURL == "/"+token {
 			c.SetParamNames("jwt")
 			c.SetParamValues(token)
 		}


### PR DESCRIPTION
Format code by `gofmt` and trim trailing spaces.