### PR TITLE
build with jsoninter

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ func hello(c echo.Context) error {
   return c.String(http.StatusOK, "Hello, World!")
 }
 ```
+## Build with jsoniter
+Echo uses encoding/json as default json package, but you can change to [jsoniter](https://github.com/json-iterator/go) by using build tags.
+
+`go build -tags=jsoniter .`
 
 ## Help
 

--- a/bind.go
+++ b/bind.go
@@ -2,7 +2,6 @@ package echo
 
 import (
 	"encoding"
-	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -10,6 +9,8 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+
+	"github.com/labstack/echo/v4/internal/json"
 )
 
 type (

--- a/bind_test.go
+++ b/bind_test.go
@@ -2,7 +2,6 @@ package echo
 
 import (
 	"bytes"
-	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"io"
@@ -15,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/labstack/echo/v4/internal/json"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/binder_test.go
+++ b/binder_test.go
@@ -2,10 +2,8 @@
 package echo
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +11,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/labstack/echo/v4/internal/json"
+	"github.com/stretchr/testify/assert"
 )
 
 func createTestContext(URL string, body io.Reader, pathParams map[string]string) Context {

--- a/context.go
+++ b/context.go
@@ -2,7 +2,6 @@ package echo
 
 import (
 	"bytes"
-	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -14,6 +13,8 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/labstack/echo/v4/internal/json"
 )
 
 type (

--- a/context_test.go
+++ b/context_test.go
@@ -3,7 +3,6 @@ package echo
 import (
 	"bytes"
 	"crypto/tls"
-	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -18,6 +17,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/labstack/echo/v4/internal/json"
 	"github.com/labstack/gommon/log"
 	testify "github.com/stretchr/testify/assert"
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/labstack/echo/v4
 go 1.15
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/json-iterator/go v1.1.10
 	github.com/labstack/gommon v0.3.0
 	github.com/mattn/go-colorable v0.1.7 // indirect
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,12 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
+github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/labstack/gommon v0.3.0 h1:JEeO0bvc78PKdyHxloTKiF8BD5iGrH8T6MSeGvSgob0=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
@@ -13,9 +18,14 @@ github.com/mattn/go-isatty v0.0.9 h1:d5US/mDsogSGW37IV293h//ZFaeajb69h+EHFsv2xGg
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=
+github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLDQ0W1YjYsBW+p8U2u7vzgW2SQVmlNazg=
+github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -1,0 +1,25 @@
+// +build !jsoniter
+
+package json
+
+import "encoding/json"
+
+var (
+	// Marshal is exported by echo/json package.
+	Marshal = json.Marshal
+	// Unmarshal is exported by echo/json package.
+	Unmarshal = json.Unmarshal
+	// NewDecoder is exported by ehco/json package.
+	NewDecoder = json.NewDecoder
+	// NewEncoder is exported by echo/json package.
+	NewEncoder = json.NewEncoder
+)
+
+type(
+	// UnmarshalTypeError is exported by echo/json package.
+	UnmarshalTypeError = json.UnmarshalTypeError
+	// SyntaxError is exported by echo/json package.
+	SyntaxError = json.SyntaxError
+	// RawMessage is exported by echo/json package.
+	RawMessage = json.RawMessage
+)

--- a/internal/json/jsoniter.go
+++ b/internal/json/jsoniter.go
@@ -1,0 +1,27 @@
+// +build jsoniter
+
+package json
+
+import jsoniter "github.com/json-iterator/go"
+import encodingJson "encoding/json"
+
+var (
+	json = jsoniter.ConfigCompatibleWithStandardLibrary
+	// Marshal is exported by echo/json package.
+	Marshal = json.Marshal
+	// Unmarshal is exported by echo/json package.
+	Unmarshal = json.Unmarshal
+	// NewDecoder is exported by ehco/json package.
+	NewDecoder = json.NewDecoder
+	// NewEncoder is exported by echo/json package.
+	NewEncoder = json.NewEncoder
+)
+
+type(
+	// UnmarshalTypeError is exported by echo/json package.
+	UnmarshalTypeError = encodingJson.UnmarshalTypeError
+	// SyntaxError is exported by echo/json package.
+	SyntaxError = encodingJson.SyntaxError
+	// RawMessage is exported by echo/json package.
+	RawMessage = encodingJson.RawMessage
+)

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"bytes"
-	"encoding/json"
 	"io"
 	"strconv"
 	"strings"
@@ -10,6 +9,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/internal/json"
 	"github.com/labstack/gommon/color"
 	"github.com/valyala/fasttemplate"
 )

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +12,7 @@ import (
 	"unsafe"
 
 	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/internal/json"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
Allowing users to replace default encoding/json with [jsoniter](https://github.com/json-iterator/go) and build binary by using build tags(Instructions added to README).

Resolves:
https://github.com/labstack/echo/issues/1698
https://github.com/labstack/echo/pull/1204

