### PR TITLE
Uses strings.EqualFold

### DIFF
--- a/context.go
+++ b/context.go
@@ -246,7 +246,7 @@ func (c *context) IsTLS() bool {
 
 func (c *context) IsWebSocket() bool {
 	upgrade := c.request.Header.Get(HeaderUpgrade)
-	return strings.ToLower(upgrade) == "websocket"
+	return strings.EqualFold(upgrade, "websocket")
 }
 
 func (c *context) Scheme() string {

--- a/middleware/basic_auth.go
+++ b/middleware/basic_auth.go
@@ -73,7 +73,7 @@ func BasicAuthWithConfig(config BasicAuthConfig) echo.MiddlewareFunc {
 			auth := c.Request().Header.Get(echo.HeaderAuthorization)
 			l := len(basic)
 
-			if len(auth) > l+1 && strings.ToLower(auth[:l]) == basic {
+			if len(auth) > l+1 && strings.EqualFold(auth[:l], basic) {
 				b, err := base64.StdEncoding.DecodeString(auth[l+1:])
 				if err != nil {
 					return err


### PR DESCRIPTION
Changes case insensitive string comparisons to string.EqualFold which performs better than strings.Lower(str) == str comparison

Already covered in test cases:
https://github.com/labstack/echo/blob/master/middleware/basic_auth_test.go#L49
https://github.com/labstack/echo/blob/master/context_test.go#L821