### PR TITLE
Add support for Go 1.15 to CI

### DIFF
--- a/.github/workflows/echo.yml
+++ b/.github/workflows/echo.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: [1.12, 1.13, 1.14]
+        go: [1.13, 1.14, 1.15]
     name: ${{ matrix.os }} @ Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/echo.yml
+++ b/.github/workflows/echo.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: [1.13, 1.14, 1.15]
+        go: [1.12, 1.13, 1.14, 1.15]
     name: ${{ matrix.os }} @ Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Since Go 1.15 is released, we should add support for testing against that version. Also, since Go 1.12 is not longer supported, it is removed from the matrix.