### PR TITLE
Fix #1499 c.SetParamValues - runtime error: index out of range [0]

### DIFF
--- a/context.go
+++ b/context.go
@@ -318,7 +318,7 @@ func (c *context) ParamValues() []string {
 
 func (c *context) SetParamValues(values ...string) {
 	// NOTE: Don't just set c.pvalues = values, because it has to have length c.echo.maxParam at all times
-	if len(c.pvalues) != len(c.pnames) {
+	if len(values) != len(c.pnames) {
 		return
 	}
 	c.pvalues = values

--- a/context.go
+++ b/context.go
@@ -317,11 +317,9 @@ func (c *context) ParamValues() []string {
 }
 
 func (c *context) SetParamValues(values ...string) {
-	// NOTE: Don't just set c.pvalues = values, because it has to have length c.echo.maxParam at all times
-	if len(values) != len(c.pnames) {
-		return
+	for _, val := range values {
+		c.pvalues = append(c.pvalues, val)
 	}
-	c.pvalues = values
 }
 
 func (c *context) QueryParam(name string) string {

--- a/context.go
+++ b/context.go
@@ -318,9 +318,10 @@ func (c *context) ParamValues() []string {
 
 func (c *context) SetParamValues(values ...string) {
 	// NOTE: Don't just set c.pvalues = values, because it has to have length c.echo.maxParam at all times
-	for i, val := range values {
-		c.pvalues[i] = val
+	if len(c.pvalues) != len(c.pnames) {
+		return
 	}
+	c.pvalues = values
 }
 
 func (c *context) QueryParam(name string) string {


### PR DESCRIPTION
issue description: https://github.com/labstack/echo/issues/1499

why: testing setParamValues() always returned -->  runtime error: index out of range [0]

Solution: Validated pvalues and pnames parity then set pvalues with values safely