### PR TITLE
Call skipper func after handler calling in the logger middleware

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -107,10 +107,6 @@ func LoggerWithConfig(config LoggerConfig) echo.MiddlewareFunc {
 
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) (err error) {
-			if config.Skipper(c) {
-				return next(c)
-			}
-
 			req := c.Request()
 			res := c.Response()
 			start := time.Now()

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -114,10 +114,17 @@ func LoggerWithConfig(config LoggerConfig) echo.MiddlewareFunc {
 			req := c.Request()
 			res := c.Response()
 			start := time.Now()
+
 			if err = next(c); err != nil {
 				c.Error(err)
 			}
+
+			if config.Skipper(c) {
+				return
+			}
+
 			stop := time.Now()
+
 			buf := config.pool.Get().(*bytes.Buffer)
 			buf.Reset()
 			defer config.pool.Put(buf)

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -185,17 +185,21 @@ func TestLoggerSkipperAfterHandler(t *testing.T) {
 		}),
 	)
 
-	e.GET("/skip", func(c echo.Context) error {
-		return c.NoContent(http.StatusBadRequest)
-	})
-	e.GET("/log", func(c echo.Context) error {
-		return c.NoContent(http.StatusNotFound)
-	})
+	handler := func(status int) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			return c.NoContent(status)
+		}
+	}
+
+	e.GET("/ok", handler(http.StatusOK))
+	e.GET("/skip", handler(http.StatusBadRequest))
+	e.GET("/log", handler(http.StatusNotFound))
 
 	tests := []struct {
 		path string
 		logged bool
 	}{
+		{path: "/ok", logged: true},
 		{path: "/skip", logged: false},
 		{path: "/log", logged: true},
 	}

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -196,7 +196,7 @@ func TestLoggerSkipperAfterHandler(t *testing.T) {
 	e.GET("/log", handler(http.StatusNotFound))
 
 	tests := []struct {
-		path string
+		path   string
 		logged bool
 	}{
 		{path: "/ok", logged: true},
@@ -213,5 +213,28 @@ func TestLoggerSkipperAfterHandler(t *testing.T) {
 		e.ServeHTTP(rec, req)
 
 		assert.Equal(t, test.logged, buf.Len() != 0, "path: %s", test.path)
+	}
+}
+
+func BenchmarkLoggerSkipping(b *testing.B) {
+	logger := LoggerWithConfig(LoggerConfig{
+		Output: new(bytes.Buffer),
+		Skipper: func(_ echo.Context) bool {
+			return true
+		},
+	})
+
+	handler := logger(func(c echo.Context) error {
+		return nil
+	})
+
+	e := echo.New()
+	c := e.NewContext(
+		httptest.NewRequest(http.MethodGet, "/", nil),
+		httptest.NewRecorder(),
+	)
+
+	for i := 0; i < b.N; i++ {
+		_ = handler(c)
 	}
 }


### PR DESCRIPTION
It's not possible now to decide if the log matters based on the response status code or any other state, that the handler sets.  
I've added the opportunity to do that.

**Usage example:**
Let's say you want to log only failed requests in the production environment, so you can just use skipper func:
```go
func skipperFunc(env config.Environment) middleware.Skipper {
	return func(c echo.Context) bool {
		status := c.Response().Status
		return env == config.EnvProduction && status >= 200 && status <= 299
	}
}
```
