### PR TITLE
Use IndexAny instead of Split to reduce memory allocation 

### DIFF
--- a/context.go
+++ b/context.go
@@ -276,7 +276,11 @@ func (c *context) RealIP() string {
 	}
 	// Fall back to legacy behavior
 	if ip := c.request.Header.Get(HeaderXForwardedFor); ip != "" {
-		return strings.Split(ip, ", ")[0]
+		i := strings.IndexAny(ip, ", ")
+		if i > 0 {
+			return ip[:i]
+		}
+		return ip
 	}
 	if ip := c.request.Header.Get(HeaderXRealIP); ip != "" {
 		return ip

--- a/context_test.go
+++ b/context_test.go
@@ -871,3 +871,12 @@ func TestContext_RealIP(t *testing.T) {
 		testify.Equal(t, tt.s, tt.c.RealIP())
 	}
 }
+
+func BenchmarkRealIPForHeaderXForwardFor(b *testing.B) {
+	c := context{request: &http.Request{
+		Header: http.Header{HeaderXForwardedFor: []string{"127.0.0.1, 127.0.1.1, "}},
+	}}
+	for i := 0; i < b.N; i++ {
+		c.RealIP()
+	}
+}

--- a/context_test.go
+++ b/context_test.go
@@ -72,6 +72,15 @@ func BenchmarkAllocXML(b *testing.B) {
 	}
 }
 
+func BenchmarkRealIPForHeaderXForwardFor(b *testing.B) {
+	c := context{request: &http.Request{
+		Header: http.Header{HeaderXForwardedFor: []string{"127.0.0.1, 127.0.1.1, "}},
+	}}
+	for i := 0; i < b.N; i++ {
+		c.RealIP()
+	}
+}
+
 func (t *Template) Render(w io.Writer, name string, data interface{}, c Context) error {
 	return t.templates.ExecuteTemplate(w, name, data)
 }
@@ -850,6 +859,14 @@ func TestContext_RealIP(t *testing.T) {
 		{
 			&context{
 				request: &http.Request{
+					Header: http.Header{HeaderXForwardedFor: []string{"127.0.0.1"}},
+				},
+			},
+			"127.0.0.1",
+		},
+		{
+			&context{
+				request: &http.Request{
 					Header: http.Header{
 						"X-Real-Ip": []string{"192.168.0.1"},
 					},
@@ -869,14 +886,5 @@ func TestContext_RealIP(t *testing.T) {
 
 	for _, tt := range tests {
 		testify.Equal(t, tt.s, tt.c.RealIP())
-	}
-}
-
-func BenchmarkRealIPForHeaderXForwardFor(b *testing.B) {
-	c := context{request: &http.Request{
-		Header: http.Header{HeaderXForwardedFor: []string{"127.0.0.1, 127.0.1.1, "}},
-	}}
-	for i := 0; i < b.N; i++ {
-		c.RealIP()
 	}
 }


### PR DESCRIPTION
benchcmp result:
```
benchcmp is deprecated in favor of benchstat: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
benchmark                                  old ns/op     new ns/op     delta
BenchmarkRealIPForHeaderXForwardFor-12     128           39.7          -68.98%
```

before:
```
goos: darwin
goarch: amd64
pkg: github.com/labstack/echo/v4
BenchmarkRealIP-12       8774244               130 ns/op              48 B/op          1 allocs/op
PASS
ok      github.com/labstack/echo/v4     1.297s
```

after:
```
goos: darwin
goarch: amd64
pkg: github.com/labstack/echo/v4
BenchmarkRealIP-12      28132903                38.2 ns/op             0 B/op          0 allocs/op
PASS
ok      github.com/labstack/echo/v4     1.133s
```