### PR TITLE
Fix crash on OpenBSD due to unsupported TCP KeepAlivePeriod

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -856,9 +856,10 @@ func (ln tcpKeepAliveListener) Accept() (c net.Conn, err error) {
 		return
 	} else if err = c.(*net.TCPConn).SetKeepAlive(true); err != nil {
 		return
-	} else if err = c.(*net.TCPConn).SetKeepAlivePeriod(3 * time.Minute); err != nil {
-		return
 	}
+	// Ignore error from setting the KeepAlivePeriod as some systems, such as
+	// OpenBSD, do not support setting TCP_USER_TIMEOUT on IPPROTO_TCP
+	_ = c.(*net.TCPConn).SetKeepAlivePeriod(3 * time.Minute)
 	return
 }
 


### PR DESCRIPTION
On OpenBSD, when the server would accept it's first connection, it would immediately crash with the message `set tcp 127.0.0.1:8082->127.0.0.1:24032: protocol not available`.

This is caused by OpenBSD not supporting changing the TCP_USER_TIMEOUT. Instead they only support setting the TCP KeepAlive Intervals through sysctl. (See issues https://github.com/aerogo/aero/issues/10 and https://github.com/rust-lang-nursery/net2-rs/issues/82)

This patch reverts one of the error handling cases from #1271, and explicitly ignores so to just use the global default KeepAliveInterval if changing it fails. 