### PR TITLE
Bind query params only for HTTP GET/DELETE methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,27 @@
+PKG := "github.com/labstack/echo"
+PKG_LIST := $(shell go list ${PKG}/...)
+
 tag:
 	@git tag `grep -P '^\tversion = ' echo.go|cut -f2 -d'"'`
 	@git tag|grep -v ^v
+
+.DEFAULT_GOAL := check
+check: lint vet race ## Check project
+
+init:
+	@go get -u golang.org/x/lint/golint
+
+lint: ## Lint the files
+	@golint -set_exit_status ${PKG_LIST}
+
+vet: ## Vet the files
+	@go vet ${PKG_LIST}
+
+test: ## Run tests
+	@go test -short ${PKG_LIST}
+
+race: ## Run tests with data race detector
+	@go test -race ${PKG_LIST}
+
+help: ## Display this help screen
+	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
fixes #1670 and continues https://github.com/labstack/echo/pull/1681#issuecomment-746705169 proposed changes 

DefaultBinder.Bind() binds now query params to struct only for GET and DELETE methods. For POST/PUT/PATCH query params are not considered anymore. This restores pre [v4.1.11](https://github.com/labstack/echo/commit/b129098169e182073d0a60e20cbed143b183e765) behavior. 