### PR TITLE
Extend HTTPError to satisfy the Go 1.13 error wrapper interface

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -795,6 +795,11 @@ func (he *HTTPError) SetInternal(err error) *HTTPError {
 	return he
 }
 
+// Unwrap satisfies the Go 1.13 error wrapper interface.
+func (he *HTTPError) Unwrap() error {
+	return he.Internal
+}
+
 // WrapHandler wraps `http.Handler` into `echo.HandlerFunc`.
 func WrapHandler(h http.Handler) HandlerFunc {
 	return func(c Context) error {

--- a/echo_go1.13_test.go
+++ b/echo_go1.13_test.go
@@ -1,0 +1,28 @@
+// +build go1.13
+
+package echo
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHTTPError_Unwrap(t *testing.T) {
+	t.Run("non-internal", func(t *testing.T) {
+		err := NewHTTPError(http.StatusBadRequest, map[string]interface{}{
+			"code": 12,
+		})
+
+		assert.Nil(t, errors.Unwrap(err))
+	})
+	t.Run("internal", func(t *testing.T) {
+		err := NewHTTPError(http.StatusBadRequest, map[string]interface{}{
+			"code": 12,
+		})
+		err.SetInternal(errors.New("internal error"))
+		assert.Equal(t, "internal error", errors.Unwrap(err).Error())
+	})
+}

--- a/echo_test.go
+++ b/echo_test.go
@@ -549,7 +549,6 @@ func TestHTTPError(t *testing.T) {
 		})
 
 		assert.Equal(t, "code=400, message=map[code:12]", err.Error())
-
 	})
 	t.Run("internal", func(t *testing.T) {
 		err := NewHTTPError(http.StatusBadRequest, map[string]interface{}{


### PR DESCRIPTION
I don't see that this has been discussed before in the issues, so my apologies if this has been discussed and rejected for some reason.