### PR TITLE
fix for issue #1492

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -93,7 +93,7 @@ func (responseWriterErr) WriteHeader(statusCode int) {
 
 func TestContext(t *testing.T) {
 	e := New()
-	*e.maxParam = 1
+	e.SetMaxParam(1)
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(userJSON))
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec).(*context)
@@ -472,7 +472,7 @@ func TestContextPath(t *testing.T) {
 
 func TestContextPathParam(t *testing.T) {
 	e := New()
-	*e.maxParam = 2
+	e.SetMaxParam(2)
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	c := e.NewContext(req, nil)
 
@@ -491,7 +491,7 @@ func TestContextPathParam(t *testing.T) {
 
 func TestContextGetAndSetParam(t *testing.T) {
 	e := New()
-	*e.maxParam = 2
+	e.SetMaxParam(2)
 	req := httptest.NewRequest(http.MethodGet, "/:foo", nil)
 	c := e.NewContext(req, nil)
 	c.SetParamNames("foo")

--- a/echo.go
+++ b/echo.go
@@ -771,6 +771,11 @@ func (e *Echo) Shutdown(ctx stdContext.Context) error {
 	return e.Server.Shutdown(ctx)
 }
 
+// SetMaxParam controls the number of path parameters allowed in the context
+func (e *Echo) SetMaxParam(maxParam int) {
+	e.maxParam = &maxParam
+}
+
 // NewHTTPError creates a new HTTPError instance.
 func NewHTTPError(code int, message ...interface{}) *HTTPError {
 	he := &HTTPError{Code: code, Message: http.StatusText(code)}

--- a/echo_test.go
+++ b/echo_test.go
@@ -590,3 +590,10 @@ func TestEchoShutdown(t *testing.T) {
 	err := <-errCh
 	assert.Equal(t, err.Error(), "http: Server closed")
 }
+
+func TestEchoSetMaxParam(t *testing.T) {
+	e := New()
+	assert.Zero(t, *e.maxParam, "Default number of maximum paramers should be zero")
+	e.SetMaxParam(4)
+	assert.Equal(t, 4, *e.maxParam, "Maximum number of parameters should have been modified")
+}


### PR DESCRIPTION
Add the ability to modify the maximum number of parameters from outside the package so that it can be usable when testing