### PR TITLE
Resubmit: Remove group.Use registering Any routes that break other routes

### DIFF
--- a/group.go
+++ b/group.go
@@ -23,10 +23,6 @@ func (g *Group) Use(middleware ...MiddlewareFunc) {
 	if len(g.middleware) == 0 {
 		return
 	}
-	// Allow all requests to reach the group as they might get dropped if router
-	// doesn't find a match, making none of the group middleware process.
-	g.Any("", NotFoundHandler)
-	g.Any("/*", NotFoundHandler)
 }
 
 // CONNECT implements `Echo#CONNECT()` for sub-routes within the Group.

--- a/group_test.go
+++ b/group_test.go
@@ -119,3 +119,37 @@ func TestGroupRouteMiddlewareWithMatchAny(t *testing.T) {
 	assert.Equal(t, "/*", m)
 
 }
+
+func TestMultipleGroupSamePathMiddleware(t *testing.T) {
+	// Ensure multiple groups with the same path do not clobber previous routes or mixup middlewares
+	e := New()
+	m1 := func(next HandlerFunc) HandlerFunc {
+		return func(c Context) error {
+			c.Set("middleware", "m1")
+			return next(c)
+		}
+	}
+	m2 := func(next HandlerFunc) HandlerFunc {
+		return func(c Context) error {
+			c.Set("middleware", "m2")
+			return next(c)
+		}
+	}
+	h := func(c Context) error {
+		return c.String(http.StatusOK, c.Get("middleware").(string))
+	}
+
+	g1 := e.Group("/group", m1)
+	{
+		g1.GET("", h)
+	}
+	g2 := e.Group("/group", m2)
+	{
+		g2.GET("/other", h)
+	}
+
+	_, m := request(http.MethodGet, "/group", e)
+	assert.Equal(t, "m1", m)
+	_, m = request(http.MethodGet, "/group/other", e)
+	assert.Equal(t, "m2", m)
+}


### PR DESCRIPTION
This can be a breaking change if this behavior is somehow important to anyone.

Fixes #1657

Resubmit of #1674