### PR TITLE
Quote regex meta characters in Rewrite

### DIFF
--- a/middleware/rewrite.go
+++ b/middleware/rewrite.go
@@ -57,7 +57,8 @@ func RewriteWithConfig(config RewriteConfig) echo.MiddlewareFunc {
 
 	// Initialize
 	for k, v := range config.Rules {
-		k = strings.Replace(k, "*", "(.*)", -1)
+		k = regexp.QuoteMeta(k)
+		k = strings.Replace(k, `\*`, "(.*)", -1)
 		k = k + "$"
 		config.rulesRegex[regexp.MustCompile(k)] = v
 	}


### PR DESCRIPTION
Currently there is a half and half situation where the user can't use regex (fully) because `*` will be replaced with `(.*)`, yet they also can't just enter any old string, because meta chars like `.` would need escaping.

e.g. currently `*.html` wouldn't work as intended, and instead `*\.html` should be used.

Work around this by using regexp's [`QuoteMeta`](https://godoc.org/regexp#QuoteMeta) function to sanitise the input before handling it.

This is a breaking change, since if someone is already working-around the bug by manually escaping stuff, their escapes would be escaped!