### PR TITLE
Test Matrix Go Versions

### DIFF
--- a/.github/workflows/echo.yml
+++ b/.github/workflows/echo.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: [1.11, 1.12, 1.13]
+        go: [1.12, 1.13, 1.14]
     name: ${{ matrix.os }} @ Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
I'm up against an issue where I'm trying to make some test improvements but limited by the differences between `go1.11` and current versions.

I'm attempting to sneak past this limitation by removing `go1.11` from the test matrix and adding `go1.14`.