### PR TITLE
Fix Static files route not working

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -895,4 +895,3 @@ func applyMiddleware(h HandlerFunc, middleware ...MiddlewareFunc) HandlerFunc {
 	}
 	return h
 }
-

--- a/echo.go
+++ b/echo.go
@@ -500,6 +500,7 @@ func (common) static(prefix, root string, get func(string, HandlerFunc, ...Middl
 		}
 		return c.File(name)
 	}
+	get(prefix, h)
 	if prefix == "/" {
 		return get(prefix+"*", h)
 	}

--- a/echo.go
+++ b/echo.go
@@ -895,3 +895,4 @@ func applyMiddleware(h HandlerFunc, middleware ...MiddlewareFunc) HandlerFunc {
 	}
 	return h
 }
+

--- a/echo_test.go
+++ b/echo_test.go
@@ -103,6 +103,15 @@ func TestEchoStatic(t *testing.T) {
 			expectBodyStartsWith: "",
 		},
 		{
+			name:                 "Directory Redirect with non-root path",
+			givenPrefix:          "/static",
+			givenRoot:            "_fixture",
+			whenURL:              "/static",
+			expectStatus:         http.StatusMovedPermanently,
+			expectHeaderLocation: "/static/",
+			expectBodyStartsWith: "",
+		},
+		{
 			name:                 "Directory with index.html",
 			givenPrefix:          "/",
 			givenRoot:            "_fixture",
@@ -158,6 +167,40 @@ func TestEchoStatic(t *testing.T) {
 				assert.False(t, ok)
 			}
 		})
+	}
+}
+
+func TestEchoStaticRedirectIndex(t *testing.T) {
+	assert := assert.New(t)
+	e := New()
+
+	// HandlerFunc
+	e.Static("/static", "_fixture")
+
+	errCh := make(chan error)
+
+	go func() {
+		errCh <- e.Start("127.0.0.1:1323")
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+
+	if resp, err := http.Get("http://127.0.0.1:1323/static"); err == nil {
+		defer resp.Body.Close()
+		assert.Equal(http.StatusOK, resp.StatusCode)
+
+		if body, err := ioutil.ReadAll(resp.Body); err == nil {
+			assert.Equal(true, strings.HasPrefix(string(body), "<!doctype html>"))
+		} else {
+			assert.Fail(err.Error())
+		}
+
+	} else {
+		assert.Fail(err.Error())
+	}
+
+	if err := e.Close(); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
fix 404 error when using Static files route Echo.Static()
resubmit of [#1671 ](https://github.com/labstack/echo/pull/1671)
[related issue](https://github.com/labstack/echo/issues/1569)