### PR TITLE
Fix #1493 router loop for param routes

### DIFF
--- a/router_test.go
+++ b/router_test.go
@@ -1184,6 +1184,26 @@ func TestRouterParam1466(t *testing.T) {
 	assert.Equal(t, "self", c.Param("type"))
 }
 
+// Issue #1493
+func TestRouterParam1493(t *testing.T) {
+	e := New()
+	r := e.router
+
+	r.Add(http.MethodGet, "/assets/:id", func(c Context) error {
+		return c.String(http.StatusOK, "assetID")
+	})
+
+	c := e.NewContext(nil, nil).(*context)
+
+	// No loop shall occur, param must be empty
+	r.Find(http.MethodGet, "/assets/3/e", c)
+	assert.Equal(t, "", c.Param("id"))
+	assert.Equal(t, 0, c.response.Status)
+	r.Find(http.MethodGet, "/assets/tree/free", c)
+	assert.Equal(t, "", c.Param("id"))
+	assert.Equal(t, 0, c.response.Status)
+}
+
 func benchmarkRouterRoutes(b *testing.B, routes []*Route) {
 	e := New()
 	r := e.router

--- a/router_test.go
+++ b/router_test.go
@@ -1031,12 +1031,15 @@ func TestRouterParamBacktraceNotFound(t *testing.T) {
 	r.Find(http.MethodGet, "/a", c)
 	assert.Equal(t, "a", c.Param("param1"))
 
+	c = e.NewContext(nil, nil).(*context)
 	r.Find(http.MethodGet, "/a/foo", c)
 	assert.Equal(t, "a", c.Param("param1"))
 
+	c = e.NewContext(nil, nil).(*context)
 	r.Find(http.MethodGet, "/a/bar", c)
 	assert.Equal(t, "a", c.Param("param1"))
 
+	c = e.NewContext(nil, nil).(*context)
 	r.Find(http.MethodGet, "/a/bar/b", c)
 	assert.Equal(t, "a", c.Param("param1"))
 	assert.Equal(t, "b", c.Param("param2"))
@@ -1157,49 +1160,43 @@ func TestRouterParam1466(t *testing.T) {
 	r.Find(http.MethodGet, "/users/ajitem", c)
 	assert.Equal(t, "ajitem", c.Param("username"))
 
+	c = e.NewContext(nil, nil).(*context)
 	r.Find(http.MethodGet, "/users/sharewithme", c)
 	assert.Equal(t, "sharewithme", c.Param("username"))
 
+	c = e.NewContext(nil, nil).(*context)
 	r.Find(http.MethodGet, "/users/signup", c)
 	assert.Equal(t, "", c.Param("username"))
 	// Additional assertions for #1479
+	c = e.NewContext(nil, nil).(*context)
 	r.Find(http.MethodGet, "/users/sharewithme/likes/projects/ids", c)
 	assert.Equal(t, "sharewithme", c.Param("username"))
 
+	c = e.NewContext(nil, nil).(*context)
 	r.Find(http.MethodGet, "/users/ajitem/likes/projects/ids", c)
 	assert.Equal(t, "ajitem", c.Param("username"))
 
+	c = e.NewContext(nil, nil).(*context)
 	r.Find(http.MethodGet, "/users/sharewithme/profile", c)
 	assert.Equal(t, "sharewithme", c.Param("username"))
 
+	c = e.NewContext(nil, nil).(*context)
 	r.Find(http.MethodGet, "/users/ajitem/profile", c)
 	assert.Equal(t, "ajitem", c.Param("username"))
 
+	c = e.NewContext(nil, nil).(*context)
 	r.Find(http.MethodGet, "/users/sharewithme/uploads/self", c)
 	assert.Equal(t, "sharewithme", c.Param("username"))
 	assert.Equal(t, "self", c.Param("type"))
 
+	c = e.NewContext(nil, nil).(*context)
 	r.Find(http.MethodGet, "/users/ajitem/uploads/self", c)
 	assert.Equal(t, "ajitem", c.Param("username"))
 	assert.Equal(t, "self", c.Param("type"))
-}
 
-// Issue #1493
-func TestRouterParam1493(t *testing.T) {
-	e := New()
-	r := e.router
-
-	r.Add(http.MethodGet, "/assets/:id", func(c Context) error {
-		return c.String(http.StatusOK, "assetID")
-	})
-
-	c := e.NewContext(nil, nil).(*context)
-
-	// No loop shall occur, param must be empty
-	r.Find(http.MethodGet, "/assets/3/e", c)
-	assert.Equal(t, "", c.Param("id"))
-	assert.Equal(t, 0, c.response.Status)
-	r.Find(http.MethodGet, "/assets/tree/free", c)
+	// Issue #1493 - check for routing loop
+	c = e.NewContext(nil, nil).(*context)
+	r.Find(http.MethodGet, "/users/tree/free", c)
 	assert.Equal(t, "", c.Param("id"))
 	assert.Equal(t, 0, c.response.Status)
 }


### PR DESCRIPTION
This pull request fixes issue #1493, which refers to a router loop recently introduced with commit 5bf6888 to fix param values. The router Find function will now correctly set the parameters and avoid the endless routing loop.

An additional test for the loop has been added (it is reproducable) and some router tests have been corrected to use a fresh context for the tests (to avoid leaking state). 

### Benchmark

Benchmarks are looking good, only minimal changes (~1% for static route performance)

With this patch:

```
rl@slimboy branch:bugfix/1493-# /usr/bin/go test -benchmem -run=^$ github.com/labstack/echo/v4 -bench '^(BenchmarkRouterStaticRoutes|BenchmarkRouterGitHubAPI|BenchmarkRouterParseAPI|BenchmarkRouterGooglePlusAPI)$'
goos: linux
goarch: amd64
pkg: github.com/labstack/echo/v4
BenchmarkRouterStaticRoutes-8    	  91005	    11681 ns/op	      0 B/op	      0 allocs/op
BenchmarkRouterGitHubAPI-8       	  48444	    24682 ns/op	      1 B/op	      0 allocs/op
BenchmarkRouterParseAPI-8        	 293914	     3933 ns/op	      0 B/op	      0 allocs/op
BenchmarkRouterGooglePlusAPI-8   	 187198	     6247 ns/op	      0 B/op	      0 allocs/op
PASS
ok  	github.com/labstack/echo/v4	5.083s
```

Before the patch (master@75620e6, some commits after v4.1.14):

```
rl@slimboy branch:master# /usr/bin/go test -benchmem -run=^$ github.com/labstack/echo/v4 -bench '^(BenchmarkRouterStaticRoutes|BenchmarkRouterGitHubAPI|BenchmarkRouterParseAPI|BenchmarkRouterGooglePlusAPI)$'
goos: linux
goarch: amd64
pkg: github.com/labstack/echo/v4
BenchmarkRouterStaticRoutes-8    	  93324	    11502 ns/op	      0 B/op	      0 allocs/op
BenchmarkRouterGitHubAPI-8       	  46220	    25976 ns/op	      1 B/op	      0 allocs/op
BenchmarkRouterParseAPI-8        	 276850	     3974 ns/op	      0 B/op	      0 allocs/op
BenchmarkRouterGooglePlusAPI-8   	 193024	     6177 ns/op	      0 B/op	      0 allocs/op
PASS
ok  	github.com/labstack/echo/v4	5.075s
```
