### PR TITLE
Fix #1457 by adding context.MatchedRoute() method

### DIFF
--- a/context.go
+++ b/context.go
@@ -45,6 +45,10 @@ type (
 		// or `X-Real-IP` request header.
 		RealIP() string
 
+		// MatchedRoute returns the chosen path of all registeres routes.
+		// Only a registered path will be returned, otherwise empty
+		MatchedRoute() string
+
 		// Path returns the registered path for the handler.
 		Path() string
 
@@ -278,6 +282,16 @@ func (c *context) RealIP() string {
 	}
 	ra, _, _ := net.SplitHostPort(c.request.RemoteAddr)
 	return ra
+}
+
+func (c *context) MatchedRoute() string {
+	pathx := c.Path()
+	for _, r := range c.Echo().Routes() {
+		if pathx == r.Path {
+			return r.Path
+		}
+	}
+	return ""
 }
 
 func (c *context) Path() string {

--- a/context_test.go
+++ b/context_test.go
@@ -666,6 +666,25 @@ func TestContext_Path(t *testing.T) {
 	testify.Equal(t, path, c.Path())
 }
 
+func TestContext_MatchedRoute(t *testing.T) {
+	e := New()
+	e.Add("GET", "/pa/th", func(c Context) error {
+		return nil
+	})
+
+	// Valid path of a registered route
+	c := e.NewContext(nil, nil)
+	path := "/pa/th"
+	c.SetPath(path)
+	testify.Equal(t, path, c.MatchedRoute())
+
+	// Empty string for a non existing path
+	c = e.NewContext(nil, nil)
+	path = "/not/existing"
+	c.SetPath(path)
+	testify.Equal(t, "", c.MatchedRoute())
+}
+
 type validator struct{}
 
 func (*validator) Validate(i interface{}) error {


### PR DESCRIPTION
This PR fixes issue #1457 by adding a MatchedRoute method to context that will only return the path of a registered route.
This will allow for easier identification of matched routes and metric providers to return a limited set of known routes.

The method is based on code that we used as a helper method to filter known paths for providing metrics of requested URIs.

Tests have been added. 