### PR TITLE
round-trip pvalues without exploding

### DIFF
--- a/bind_test.go
+++ b/bind_test.go
@@ -332,6 +332,7 @@ func TestBindbindData(t *testing.T) {
 
 func TestBindParam(t *testing.T) {
 	e := New()
+	*e.maxParam = 2
 	req := httptest.NewRequest(GET, "/", nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
@@ -362,6 +363,7 @@ func TestBindParam(t *testing.T) {
 	// Bind something with param and post data payload
 	body := bytes.NewBufferString(`{ "name": "Jon Snow" }`)
 	e2 := New()
+	*e2.maxParam = 2
 	req2 := httptest.NewRequest(POST, "/", body)
 	req2.Header.Set(HeaderContentType, MIMEApplicationJSON)
 

--- a/context.go
+++ b/context.go
@@ -312,7 +312,10 @@ func (c *context) ParamValues() []string {
 }
 
 func (c *context) SetParamValues(values ...string) {
-	c.pvalues = values
+	// NOTE: Don't just set c.pvalues = values, because it has to have length c.echo.maxParam at all times
+	for i, val := range values {
+		c.pvalues[i] = val
+	}
 }
 
 func (c *context) QueryParam(name string) string {

--- a/middleware/jwt_test.go
+++ b/middleware/jwt_test.go
@@ -60,6 +60,8 @@ func TestJWTRace(t *testing.T) {
 
 func TestJWT(t *testing.T) {
 	e := echo.New()
+	r := e.Router()
+	r.Add("GET", "/:jwt", func(echo.Context) error { return nil })
 	handler := func(c echo.Context) error {
 		return c.String(http.StatusOK, "test")
 	}


### PR DESCRIPTION
When upgrading a codebase from echo v3 to v4, I bumped into this: calling `SetParamValues` doesn't protect against resizing`pvalues`, which causes subsequent calls to `Reset` to panic if it becomes smaller than `*e.maxParam`.

It's entirely possible this codebase is doing something it shouldn't, to end up in this state (specifically where `*e.maxParam` != `len(c.pvalues)`?) Regardless, I believe `SetParamValues` shouldn't allow callers to screw up the internals of the context.