### PR TITLE
Adding sync.Pool to Decompress middleware

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -59,7 +59,7 @@ func GzipWithConfig(config GzipConfig) echo.MiddlewareFunc {
 		config.Level = DefaultGzipConfig.Level
 	}
 
-	pool := gzipPool(config)
+	pool := gzipCompressPool(config)
 
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
@@ -133,7 +133,7 @@ func (w *gzipResponseWriter) Push(target string, opts *http.PushOptions) error {
 	return http.ErrNotSupported
 }
 
-func gzipPool(config GzipConfig) sync.Pool {
+func gzipCompressPool(config GzipConfig) sync.Pool {
 	return sync.Pool{
 		New: func() interface{} {
 			w, err := gzip.NewWriterLevel(ioutil.Discard, config.Level)

--- a/middleware/decompress.go
+++ b/middleware/decompress.go
@@ -3,9 +3,12 @@ package middleware
 import (
 	"bytes"
 	"compress/gzip"
-	"github.com/labstack/echo/v4"
 	"io"
 	"io/ioutil"
+	"net/http"
+	"sync"
+
+	"github.com/labstack/echo/v4"
 )
 
 type (
@@ -32,27 +35,63 @@ func Decompress() echo.MiddlewareFunc {
 //DecompressWithConfig decompresses request body based if content encoding type is set to "gzip" with config
 func DecompressWithConfig(config DecompressConfig) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		pool := gzipDecompressPool()
 		return func(c echo.Context) error {
 			if config.Skipper(c) {
 				return next(c)
 			}
 			switch c.Request().Header.Get(echo.HeaderContentEncoding) {
 			case GZIPEncoding:
-				gr, err := gzip.NewReader(c.Request().Body)
-				if err != nil {
+				b := c.Request().Body
+
+				i := pool.Get()
+				gr, ok := i.(*gzip.Reader)
+				if !ok {
+					return echo.NewHTTPError(http.StatusInternalServerError, i.(error).Error())
+				}
+
+				if err := gr.Reset(b); err != nil {
+					pool.Put(gr)
 					if err == io.EOF { //ignore if body is empty
 						return next(c)
 					}
 					return err
 				}
-				defer gr.Close()
 				var buf bytes.Buffer
 				io.Copy(&buf, gr)
+
+				gr.Close()
+				pool.Put(gr)
+
+				b.Close() // http.Request.Body is closed by the Server, but because we are replacing it, it must be closed here
+
 				r := ioutil.NopCloser(&buf)
-				defer r.Close()
 				c.Request().Body = r
 			}
 			return next(c)
 		}
+	}
+}
+
+func gzipDecompressPool() sync.Pool {
+	return sync.Pool{
+		New: func() interface{} {
+			// create with an empty reader (but with GZIP header)
+			w, err := gzip.NewWriterLevel(ioutil.Discard, gzip.BestSpeed)
+			if err != nil {
+				return err
+			}
+
+			b := new(bytes.Buffer)
+			w.Reset(b)
+			w.Flush()
+			w.Close()
+
+			r, err := gzip.NewReader(bytes.NewReader(b.Bytes()))
+			if err != nil {
+				return err
+			}
+			return r
+		},
 	}
 }


### PR DESCRIPTION
Fixing a http.Request.Body leak on the decompress middleware that were not properly Close
Removing the defer on the call to gzip.Reader, because that reader is already exhausted after the call to io.Copy