### PR TITLE
Omit `internal=<nil>` in error strings

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -783,6 +783,9 @@ func NewHTTPError(code int, message ...interface{}) *HTTPError {
 
 // Error makes it compatible with `error` interface.
 func (he *HTTPError) Error() string {
+	if he.Internal == nil {
+		return fmt.Sprintf("code=%d, message=%v", he.Code, he.Message)
+	}
 	return fmt.Sprintf("code=%d, message=%v, internal=%v", he.Code, he.Message, he.Internal)
 }
 

--- a/echo_test.go
+++ b/echo_test.go
@@ -543,10 +543,21 @@ func request(method, path string, e *Echo) (int, string) {
 }
 
 func TestHTTPError(t *testing.T) {
-	err := NewHTTPError(http.StatusBadRequest, map[string]interface{}{
-		"code": 12,
+	t.Run("non-internal", func(t *testing.T) {
+		err := NewHTTPError(http.StatusBadRequest, map[string]interface{}{
+			"code": 12,
+		})
+
+		assert.Equal(t, "code=400, message=map[code:12]", err.Error())
+
 	})
-	assert.Equal(t, "code=400, message=map[code:12], internal=<nil>", err.Error())
+	t.Run("internal", func(t *testing.T) {
+		err := NewHTTPError(http.StatusBadRequest, map[string]interface{}{
+			"code": 12,
+		})
+		err.SetInternal(errors.New("internal error"))
+		assert.Equal(t, "code=400, message=map[code:12], internal=internal error", err.Error())
+	})
 }
 
 func TestEchoClose(t *testing.T) {


### PR DESCRIPTION
The addition of  `internal=%v` to the `HTTPError.Error()` output broke a number of our tests, and introduces a rather strange looking `internal=<nil>` field to the vast majority of our errors.

This PR omits that field, when it is nil.