### PR TITLE
Panic when a route is added with different path params

### DIFF
--- a/echo_test.go
+++ b/echo_test.go
@@ -50,6 +50,7 @@ const userXMLPretty = `<user>
 
 func TestEcho(t *testing.T) {
 	e := New()
+	e.BuildRouters()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
@@ -185,6 +186,7 @@ func TestEchoStatic(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			e := New()
 			e.Static(tc.givenPrefix, tc.givenRoot)
+			e.BuildRouters()
 			req := httptest.NewRequest(http.MethodGet, tc.whenURL, nil)
 			rec := httptest.NewRecorder()
 			e.ServeHTTP(rec, req)
@@ -243,6 +245,7 @@ func TestEchoStaticRedirectIndex(t *testing.T) {
 func TestEchoFile(t *testing.T) {
 	e := New()
 	e.File("/walle", "_fixture/images/walle.png")
+	e.BuildRouters()
 	c, b := request(http.MethodGet, "/walle", e)
 	assert.Equal(t, http.StatusOK, c)
 	assert.NotEmpty(t, b)
@@ -286,6 +289,8 @@ func TestEchoMiddleware(t *testing.T) {
 		return c.String(http.StatusOK, "OK")
 	})
 
+	e.BuildRouters()
+
 	c, b := request(http.MethodGet, "/", e)
 	assert.Equal(t, "-1123", buf.String())
 	assert.Equal(t, http.StatusOK, c)
@@ -300,6 +305,7 @@ func TestEchoMiddlewareError(t *testing.T) {
 		}
 	})
 	e.GET("/", NotFoundHandler)
+	e.BuildRouters()
 	c, _ := request(http.MethodGet, "/", e)
 	assert.Equal(t, http.StatusInternalServerError, c)
 }
@@ -311,6 +317,8 @@ func TestEchoHandler(t *testing.T) {
 	e.GET("/ok", func(c Context) error {
 		return c.String(http.StatusOK, "OK")
 	})
+
+	e.BuildRouters()
 
 	c, b := request(http.MethodGet, "/ok", e)
 	assert.Equal(t, http.StatusOK, c)
@@ -473,6 +481,7 @@ func TestEchoEncodedPath(t *testing.T) {
 	e.GET("/:id", func(c Context) error {
 		return c.NoContent(http.StatusOK)
 	})
+	e.BuildRouters()
 	req := httptest.NewRequest(http.MethodGet, "/with%2Fslash", nil)
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
@@ -525,6 +534,8 @@ func TestEchoGroup(t *testing.T) {
 	})
 	g3.GET("", h)
 
+	e.BuildRouters()
+
 	request(http.MethodGet, "/users", e)
 	assert.Equal(t, "0", buf.String())
 
@@ -539,6 +550,7 @@ func TestEchoGroup(t *testing.T) {
 
 func TestEchoNotFound(t *testing.T) {
 	e := New()
+	e.BuildRouters()
 	req := httptest.NewRequest(http.MethodGet, "/files", nil)
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
@@ -550,6 +562,7 @@ func TestEchoMethodNotAllowed(t *testing.T) {
 	e.GET("/", func(c Context) error {
 		return c.String(http.StatusOK, "Echo!")
 	})
+	e.BuildRouters()
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
@@ -840,6 +853,7 @@ func testMethod(t *testing.T, method, path string, e *Echo) {
 	})
 	i := interface{}(e)
 	reflect.ValueOf(i).MethodByName(method).Call([]reflect.Value{p, h})
+	e.BuildRouters()
 	_, body := request(method, path, e)
 	assert.Equal(t, method, body)
 }
@@ -884,6 +898,7 @@ func TestDefaultHTTPErrorHandler(t *testing.T) {
 			"error":   "stackinfo",
 		})
 	})
+	e.BuildRouters()
 	// With Debug=true plain response contains error message
 	c, b := request(http.MethodGet, "/plain", e)
 	assert.Equal(t, http.StatusInternalServerError, c)

--- a/group_test.go
+++ b/group_test.go
@@ -32,6 +32,7 @@ func TestGroupFile(t *testing.T) {
 	e := New()
 	g := e.Group("/group")
 	g.File("/walle", "_fixture/images/walle.png")
+	e.BuildRouters()
 	expectedData, err := ioutil.ReadFile("_fixture/images/walle.png")
 	assert.Nil(t, err)
 	req := httptest.NewRequest(http.MethodGet, "/group/walle", nil)
@@ -75,6 +76,8 @@ func TestGroupRouteMiddleware(t *testing.T) {
 	g.GET("/404", h, m4)
 	g.GET("/405", h, m5)
 
+	e.BuildRouters()
+
 	c, _ := request(http.MethodGet, "/group/404", e)
 	assert.Equal(t, 404, c)
 	c, _ = request(http.MethodGet, "/group/405", e)
@@ -104,6 +107,8 @@ func TestGroupRouteMiddlewareWithMatchAny(t *testing.T) {
 	g.GET("", h, m2)
 	e.GET("unrelated", h, m2)
 	e.GET("*", h, m2)
+
+	e.BuildRouters()
 
 	_, m := request(http.MethodGet, "/group/help", e)
 	assert.Equal(t, "/group/help", m)

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -112,6 +112,7 @@ func TestGzipErrorReturned(t *testing.T) {
 	e.GET("/", func(c echo.Context) error {
 		return echo.ErrNotFound
 	})
+	e.BuildRouters()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set(echo.HeaderAcceptEncoding, gzipScheme)
 	rec := httptest.NewRecorder()
@@ -128,6 +129,7 @@ func TestGzipErrorReturnedInvalidConfig(t *testing.T) {
 		c.Response().Write([]byte("test"))
 		return nil
 	})
+	e.BuildRouters()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set(echo.HeaderAcceptEncoding, gzipScheme)
 	rec := httptest.NewRecorder()
@@ -141,6 +143,7 @@ func TestGzipWithStatic(t *testing.T) {
 	e := echo.New()
 	e.Use(Gzip())
 	e.Static("/test", "../_fixture/images")
+	e.BuildRouters()
 	req := httptest.NewRequest(http.MethodGet, "/test/walle.png", nil)
 	req.Header.Set(echo.HeaderAcceptEncoding, gzipScheme)
 	rec := httptest.NewRecorder()

--- a/middleware/decompress_test.go
+++ b/middleware/decompress_test.go
@@ -76,6 +76,7 @@ func TestDecompressDefaultConfig(t *testing.T) {
 
 func TestCompressRequestWithoutDecompressMiddleware(t *testing.T) {
 	e := echo.New()
+	e.BuildRouters()
 	body := `{"name":"echo"}`
 	gz, _ := gzipString(body)
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(gz)))
@@ -112,6 +113,7 @@ func TestDecompressErrorReturned(t *testing.T) {
 	e.GET("/", func(c echo.Context) error {
 		return echo.ErrNotFound
 	})
+	e.BuildRouters()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set(echo.HeaderContentEncoding, GZIPEncoding)
 	rec := httptest.NewRecorder()
@@ -127,6 +129,7 @@ func TestDecompressSkipper(t *testing.T) {
 			return c.Request().URL.Path == "/skip"
 		},
 	}))
+	e.BuildRouters()
 	body := `{"name": "echo"}`
 	req := httptest.NewRequest(http.MethodPost, "/skip", strings.NewReader(body))
 	req.Header.Set(echo.HeaderContentEncoding, GZIPEncoding)
@@ -156,6 +159,7 @@ func TestDecompressPoolError(t *testing.T) {
 		Skipper:            DefaultSkipper,
 		GzipDecompressPool: &TestDecompressPoolWithError{},
 	}))
+	e.BuildRouters()
 	body := `{"name": "echo"}`
 	req := httptest.NewRequest(http.MethodPost, "/echo", strings.NewReader(body))
 	req.Header.Set(echo.HeaderContentEncoding, GZIPEncoding)

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -101,6 +101,8 @@ func TestLoggerTemplate(t *testing.T) {
 		return c.String(http.StatusOK, "Header Logged")
 	})
 
+	e.BuildRouters()
+
 	req := httptest.NewRequest(http.MethodGet, "/?username=apagano-param&password=secret", nil)
 	req.RequestURI = "/"
 	req.Header.Add(echo.HeaderXRealIP, "127.0.0.1")
@@ -158,6 +160,8 @@ func TestLoggerCustomTimestamp(t *testing.T) {
 	e.GET("/", func(c echo.Context) error {
 		return c.String(http.StatusOK, "custom time stamp test")
 	})
+
+	e.BuildRouters()
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()

--- a/middleware/proxy_1_11_test.go
+++ b/middleware/proxy_1_11_test.go
@@ -41,6 +41,7 @@ func TestProxy_1_11(t *testing.T) {
 	// Random
 	e := echo.New()
 	e.Use(Proxy(rb))
+	e.BuildRouters()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 

--- a/middleware/proxy_test.go
+++ b/middleware/proxy_test.go
@@ -53,6 +53,7 @@ func TestProxy(t *testing.T) {
 	// Random
 	e := echo.New()
 	e.Use(Proxy(rb))
+	e.BuildRouters()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
@@ -75,6 +76,7 @@ func TestProxy(t *testing.T) {
 	rrb := NewRoundRobinBalancer(targets)
 	e = echo.New()
 	e.Use(Proxy(rrb))
+	e.BuildRouters()
 	rec = httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 	body = rec.Body.String()
@@ -94,6 +96,7 @@ func TestProxy(t *testing.T) {
 			return nil
 		},
 	}))
+	e.BuildRouters()
 	rec = httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, "modified", rec.Body.String())
@@ -111,6 +114,7 @@ func TestProxy(t *testing.T) {
 	e = echo.New()
 	e.Use(contextObserver)
 	e.Use(Proxy(rrb1))
+	e.BuildRouters()
 	rec = httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 }
@@ -123,6 +127,7 @@ func TestProxyRealIPHeader(t *testing.T) {
 	rrb := NewRoundRobinBalancer([]*ProxyTarget{{Name: "upstream", URL: url}})
 	e := echo.New()
 	e.Use(Proxy(rrb))
+	e.BuildRouters()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 
@@ -178,6 +183,7 @@ func TestProxyRewrite(t *testing.T) {
 			"/users/*/orders/*": "/user/$1/order/$2",
 		},
 	}))
+	e.BuildRouters()
 	req.URL, _ = url.Parse("/api/users")
 	rec = httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
@@ -233,6 +239,8 @@ func TestProxyRewriteRegex(t *testing.T) {
 		},
 	}))
 
+	e.BuildRouters()
+
 	testCases := []struct {
 		requestPath string
 		statusCode  int
@@ -246,7 +254,6 @@ func TestProxyRewriteRegex(t *testing.T) {
 		{"/x/ignore/test", http.StatusOK, "/v4/test"},
 		{"/y/foo/bar", http.StatusOK, "/v5/bar/foo"},
 	}
-
 
 	for _, tc := range testCases {
 		t.Run(tc.requestPath, func(t *testing.T) {

--- a/middleware/static_test.go
+++ b/middleware/static_test.go
@@ -117,6 +117,8 @@ func TestStatic(t *testing.T) {
 				e.Use(middlewareFunc)
 			}
 
+			e.BuildRouters()
+
 			req := httptest.NewRequest(http.MethodGet, tc.whenURL, nil)
 			rec := httptest.NewRecorder()
 
@@ -256,6 +258,8 @@ func TestStatic_GroupWithStatic(t *testing.T) {
 			}
 			g := e.Group(group)
 			g.Static(tc.givenPrefix, tc.givenRoot)
+
+			e.BuildRouters()
 
 			req := httptest.NewRequest(http.MethodGet, tc.whenURL, nil)
 			rec := httptest.NewRecorder()

--- a/router.go
+++ b/router.go
@@ -1,7 +1,9 @@
 package echo
 
 import (
+	"fmt"
 	"net/http"
+	"reflect"
 	"strings"
 )
 
@@ -201,11 +203,16 @@ func (r *Router) insert(method, path string, h HandlerFunc, t kind, ppath string
 		} else {
 			// Node already exists
 			if h != nil {
-				cn.addHandler(method, h)
-				cn.ppath = ppath
 				if len(cn.pnames) == 0 { // Issue #729
 					cn.pnames = pnames
+				} else {
+					if !reflect.DeepEqual(cn.pnames, pnames) {
+						panic(fmt.Sprintf("echo: route params are different for %s - %s != %s",
+							cn.ppath, cn.pnames, pnames))
+					}
 				}
+				cn.addHandler(method, h)
+				cn.ppath = ppath
 			}
 		}
 		return

--- a/router_test.go
+++ b/router_test.go
@@ -1542,6 +1542,33 @@ func TestRouterPanicWhenParamNoRootOnlyChildsFailsFind(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, he.Code)
 }
 
+// Issue #1726
+func TestRouterParamDifferentNamesPerHTTPMethod(t *testing.T) {
+	e := New()
+	r := e.router
+
+	r.Add(http.MethodGet, "/translation/:lang", func(Context) error {
+		return nil
+	})
+	r.Add(http.MethodPut, "/translation/:lang", func(Context) error {
+		return nil
+	})
+
+	c := e.NewContext(nil, nil).(*context)
+
+	r.Find(http.MethodGet, "/translation/en-US", c)
+	assert.Equal(t, "en-US", c.Param("lang"))
+
+	r.Find(http.MethodPut, "/translation/es-AR", c)
+	assert.Equal(t, "es-AR", c.Param("lang"))
+
+	assert.Panics(t, func() {
+		r.Add(http.MethodDelete, "/translation/:id", func(Context) error {
+			return nil
+		})
+	})
+}
+
 func benchmarkRouterRoutes(b *testing.B, routes []*Route, routesToFind []*Route) {
 	e := New()
 	r := e.router


### PR DESCRIPTION
From now, Echo panics if a route that was already added, is added again
but for a different HTTP method and the path params are different.
e.g.
GET /translation/:lang -> Added OK
PUT /translation/:lang -> Added OK
DELETE /translation/:id -> Panic

Partially Fixes #1726 #1744