### PR TITLE
Add support for 1.13 error chains to HTTPError

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -761,6 +761,12 @@ func (he *HTTPError) SetInternal(err error) *HTTPError {
 	return he
 }
 
+// Unwrap provides compatibility for Go 1.13 error chains.
+// It returns HTTPError.Internal.
+func (he *HTTPError) Unwrap() error {
+	return he.Internal
+}
+
 // WrapHandler wraps `http.Handler` into `echo.HandlerFunc`.
 func WrapHandler(h http.Handler) HandlerFunc {
 	return func(c Context) error {

--- a/echo_test.go
+++ b/echo_test.go
@@ -537,6 +537,12 @@ func TestHTTPError(t *testing.T) {
 	assert.Equal(t, "code=400, message=map[code:12], internal=<nil>", err.Error())
 }
 
+func TestHTTPError_Unwrap(t *testing.T) {
+	expected := errors.New("internal")
+	err := NewHTTPError(http.StatusInternalServerError).SetInternal(expected)
+	assert.EqualError(t, err.Unwrap(), expected.Error())
+}
+
 func TestEchoClose(t *testing.T) {
 	e := New()
 	errCh := make(chan error)


### PR DESCRIPTION
I wish the HTTPError had an Unwrap method.

Sometimes middleware or HTTPErrorHandler needs to examine the HTTPError.Internal returned by a HandlerFunc.

If HTTPError can compatible with the error chain of go 1.13, branching by error type to be simpler.
