### PR TITLE
Fixed double group prefix in Group.File, Group.Add

### DIFF
--- a/group.go
+++ b/group.go
@@ -109,7 +109,7 @@ func (g *Group) Static(prefix, root string) {
 
 // File implements `Echo#File()` for sub-routes within the Group.
 func (g *Group) File(path, file string) {
-	g.file(g.prefix+path, file, g.GET)
+	g.file(path, file, g.GET)
 }
 
 // Add implements `Echo#Add()` for sub-routes within the Group.

--- a/group_test.go
+++ b/group_test.go
@@ -1,7 +1,9 @@
 package echo
 
 import (
+	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,6 +26,19 @@ func TestGroup(t *testing.T) {
 	g.Match([]string{http.MethodGet, http.MethodPost}, "/", h)
 	g.Static("/static", "/tmp")
 	g.File("/walle", "_fixture/images//walle.png")
+}
+
+func TestGroupFile(t *testing.T) {
+	e := New()
+	g := e.Group("/group")
+	g.File("/walle", "_fixture/images/walle.png")
+	expectedData, err := ioutil.ReadFile("_fixture/images/walle.png")
+	assert.Nil(t, err)
+	req := httptest.NewRequest(http.MethodGet, "/group/walle", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, expectedData, rec.Body.Bytes())
 }
 
 func TestGroupRouteMiddleware(t *testing.T) {


### PR DESCRIPTION
Group.File was padding with g.prefix even though it would later call Group.Add which padded with prefix again - for a total of two times

So if you have a group with prefix `/group`
and added a file `/walle.png` using `group.File`
then it would be available at route /group/group/walle.png