### PR TITLE
Allow bound interface to be a slice of data 

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -100,6 +100,10 @@ func (b *DefaultBinder) bindData(ptr interface{}, data map[string][]string, tag 
 
 	// !struct
 	if typ.Kind() != reflect.Struct {
+		if tag == "param" || tag == "query" {
+			// incompatible type, data is probably to be found in the body
+			return nil
+		}
 		return errors.New("binding element must be a struct")
 	}
 

--- a/echo_test.go
+++ b/echo_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"reflect"
 	"strings"
 	"testing"
@@ -26,6 +27,7 @@ type (
 
 const (
 	userJSON                    = `{"id":1,"name":"Jon Snow"}`
+	usersJSON                   = `[{"id":1,"name":"Jon Snow"}]`
 	userXML                     = `<user><id>1</id><name>Jon Snow</name></user>`
 	userForm                    = `id=1&name=Jon Snow`
 	invalidContent              = "invalid content"
@@ -43,6 +45,8 @@ const userXMLPretty = `<user>
   <id>1</id>
   <name>Jon Snow</name>
 </user>`
+
+var dummyQuery = url.Values{"dummy": []string{"useless"}}
 
 func TestEcho(t *testing.T) {
 	e := New()


### PR DESCRIPTION
Do not throw an error when binding to a slice, if binding occurs
on path- or query-parameters
=> data is very likely to be found in the body, which will be bound later

Should fix #1356, fix #1448, partially fix #1495 (second case), fix #1565