### PR TITLE
Fix routing conflict for dynamic routes and static route with common prefix (#1509)

### DIFF
--- a/router.go
+++ b/router.go
@@ -347,7 +347,14 @@ func (r *Router) Find(method, path string, c Context) {
 		if l == pl {
 			// Continue search
 			search = search[l:]
-		} else {
+			// Finish routing if no remaining search and we are on an leaf node
+			if search == "" && (cn.ppath != "" || cn.parent == nil) {
+				break
+			}
+		}
+
+		// Attempt to go back up the tree on no matching prefix or no remaining search
+		if l != pl || search == "" {
 			if nn == nil { // Issue #1348
 				return // Not found
 			}
@@ -358,10 +365,6 @@ func (r *Router) Find(method, path string, c Context) {
 			} else if nk == akind {
 				goto Any
 			}
-		}
-
-		if search == "" {
-			break
 		}
 
 		// Static node

--- a/router.go
+++ b/router.go
@@ -348,7 +348,7 @@ func (r *Router) Find(method, path string, c Context) {
 			// Continue search
 			search = search[l:]
 			// Finish routing if no remaining search and we are on an leaf node
-			if search == "" && (cn.ppath != "" || cn.parent == nil) {
+			if search == "" && (nn == nil || cn.parent == nil || cn.ppath != "") {
 				break
 			}
 		}

--- a/router_test.go
+++ b/router_test.go
@@ -567,6 +567,32 @@ func TestRouterParamWithSlash(t *testing.T) {
 	})
 }
 
+// Issue #1509
+func TestRouterParamStaticConflict(t *testing.T) {
+	e := New()
+	r := e.router
+	handler := func(c Context) error {
+		c.Set("path", c.Path())
+		return nil
+	}
+
+	g := e.Group("/g")
+	g.GET("/skills", handler)
+	g.GET("/status", handler)
+	g.GET("/:name", handler)
+
+	c := e.NewContext(nil, nil).(*context)
+	r.Find(http.MethodGet, "/g/s", c)
+	c.handler(c)
+	assert.Equal(t, "s", c.Param("name"))
+	assert.Equal(t, "/g/:name", c.Get("path"))
+
+	c = e.NewContext(nil, nil).(*context)
+	r.Find(http.MethodGet, "/g/status", c)
+	c.handler(c)
+	assert.Equal(t, "/g/status", c.Get("path"))
+}
+
 func TestRouterMatchAny(t *testing.T) {
 	e := New()
 	r := e.router


### PR DESCRIPTION
This PR resolves issue #1509 

A routing conflict is caused by radix tree node splits on common prefix of static routes together with a param route on the same level. An additional test has been added for this issue.

This patch actually ensures that routing will continue back up the route tree in that case.