### PR TITLE
Increasing number of benchmarks on GitHub action

### DIFF
--- a/.github/workflows/echo.yml
+++ b/.github/workflows/echo.yml
@@ -104,12 +104,12 @@ jobs:
       - name: Run Benchmark (Previous)
         run: |
           cd previous
-          go test -run="-" -bench=".*" -count=5 ./... > benchmark.txt
+          go test -run="-" -bench=".*" -count=8 ./... > benchmark.txt
 
       - name: Run Benchmark (New)
         run: |
           cd new
-          go test -run="-" -bench=".*" -count=5 ./... > benchmark.txt
+          go test -run="-" -bench=".*" -count=8 ./... > benchmark.txt
 
       - name: Run Benchstat
         run: |


### PR DESCRIPTION
Now the number of times that the benchmarks are run before being compared is 8 on the GitHub action.