### PR TITLE
Fix Static files route not working

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -496,6 +496,7 @@ func (common) static(prefix, root string, get func(string, HandlerFunc, ...Middl
 		}
 		return c.File(name)
 	}
+	get(prefix, h)
 	if prefix == "/" {
 		return get(prefix+"*", h)
 	}

--- a/echo_test.go
+++ b/echo_test.go
@@ -87,6 +87,14 @@ func TestEchoStatic(t *testing.T) {
 	assert.Equal(http.StatusMovedPermanently, rec.Code)
 	assert.Equal("/folder/", rec.HeaderMap["Location"][0])
 
+	// Directory Redirect with non-root path
+	e.Static("/static", "_fixture")
+	req = httptest.NewRequest(http.MethodGet, "/static", nil)
+	rec = httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(http.StatusMovedPermanently, rec.Code)
+	assert.Equal("/static/", rec.HeaderMap["Location"][0])
+
 	// Directory with index.html
 	e.Static("/", "_fixture")
 	c, r := request(http.MethodGet, "/", e)
@@ -98,6 +106,40 @@ func TestEchoStatic(t *testing.T) {
 	assert.Equal(http.StatusOK, c)
 	assert.Equal(true, strings.HasPrefix(r, "<!doctype html>"))
 
+}
+
+func TestEchoStaticRedirectIndex(t *testing.T) {
+	assert := assert.New(t)
+	e := New()
+
+	// HandlerFunc
+	e.Static("/static", "_fixture")
+
+	errCh := make(chan error)
+
+	go func() {
+		errCh <- e.Start("127.0.0.1:1323")
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+
+	if resp, err := http.Get("http://127.0.0.1:1323/static"); err == nil {
+		defer resp.Body.Close()
+		assert.Equal(http.StatusOK, resp.StatusCode)
+
+		if body, err := ioutil.ReadAll(resp.Body); err == nil {
+			assert.Equal(true, strings.HasPrefix(string(body), "<!doctype html>"))
+		} else {
+			assert.Fail(err.Error())
+		}
+
+	} else {
+		assert.Fail(err.Error())
+	}
+
+	if err := e.Close(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestEchoFile(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pwli0755/echo/v4
+module github.com/labstack/echo/v4
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/labstack/echo/v4
+module github.com/pwli0755/echo/v4
 
 go 1.15
 


### PR DESCRIPTION
fix 404 error when using Static files route `Echo.Static()`

[related issue]( https://github.com/labstack/echo/issues/1569)
