### PR TITLE
The directory path does not end with '/', it needs to be redirected

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Lower is better!
 
 ### Installation
 
-```go
+```sh
 // go get github.com/labstack/echo/{version}
 go get github.com/labstack/echo/v4
 ```

--- a/echo_test.go
+++ b/echo_test.go
@@ -76,8 +76,16 @@ func TestEchoStatic(t *testing.T) {
 
 	// Directory
 	e.Static("/images", "_fixture/images")
-	c, _ = request(http.MethodGet, "/images", e)
+	c, _ = request(http.MethodGet, "/images/", e)
 	assert.Equal(http.StatusNotFound, c)
+
+	// Directory Redirect
+	e.Static("/", "_fixture")
+	req := httptest.NewRequest(http.MethodGet, "/folder", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(http.StatusMovedPermanently, rec.Code)
+	assert.Equal("/folder/", rec.HeaderMap["Location"][0])
 
 	// Directory with index.html
 	e.Static("/", "_fixture")
@@ -86,9 +94,10 @@ func TestEchoStatic(t *testing.T) {
 	assert.Equal(true, strings.HasPrefix(r, "<!doctype html>"))
 
 	// Sub-directory with index.html
-	c, r = request(http.MethodGet, "/folder", e)
+	c, r = request(http.MethodGet, "/folder/", e)
 	assert.Equal(http.StatusOK, c)
 	assert.Equal(true, strings.HasPrefix(r, "<!doctype html>"))
+
 }
 
 func TestEchoFile(t *testing.T) {

--- a/middleware/recover_test.go
+++ b/middleware/recover_test.go
@@ -2,11 +2,13 @@ package middleware
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/labstack/echo/v4"
+	"github.com/labstack/gommon/log"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,4 +25,59 @@ func TestRecover(t *testing.T) {
 	h(c)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 	assert.Contains(t, buf.String(), "PANIC RECOVER")
+}
+
+func TestRecoverWithConfig_LogLevel(t *testing.T) {
+	tests := []struct {
+		logLevel  log.Lvl
+		levelName string
+	}{{
+		logLevel:  log.DEBUG,
+		levelName: "DEBUG",
+	}, {
+		logLevel:  log.INFO,
+		levelName: "INFO",
+	}, {
+		logLevel:  log.WARN,
+		levelName: "WARN",
+	}, {
+		logLevel:  log.ERROR,
+		levelName: "ERROR",
+	}, {
+		logLevel:  log.OFF,
+		levelName: "OFF",
+	}}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.levelName, func(t *testing.T) {
+			e := echo.New()
+			e.Logger.SetLevel(log.DEBUG)
+
+			buf := new(bytes.Buffer)
+			e.Logger.SetOutput(buf)
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			config := DefaultRecoverConfig
+			config.LogLevel = tt.logLevel
+			h := RecoverWithConfig(config)(echo.HandlerFunc(func(c echo.Context) error {
+				panic("test")
+			}))
+
+			h(c)
+
+			assert.Equal(t, http.StatusInternalServerError, rec.Code)
+
+			output := buf.String()
+			if tt.logLevel == log.OFF {
+				assert.Empty(t, output)
+			} else {
+				assert.Contains(t, output, "PANIC RECOVER")
+				assert.Contains(t, output, fmt.Sprintf(`"level":"%s"`, tt.levelName))
+			}
+		})
+	}
 }


### PR DESCRIPTION
https://github.com/labstack/echo/issues/1533#issue-580533874

**Reference golang source code**

https://github.com/golang/go/blob/cf9b4f63a57b4360be700831781885fc6cf5a0b1/src/net/http/fs.go#L575-L612

```go
	if redirect {
		// redirect to canonical path: / at end of directory url
		// r.URL.Path always begins with /
		url := r.URL.Path
		if d.IsDir() {
			if url[len(url)-1] != '/' {
				localRedirect(w, r, path.Base(url)+"/")
				return
			}
		} else {
			if url[len(url)-1] == '/' {
				localRedirect(w, r, "../"+path.Base(url))
				return
			}
		}
	}


	if d.IsDir() {
		url := r.URL.Path
		// redirect if the directory name doesn't end in a slash
		if url == "" || url[len(url)-1] != '/' {
			localRedirect(w, r, path.Base(url)+"/")
			return
		}


		// use contents of index.html for directory, if present
		index := strings.TrimSuffix(name, "/") + indexPage
		ff, err := fs.Open(index)
		if err == nil {
			defer ff.Close()
			dd, err := ff.Stat()
			if err == nil {
				name = index
				d = dd
				f = ff
			}
		}
	}
```