### PR TITLE
bugfix proxy and rewrite, updated test with actual call settings

### DIFF
--- a/middleware/proxy_test.go
+++ b/middleware/proxy_test.go
@@ -94,36 +94,35 @@ func TestProxy(t *testing.T) {
 			"/users/*/orders/*": "/user/$1/order/$2",
 		},
 	}))
-	req.URL.Path = "/api/users"
+	req.URL, _ = url.Parse("/api/users")
 	rec = httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, "/users", req.URL.EscapedPath())
 	assert.Equal(t, http.StatusOK, rec.Code)
-	req.URL.Path = "/js/main.js"
+	req.URL, _ = url.Parse( "/js/main.js")
 	rec = httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, "/public/javascripts/main.js", req.URL.EscapedPath())
 	assert.Equal(t, http.StatusOK, rec.Code)
-	req.URL.Path = "/old"
+	req.URL, _ = url.Parse("/old")
 	rec = httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, "/new", req.URL.EscapedPath())
 	assert.Equal(t, http.StatusOK, rec.Code)
-	req.URL.Path = "/users/jack/orders/1"
+	req.URL, _ = url.Parse( "/users/jack/orders/1")
 	rec = httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, "/user/jack/order/1", req.URL.EscapedPath())
 	assert.Equal(t, http.StatusOK, rec.Code)
-	req.URL.Path = "/users/jill/orders/T%2FcO4lW%2Ft%2FVp%2F"
+	req.URL, _ = url.Parse("/user/jill/order/T%2FcO4lW%2Ft%2FVp%2F")
 	rec = httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, "/user/jill/order/T%2FcO4lW%2Ft%2FVp%2F", req.URL.EscapedPath())
 	assert.Equal(t, http.StatusOK, rec.Code)
-	req.URL.Path =  "/users/jill/orders/%%%%"
+	req.URL, _ = url.Parse("/api/new users")
 	rec = httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
-
+	assert.Equal(t, "/new%20users", req.URL.EscapedPath())
 	// ModifyResponse
 	e = echo.New()
 	e.Use(ProxyWithConfig(ProxyConfig{

--- a/middleware/rewrite_test.go
+++ b/middleware/rewrite_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/labstack/echo/v4"
@@ -23,33 +24,28 @@ func TestRewrite(t *testing.T) {
 	}))
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
-	req.URL.Path = "/api/users"
+	req.URL, _ = url.Parse("/api/users")
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, "/users", req.URL.EscapedPath())
-	req.URL.Path = "/js/main.js"
+	req.URL, _ = url.Parse("/js/main.js")
 	rec = httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, "/public/javascripts/main.js", req.URL.EscapedPath())
-	req.URL.Path = "/old"
+	req.URL, _ = url.Parse("/old")
 	rec = httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, "/new", req.URL.EscapedPath())
-	req.URL.Path = "/users/jack/orders/1"
+	req.URL, _ = url.Parse("/users/jack/orders/1")
 	rec = httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, "/user/jack/order/1", req.URL.EscapedPath())
-	req.URL.Path = "/api/new users"
-	rec = httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-	assert.Equal(t, "/new%20users", req.URL.EscapedPath())
-	req.URL.Path = "/users/jill/orders/T%2FcO4lW%2Ft%2FVp%2F"
+	req.URL, _ = url.Parse("/user/jill/order/T%2FcO4lW%2Ft%2FVp%2F")
 	rec = httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, "/user/jill/order/T%2FcO4lW%2Ft%2FVp%2F", req.URL.EscapedPath())
-	req.URL.Path = "/users/jill/orders/%%%%"
-	rec = httptest.NewRecorder()
+	req.URL, _ = url.Parse("/api/new users")
 	e.ServeHTTP(rec, req)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, "/new%20users", req.URL.EscapedPath())
 }
 
 // Issue #1086
@@ -58,11 +54,10 @@ func TestEchoRewritePreMiddleware(t *testing.T) {
 	r := e.Router()
 
 	// Rewrite old url to new one
-	e.Pre(RewriteWithConfig(RewriteConfig{
-		Rules: map[string]string{
+	e.Pre(Rewrite(map[string]string{
 			"/old": "/new",
 		},
-	}))
+	))
 
 	// Route
 	r.Add(http.MethodGet, "/new", func(c echo.Context) error {


### PR DESCRIPTION
Issue: Proxy and Rewrite Middleware don't set URL appropriately in tests and this causes different behavior when running tests vs when proxy and rewrite middleware are used in real server mode.

We should use [url Parse](https://golang.org/pkg/net/url/#URL.Parse) method instead.

Check how path, raw path is set when using URL.Parse in this [playground](https://play.golang.org/p/1PvaqYTm7vD) example. This is how url path and raw path is set when running echo server and invoking API endpoints.

After updating tests, was able to find a bug in proxy and rewrite and was able to fix it (and made sure it passes in real scenario calls as well).

Also, refactored some common code that's shared between proxy with rewrite rules and rewrite middleware rules. This also fixed one other bug e.g. the [regex rules](https://github.com/labstack/echo/blob/master/middleware/rewrite.go#L60-L68) for rewrite is different from proxy [regex rules](https://github.com/labstack/echo/blob/master/middleware/proxy.go#L212-L215) when they should be same (rewrite regex rules works as expected).

After refactoring and using common function the below test works in proxy and rewrite (in current master code, proxy test for below scenario would fail):

	u, _:= url.Parse("/api/new users")
	req.URL = u
	rec = httptest.NewRecorder()
	e.ServeHTTP(rec, req)
	assert.Equal(t, "/new%20users", req.URL.EscapedPath()) 