### PR TITLE
Fix order of adding middleware  by Echo.Use

### DIFF
--- a/middleware/proxy_1_11_test.go
+++ b/middleware/proxy_1_11_test.go
@@ -41,6 +41,9 @@ func TestProxy_1_11(t *testing.T) {
 	// Random
 	e := echo.New()
 	e.Use(Proxy(rb))
+	e.GET("/*", func(c echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	})
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 

--- a/middleware/proxy_test.go
+++ b/middleware/proxy_test.go
@@ -52,6 +52,9 @@ func TestProxy(t *testing.T) {
 	// Random
 	e := echo.New()
 	e.Use(Proxy(rb))
+	e.GET("/", func(c echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	})
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
@@ -74,6 +77,9 @@ func TestProxy(t *testing.T) {
 	rrb := NewRoundRobinBalancer(targets)
 	e = echo.New()
 	e.Use(Proxy(rrb))
+	e.GET("/", func(c echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	})
 	rec = httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 	body = rec.Body.String()
@@ -94,6 +100,9 @@ func TestProxy(t *testing.T) {
 			"/users/*/orders/*": "/user/$1/order/$2",
 		},
 	}))
+	e.GET("/*", func(c echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	})
 	req.URL.Path = "/api/users"
 	rec = httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
@@ -119,7 +128,7 @@ func TestProxy(t *testing.T) {
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, "/user/jill/order/T%2FcO4lW%2Ft%2FVp%2F", req.URL.EscapedPath())
 	assert.Equal(t, http.StatusOK, rec.Code)
-	req.URL.Path =  "/users/jill/orders/%%%%"
+	req.URL.Path = "/users/jill/orders/%%%%"
 	rec = httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
@@ -134,6 +143,9 @@ func TestProxy(t *testing.T) {
 			return nil
 		},
 	}))
+	e.GET("/*", func(c echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	})
 	rec = httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, "modified", rec.Body.String())
@@ -163,6 +175,9 @@ func TestProxyRealIPHeader(t *testing.T) {
 	rrb := NewRoundRobinBalancer([]*ProxyTarget{{Name: "upstream", URL: url}})
 	e := echo.New()
 	e.Use(Proxy(rrb))
+	e.GET("/", func(c echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	})
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 

--- a/middleware/rewrite_test.go
+++ b/middleware/rewrite_test.go
@@ -21,6 +21,9 @@ func TestRewrite(t *testing.T) {
 			"/users/*/orders/*": "/user/$1/order/$2",
 		},
 	}))
+	e.GET("/*", func(c echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	})
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	req.URL.Path = "/api/users"


### PR DESCRIPTION
Middleware is applied for all the path registered before and after `Echo.Use` #1519 
They was adding to `e.middlewares`:
https://github.com/labstack/echo/blob/151ed6b3f150163352985448b5630ab69de40aa5/echo.go#L390
```go
// Use adds middleware to the chain which is run after router.
func (e *Echo) Use(middleware ...MiddlewareFunc) {
	e.middleware = append(e.middleware, middleware...)
}
```
and then all was applying to handler when `Echo.ServeHTTP` called:
https://github.com/labstack/echo/blob/151ed6b3f150163352985448b5630ab69de40aa5/echo.go#L611
```go
	if e.premiddleware == nil {
		e.findRouter(r.Host).Find(r.Method, r.URL.EscapedPath(), c)
		h = c.Handler()
		h = applyMiddleware(h, e.middleware...)
	} else {
		h = func(c Context) error {
			e.findRouter(r.Host).Find(r.Method, r.URL.EscapedPath(), c)
			h := c.Handler()
			h = applyMiddleware(h, e.middleware...)
			return h(c)
		}
		h = applyMiddleware(h, e.premiddleware...)
	}
```

I tried to fix it by applying all middlewares in `echo.add` function.
It pass all tests but proxy_test and rewrite_test becuse these tests call `e.ServeHTTP(rec, req)` and i moved applying middlewares to `Echo.add` and during these tests it never being called. Tests should use `Echo.Get` for passing like `TestEchoMiddleware` in `echo_test.go`:
https://github.com/labstack/echo/blob/151ed6b3f150163352985448b5630ab69de40aa5/echo_test.go#L111
So is my way wrong or tests should be changed?