### PR TITLE
use echo.GetPath for rewrite in proxy

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -606,12 +606,12 @@ func (e *Echo) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h := NotFoundHandler
 
 	if e.premiddleware == nil {
-		e.findRouter(r.Host).Find(r.Method, getPath(r), c)
+		e.findRouter(r.Host).Find(r.Method, GetPath(r), c)
 		h = c.Handler()
 		h = applyMiddleware(h, e.middleware...)
 	} else {
 		h = func(c Context) error {
-			e.findRouter(r.Host).Find(r.Method, getPath(r), c)
+			e.findRouter(r.Host).Find(r.Method, GetPath(r), c)
 			h := c.Handler()
 			h = applyMiddleware(h, e.middleware...)
 			return h(c)
@@ -817,7 +817,8 @@ func WrapMiddleware(m func(http.Handler) http.Handler) MiddlewareFunc {
 	}
 }
 
-func getPath(r *http.Request) string {
+// GetPath returns RawPath, if it's empty returns Path from URL
+func GetPath(r *http.Request) string {
 	path := r.URL.RawPath
 	if path == "" {
 		path = r.URL.Path

--- a/middleware/proxy.go
+++ b/middleware/proxy.go
@@ -224,7 +224,7 @@ func ProxyWithConfig(config ProxyConfig) echo.MiddlewareFunc {
 
 			// Rewrite
 			for k, v := range config.rewriteRegex {
-				replacer := captureTokens(k, req.URL.Path)
+				replacer := captureTokens(k, echo.GetPath(req))
 				if replacer != nil {
 					req.URL.Path = replacer.Replace(v)
 				}

--- a/middleware/proxy_test.go
+++ b/middleware/proxy_test.go
@@ -104,6 +104,10 @@ func TestProxy(t *testing.T) {
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, "/user/jack/order/1", req.URL.Path)
 	assert.Equal(t, http.StatusOK, rec.Code)
+  req.URL.Path = "/users/jill/orders/T%2FcO4lW%2Ft%2FVp%2F"
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, "/user/jill/order/T%2FcO4lW%2Ft%2FVp%2F", req.URL.Path)
+	assert.Equal(t, http.StatusOK, rec.Code)
 
 	// ProxyTarget is set in context
 	contextObserver := func(next echo.HandlerFunc) echo.HandlerFunc {


### PR DESCRIPTION
This resolves issue # https://github.com/labstack/echo/issues/1547 

Proxy with Rewrite should use RawPath if it exists, instead of using Path. 

```
e.Group("/mock",
		middleware.ProxyWithConfig(middleware.ProxyConfig{
			Balancer: middleware.NewRoundRobinBalancer([]*middleware.ProxyTarget{{URL:url}}),
			Rewrite: map[string]string{
				"/mock/*": "/$1",
			},
		}))
```

http://localhost:4000/mock/accounts/4rVVGQ4edhovGt4M40vVkRVST6bDH7I1+gYmVqgi2LIuQON12PxT%2FcO4lW%2Ft%2FVp%2F 

**should proxy to** 

http://localhost:4000/accounts/4rVVGQ4edhovGt4M40vVkRVST6bDH7I1+gYmVqgi2LIuQON12PxT%2FcO4lW%2Ft%2FVp%2F 





