### PR TITLE
Fix #1423: Use case sensitive only for bind query params

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -124,7 +124,7 @@ func (b *DefaultBinder) bindData(ptr interface{}, data map[string][]string, tag 
 		}
 
 		inputValue, exists := data[inputFieldName]
-		if !exists {
+		if !exists && tag == "query" {
 			// Go json.Unmarshal supports case insensitive binding.  However the
 			// url params are bound case sensitive which is inconsistent.  To
 			// fix this we must check all of the map values in a

--- a/bind_test.go
+++ b/bind_test.go
@@ -382,6 +382,32 @@ func TestBindParam(t *testing.T) {
 	}
 }
 
+func TestBindParamIgnoreCaseSensitive(t *testing.T) {
+	e := New()
+	*e.maxParam = 1
+
+	body := bytes.NewBufferString(`{ "id": 1, "name": "Jon Snow" }`)
+	req := httptest.NewRequest(POST, "/", body)
+	req.Header.Set(HeaderContentType, MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+
+	ctx := e.NewContext(req, rec)
+	ctx.SetPath("/users/:id")
+	ctx.SetParamNames("id")
+	ctx.SetParamValues("a")
+
+	u2 := new(struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	})
+
+	err := ctx.Bind(u2)
+	if assert.NoError(t, err) {
+		assert.Equal(t, 1, u2.ID)
+		assert.Equal(t, "Jon Snow", u2.Name)
+	}
+}
+
 func TestBindUnmarshalTypeError(t *testing.T) {
 	body := bytes.NewBufferString(`{ "id": "text" }`)
 	e := New()


### PR DESCRIPTION
The problem was being caused because method [bindData](https://github.com/labstack/echo/blob/master/bind.go#L126-L139) tries to get the value when the parameter name does not match with the tag name. 

As this logic seems to make sense only for query parameters, I've added an extra condition to run the case sensitive logic only when the tag is `query`

Fixes #1423 



