### PR TITLE
Fix Security Vulnerability - Directory Traversal

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -49,7 +49,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -486,7 +485,7 @@ func (common) static(prefix, root string, get func(string, HandlerFunc, ...Middl
 			return err
 		}
 
-		name := filepath.Join(root, path.Clean("/"+p)) // "/"+ for security
+		name := filepath.Join(root, filepath.Clean("/"+p)) // "/"+ for security
 		fi, err := os.Stat(name)
 		if err != nil {
 			// The access path does not exist

--- a/middleware/static.go
+++ b/middleware/static.go
@@ -167,7 +167,7 @@ func StaticWithConfig(config StaticConfig) echo.MiddlewareFunc {
 			if err != nil {
 				return
 			}
-			name := filepath.Join(config.Root, path.Clean("/"+p)) // "/"+ for security
+			name := filepath.Join(config.Root, filepath.Clean("/"+p)) // "/"+ for security
 
 			if config.IgnoreBase {
 				routePath := path.Base(strings.TrimRight(c.Path(), "/*"))


### PR DESCRIPTION
Hi, We are [Apache ServiceComb](https://github.com/apache/servicecomb-service-center) team. labstack/echo is the good project, we use it in our frontend project.

Recently, we have found a security vulnerability.

At echo.go（Line 483）

the static directory is bound by calling e.static ("/", staticPath).

The original intention is to read the root directory.
In Windows platform, POC can be constructed for path traversal.

Attack vector(s) :

```
1) Set up demo
2) In Windows platform, you can traverse through ..\

    POC-Request：

    GET /..\\other-dir/secret.txt HTTP/1.1

    HOST: 127.0.0.1:80

    Accept-Encoding: gzip, deflate

    Accept: */*

    Accept-Language: en

    User-Agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1;
Win64; x64; Trident/5.0)

    Connection: close
```