### PR TITLE
Adding a new config to DefaultBinder

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -19,7 +19,11 @@ type (
 	}
 
 	// DefaultBinder is the default implementation of the Binder interface.
-	DefaultBinder struct{}
+	DefaultBinder struct {
+		// AvoidBindByFieldName avoid binding struct fields by name automatically. If it's set to true, the binding is
+		// only performed when a valid tag is pressent
+		AvoidBindByFieldName bool
+	}
 
 	// BindUnmarshaler is the interface used to wrap the UnmarshalParam method.
 	// Types that don't implement this, but do implement encoding.TextUnmarshaler
@@ -113,13 +117,14 @@ func (b *DefaultBinder) bindData(ptr interface{}, data map[string][]string, tag 
 		inputFieldName := typeField.Tag.Get(tag)
 
 		if inputFieldName == "" {
-			inputFieldName = typeField.Name
 			// If tag is nil, we inspect if the field is a struct.
 			if _, ok := structField.Addr().Interface().(BindUnmarshaler); !ok && structFieldKind == reflect.Struct {
 				if err := b.bindData(structField.Addr().Interface(), data, tag); err != nil {
 					return err
 				}
 				continue
+			} else if b.AvoidBindByFieldName == false {
+				inputFieldName = typeField.Name
 			}
 		}
 

--- a/bind.go
+++ b/bind.go
@@ -21,7 +21,9 @@ type (
 	// DefaultBinder is the default implementation of the Binder interface.
 	DefaultBinder struct {
 		// AvoidBindByFieldName avoid binding struct fields by name automatically. If it's set to true, the binding is
-		// only performed when a valid tag is pressent
+		// only performed when a valid tag is pressent.
+		// This doesn't apply for json/xml encoding. In this case you should use the features provided in the Go stdlib
+		// to achieve this. e.g. If you want to ignore a struct field during binding, you should add the tag `json:"-"`
 		AvoidBindByFieldName bool
 	}
 

--- a/bind_test.go
+++ b/bind_test.go
@@ -347,6 +347,29 @@ func TestBindbindDataAvoidBindByFieldName(t *testing.T) {
 	assertBindTestStructDefaultValues(assert, ts)
 }
 
+func TestBindAvoidBindingJsonStructField(t *testing.T) {
+	type User struct {
+		ID      int  `json:"id"`
+		IsAdmin bool `json:"-"`
+	}
+
+	assert := assert.New(t)
+
+	e := New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(userAvoidBindJSONField))
+	req.Header.Set(HeaderContentType, MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	defaultUser := &User{}
+	b := new(DefaultBinder)
+	b.Bind(defaultUser, c)
+
+	assert.Equal(1, defaultUser.ID)
+	// This should be false because the Zero value of a bool is false and the JSON have it in true
+	assert.Equal(false, defaultUser.IsAdmin)
+}
+
 func TestBindParam(t *testing.T) {
 	e := New()
 	req := httptest.NewRequest(GET, "/", nil)

--- a/bind_test.go
+++ b/bind_test.go
@@ -330,6 +330,23 @@ func TestBindbindData(t *testing.T) {
 	assertBindTestStruct(assert, ts)
 }
 
+func TestBindbindDataByTags(t *testing.T) {
+	assert := assert.New(t)
+	ts := new(bindTestStructWithTags)
+	b := new(DefaultBinder)
+	b.bindData(ts, values, "form")
+	assertBindTestStruct(assert, (*bindTestStruct)(ts))
+}
+
+func TestBindbindDataAvoidBindByFieldName(t *testing.T) {
+	assert := assert.New(t)
+	ts := new(bindTestStruct)
+	b := new(DefaultBinder)
+	b.AvoidBindByFieldName = true
+	b.bindData(ts, values, "form")
+	assertBindTestStructDefaultValues(assert, ts)
+}
+
 func TestBindParam(t *testing.T) {
 	e := New()
 	req := httptest.NewRequest(GET, "/", nil)
@@ -513,6 +530,24 @@ func assertBindTestStruct(a *assert.Assertions, ts *bindTestStruct) {
 	a.Equal(float32(32.5), ts.F32)
 	a.Equal(float64(64.5), ts.F64)
 	a.Equal("test", ts.S)
+	a.Equal("", ts.GetCantSet())
+}
+
+func assertBindTestStructDefaultValues(a *assert.Assertions, ts *bindTestStruct) {
+	a.Equal(0, ts.I)
+	a.Equal(int8(0), ts.I8)
+	a.Equal(int16(0), ts.I16)
+	a.Equal(int32(0), ts.I32)
+	a.Equal(int64(0), ts.I64)
+	a.Equal(uint(0), ts.UI)
+	a.Equal(uint8(0), ts.UI8)
+	a.Equal(uint16(0), ts.UI16)
+	a.Equal(uint32(0), ts.UI32)
+	a.Equal(uint64(0), ts.UI64)
+	a.Equal(false, ts.B)
+	a.Equal(float32(0), ts.F32)
+	a.Equal(float64(0), ts.F64)
+	a.Equal("", ts.S)
 	a.Equal("", ts.GetCantSet())
 }
 

--- a/echo_test.go
+++ b/echo_test.go
@@ -32,6 +32,7 @@ const (
 	userJSONInvalidType         = `{"id":"1","name":"Jon Snow"}`
 	userXMLConvertNumberError   = `<user><id>Number one</id><name>Jon Snow</name></user>`
 	userXMLUnsupportedTypeError = `<user><>Number one</><name>Jon Snow</name></user>`
+	userAvoidBindJSONField      = `{"id": 1, "isAdmin": true}`
 )
 
 const userJSONPretty = `{


### PR DESCRIPTION
Now the DefaultBinder could be configured to avoid binding struct fields by name. This is particularly useful when the user don't want to bind certain struct fields (with this config in true, only the tagged fields will be binded)

Fixes #1620, fixes #1631, partially fixes #1670