### PR TITLE
Fix #1526 trailing slash to any route

### DIFF
--- a/router.go
+++ b/router.go
@@ -355,6 +355,10 @@ func (r *Router) Find(method, path string, c Context) {
 
 		// Attempt to go back up the tree on no matching prefix or no remaining search
 		if l != pl || search == "" {
+			// Handle special case of trailing slash route with existing any route
+			if cn.findChildByKind(akind) != nil { // Issue #1526
+				goto Any
+			}
 			if nn == nil { // Issue #1348
 				return // Not found
 			}

--- a/router.go
+++ b/router.go
@@ -355,8 +355,8 @@ func (r *Router) Find(method, path string, c Context) {
 
 		// Attempt to go back up the tree on no matching prefix or no remaining search
 		if l != pl || search == "" {
-			// Handle special case of trailing slash route with existing any route
-			if cn.findChildByKind(akind) != nil { // Issue #1526
+			// Handle special case of trailing slash route with existing any route (see #1526)
+			if path[len(path)-1] == '/' && cn.findChildByKind(akind) != nil {
 				goto Any
 			}
 			if nn == nil { // Issue #1348

--- a/router_test.go
+++ b/router_test.go
@@ -635,6 +635,7 @@ func TestRouterMatchAnySlash(t *testing.T) {
 	r.Add(http.MethodGet, "/img/*", handler)
 	r.Add(http.MethodGet, "/img/load", handler)
 	r.Add(http.MethodGet, "/img/load/*", handler)
+	r.Add(http.MethodGet, "/assets/*", handler)
 
 	c := e.NewContext(nil, nil).(*context)
 	r.Find(http.MethodGet, "/", c)
@@ -671,6 +672,22 @@ func TestRouterMatchAnySlash(t *testing.T) {
 	c.handler(c)
 	assert.Equal(t, "/img/load/*", c.Get("path"))
 	assert.Equal(t, "ben", c.Param("*"))
+
+	// Test /assets/* any route
+	// ... without trailing slash must not match
+	c = e.NewContext(nil, nil).(*context)
+	r.Find(http.MethodGet, "/assets", c)
+	c.handler(c)
+	assert.Equal(t, nil, c.Get("path"))
+	assert.Equal(t, "", c.Param("*"))
+
+	// ... with trailing slash must match
+	c = e.NewContext(nil, nil).(*context)
+	r.Find(http.MethodGet, "/assets/", c)
+	c.handler(c)
+	assert.Equal(t, "/assets/*", c.Get("path"))
+	assert.Equal(t, "", c.Param("*"))
+
 }
 
 func TestRouterMatchAnyMultiLevel(t *testing.T) {


### PR DESCRIPTION
This PR fixes #1526 to handle a corner case for a request with trailing slash that shall match an any route just below the request path.

`GET /users/` will now correctly match the any route `/users/*`
