### PR TITLE
Fixes the uses of caret(^) in rewrite regex

### DIFF
--- a/middleware/rewrite.go
+++ b/middleware/rewrite.go
@@ -59,6 +59,9 @@ func RewriteWithConfig(config RewriteConfig) echo.MiddlewareFunc {
 	for k, v := range config.Rules {
 		k = regexp.QuoteMeta(k)
 		k = strings.Replace(k, `\*`, "(.*)", -1)
+		if strings.HasPrefix(k, `\^`) {
+			k = strings.Replace(k, `\^`, "^", -1)
+		}
 		k = k + "$"
 		config.rulesRegex[regexp.MustCompile(k)] = v
 	}

--- a/middleware/rewrite.go
+++ b/middleware/rewrite.go
@@ -59,7 +59,11 @@ func RewriteWithConfig(config RewriteConfig) echo.MiddlewareFunc {
 	for k, v := range config.Rules {
 		k = regexp.QuoteMeta(k)
 		k = strings.Replace(k, `\*`, "(.*)", -1)
+		k = strings.Replace(k, `\^`, "^", -1)
 		k = k + "$"
+		if strings.HasPrefix(k, "/") {
+			k = "^" + k
+		}
 		config.rulesRegex[regexp.MustCompile(k)] = v
 	}
 

--- a/middleware/rewrite.go
+++ b/middleware/rewrite.go
@@ -59,11 +59,7 @@ func RewriteWithConfig(config RewriteConfig) echo.MiddlewareFunc {
 	for k, v := range config.Rules {
 		k = regexp.QuoteMeta(k)
 		k = strings.Replace(k, `\*`, "(.*)", -1)
-		k = strings.Replace(k, `\^`, "^", -1)
 		k = k + "$"
-		if strings.HasPrefix(k, "/") {
-			k = "^" + k
-		}
 		config.rulesRegex[regexp.MustCompile(k)] = v
 	}
 

--- a/middleware/rewrite_test.go
+++ b/middleware/rewrite_test.go
@@ -18,10 +18,6 @@ func TestRewrite(t *testing.T) {
 			"/api/*":            "/$1",
 			"/js/*":             "/public/javascripts/$1",
 			"/users/*/orders/*": "/user/$1/order/$2",
-			"/foo/*":            "/v1/foo/$1",
-			"/v1/foo/*":         "/v1/foo/$1",
-			"/v2/foo/*":         "/v2/foo/$1",
-			"^/bar/*":           "/foobar/$1",
 		},
 	}))
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -41,18 +37,6 @@ func TestRewrite(t *testing.T) {
 	req.URL.Path = "/api/new users"
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, "/new users", req.URL.Path)
-	req.URL.Path = "/foo/bar"
-	e.ServeHTTP(rec, req)
-	assert.Equal(t, "/v1/foo/bar", req.URL.Path)
-	req.URL.Path = "/v1/foo/bar"
-	e.ServeHTTP(rec, req)
-	assert.Equal(t, "/v1/foo/bar", req.URL.Path)
-	req.URL.Path = "/v2/foo/bar"
-	e.ServeHTTP(rec, req)
-	assert.Equal(t, "/v2/foo/bar", req.URL.Path)
-	req.URL.Path = "/bar/baz"
-	e.ServeHTTP(rec, req)
-	assert.Equal(t, "/foobar/baz", req.URL.Path)
 }
 
 // Issue #1086

--- a/middleware/rewrite_test.go
+++ b/middleware/rewrite_test.go
@@ -18,6 +18,10 @@ func TestRewrite(t *testing.T) {
 			"/api/*":            "/$1",
 			"/js/*":             "/public/javascripts/$1",
 			"/users/*/orders/*": "/user/$1/order/$2",
+			"/foo/*":            "/v1/foo/$1",
+			"/v1/foo/*":         "/v1/foo/$1",
+			"/v2/foo/*":         "/v2/foo/$1",
+			"^/bar/*":           "/foobar/$1",
 		},
 	}))
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -37,6 +41,18 @@ func TestRewrite(t *testing.T) {
 	req.URL.Path = "/api/new users"
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, "/new users", req.URL.Path)
+	req.URL.Path = "/foo/bar"
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, "/v1/foo/bar", req.URL.Path)
+	req.URL.Path = "/v1/foo/bar"
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, "/v1/foo/bar", req.URL.Path)
+	req.URL.Path = "/v2/foo/bar"
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, "/v2/foo/bar", req.URL.Path)
+	req.URL.Path = "/bar/baz"
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, "/foobar/baz", req.URL.Path)
 }
 
 // Issue #1086


### PR DESCRIPTION
Fixes #1573

When use `QuoteMeta`，`^` will be replaced to `\^`, and than out of action as regex element.