### PR TITLE
Do not handle special trailing slash case for partial prefix

### DIFF
--- a/router.go
+++ b/router.go
@@ -372,14 +372,14 @@ func (r *Router) Find(method, path string, c Context) {
 			if search == "" && (nn == nil || cn.parent == nil || cn.ppath != "") {
 				break
 			}
+			// Handle special case of trailing slash route with existing any route (see #1526)
+			if search == "" && path[len(path)-1] == '/' && cn.anyChildren != nil {
+				goto Any
+			}
 		}
 
 		// Attempt to go back up the tree on no matching prefix or no remaining search
 		if l != pl || search == "" {
-			// Handle special case of trailing slash route with existing any route (see #1526)
-			if path[len(path)-1] == '/' && cn.anyChildren != nil {
-				goto Any
-			}
 			if nn == nil { // Issue #1348
 				return // Not found
 			}


### PR DESCRIPTION
Only handle the special trailing slash case if the whole prefix
matches. Otherwise we might be using a completely wrong
route, e.g. /users/* for the path /users_prefix/ where
the route is only a partial prefix of the requested path.

Fixes #1739