### PR TITLE
added ModifyResponse option to ProxyConfig

### DIFF
--- a/middleware/proxy.go
+++ b/middleware/proxy.go
@@ -45,6 +45,9 @@ type (
 		// Examples: If custom TLS certificates are required.
 		Transport http.RoundTripper
 
+		// ModifyResponse defines function to modify response from ProxyTarget.
+		ModifyResponse func(*http.Response) error
+
 		rewriteRegex map[*regexp.Regexp]string
 	}
 

--- a/middleware/proxy_1_11.go
+++ b/middleware/proxy_1_11.go
@@ -20,5 +20,6 @@ func proxyHTTP(tgt *ProxyTarget, c echo.Context, config ProxyConfig) http.Handle
 		c.Set("_error", echo.NewHTTPError(http.StatusBadGateway, fmt.Sprintf("remote %s unreachable, could not forward: %v", desc, err)))
 	}
 	proxy.Transport = config.Transport
+	proxy.ModifyResponse = config.ModifyResponse
 	return proxy
 }


### PR DESCRIPTION
Proxied response can be easily modified with optional built in function of ReverseProxy from core Go package "net/http/httputil".