### PR TITLE
Fix Bindings for empty fields

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -241,9 +241,6 @@ func unmarshalFieldPtr(value string, field reflect.Value) (bool, error) {
 }
 
 func setIntField(value string, bitSize int, field reflect.Value) error {
-	if value == "" {
-		value = "0"
-	}
 	intVal, err := strconv.ParseInt(value, 10, bitSize)
 	if err == nil {
 		field.SetInt(intVal)
@@ -252,9 +249,6 @@ func setIntField(value string, bitSize int, field reflect.Value) error {
 }
 
 func setUintField(value string, bitSize int, field reflect.Value) error {
-	if value == "" {
-		value = "0"
-	}
 	uintVal, err := strconv.ParseUint(value, 10, bitSize)
 	if err == nil {
 		field.SetUint(uintVal)
@@ -263,9 +257,6 @@ func setUintField(value string, bitSize int, field reflect.Value) error {
 }
 
 func setBoolField(value string, field reflect.Value) error {
-	if value == "" {
-		value = "false"
-	}
 	boolVal, err := strconv.ParseBool(value)
 	if err == nil {
 		field.SetBool(boolVal)
@@ -274,9 +265,6 @@ func setBoolField(value string, field reflect.Value) error {
 }
 
 func setFloatField(value string, bitSize int, field reflect.Value) error {
-	if value == "" {
-		value = "0.0"
-	}
 	floatVal, err := strconv.ParseFloat(value, bitSize)
 	if err == nil {
 		field.SetFloat(floatVal)

--- a/bind_test.go
+++ b/bind_test.go
@@ -435,33 +435,25 @@ func TestBindSetFields(t *testing.T) {
 	if assert.NoError(setIntField("5", 0, val.FieldByName("I"))) {
 		assert.Equal(5, ts.I)
 	}
-	if assert.NoError(setIntField("", 0, val.FieldByName("I"))) {
-		assert.Equal(0, ts.I)
-	}
+	assert.Error(setIntField("", 0, val.FieldByName("I")))
 
 	// Uint
 	if assert.NoError(setUintField("10", 0, val.FieldByName("UI"))) {
 		assert.Equal(uint(10), ts.UI)
 	}
-	if assert.NoError(setUintField("", 0, val.FieldByName("UI"))) {
-		assert.Equal(uint(0), ts.UI)
-	}
+	assert.Error(setUintField("", 0, val.FieldByName("UI")))
 
 	// Float
 	if assert.NoError(setFloatField("15.5", 0, val.FieldByName("F32"))) {
 		assert.Equal(float32(15.5), ts.F32)
 	}
-	if assert.NoError(setFloatField("", 0, val.FieldByName("F32"))) {
-		assert.Equal(float32(0.0), ts.F32)
-	}
+	assert.Error(setFloatField("", 0, val.FieldByName("F32")))
 
 	// Bool
 	if assert.NoError(setBoolField("true", val.FieldByName("B"))) {
 		assert.Equal(true, ts.B)
 	}
-	if assert.NoError(setBoolField("", val.FieldByName("B"))) {
-		assert.Equal(false, ts.B)
-	}
+	assert.Error(setBoolField("", val.FieldByName("B")))
 
 	ok, err := unmarshalFieldNonPtr("2016-12-06T19:09:05Z", val.FieldByName("T"))
 	if assert.NoError(err) {


### PR DESCRIPTION
This PR is related to the already discussed issue (https://github.com/labstack/echo/issues/1521).

Without that fix empty fields have default values during binding that does not fail. This situation makes it difficult to validate requests later.

For instance, I had an empty required bool field in the request. It turns into `false`, binding works without error and the filed passes subsequent validation. This is not a valid behaviour. We would like bindings to fail in such cases like json.Umsarshal. If you try to unmarshal empty field into a bool, it will fail with error.

PR should be tagged as v5.