### PR TITLE
make gzipResponseWriter implement http.Pusher

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -119,3 +119,10 @@ func (w *gzipResponseWriter) Flush() {
 func (w *gzipResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return w.ResponseWriter.(http.Hijacker).Hijack()
 }
+
+func (w *gzipResponseWriter) Push(target string, opts *http.PushOptions) error {
+	if p, ok := w.ResponseWriter.(http.Pusher); ok {
+		return p.Push(target, opts)
+	}
+	return http.ErrNotSupported
+}


### PR DESCRIPTION
This PR fixes #1602.

This PR make gzipResponseWriter implement http.Pusher.
As described in [http.Pusher](https://golang.org/pkg/net/http/#Pusher) comments, Push returns http.ErrNotSupported when ResponseWriter does not implement http.Pusher

> Push returns ErrNotSupported if the client has disabled push or if push
> is not supported on the underlying connection.