### PR TITLE
Closes #1499

### DIFF
--- a/context.go
+++ b/context.go
@@ -310,6 +310,7 @@ func (c *context) ParamNames() []string {
 
 func (c *context) SetParamNames(names ...string) {
 	c.pnames = names
+	c.pvalues = make([]string, len(c.pnames))
 }
 
 func (c *context) ParamValues() []string {
@@ -317,7 +318,10 @@ func (c *context) ParamValues() []string {
 }
 
 func (c *context) SetParamValues(values ...string) {
-	// NOTE: Don't just set c.pvalues = values, because it has to have length c.echo.maxParam at all times
+	// NOTE: Don't just set c.pvalues = values, because it has to have length c.pnames at all times
+	if len(c.pnames) == 0 {
+		panic("Please call `c.SetParamNames` before setting param values")
+	}
 	for i, val := range values {
 		c.pvalues[i] = val
 	}

--- a/echo.go
+++ b/echo.go
@@ -301,9 +301,8 @@ func New() (e *Echo) {
 		AutoTLSManager: autocert.Manager{
 			Prompt: autocert.AcceptTOS,
 		},
-		Logger:   log.New("echo"),
-		colorer:  color.New(),
-		maxParam: new(int),
+		Logger:  log.New("echo"),
+		colorer: color.New(),
 	}
 	e.Server.Handler = e
 	e.TLSServer.Handler = e
@@ -326,7 +325,6 @@ func (e *Echo) NewContext(r *http.Request, w http.ResponseWriter) Context {
 		response: NewResponse(w, e),
 		store:    make(Map),
 		echo:     e,
-		pvalues:  make([]string, *e.maxParam),
 		handler:  NotFoundHandler,
 	}
 }


### PR DESCRIPTION
Echo use to explicitly set c.pvalues as the input with no check for the length of c.pnames. The `maxparam` vaue directly in the Echo object has been removed in favor of the SetParamNames leading the charge and keeping param values in check. 