### PR TITLE
Fix #1787: Add support for optional filesystem to the static middleware

### DIFF
--- a/middleware/static.go
+++ b/middleware/static.go
@@ -155,8 +155,6 @@ func StaticWithConfig(config StaticConfig) echo.MiddlewareFunc {
 		config.Root = "."
 	}
 
-	config.Root = filepath.ToSlash(config.Root)
-
 	// Index template
 	t, err := template.New("index").Parse(html)
 	if err != nil {
@@ -177,7 +175,7 @@ func StaticWithConfig(config StaticConfig) echo.MiddlewareFunc {
 			if err != nil {
 				return
 			}
-			name := path.Join(config.Root, path.Clean("/"+p)) // "/"+ for security
+			name := filepath.Join(config.Root, filepath.Clean("/"+p)) // "/"+ for security
 
 			if config.IgnoreBase {
 				routePath := path.Base(strings.TrimRight(c.Path(), "/*"))
@@ -203,7 +201,7 @@ func StaticWithConfig(config StaticConfig) echo.MiddlewareFunc {
 					return err
 				}
 
-				file, err = openFile(config.Filesystem, path.Join(config.Root, config.Index))
+				file, err = openFile(config.Filesystem, filepath.Join(config.Root, config.Index))
 				if err != nil {
 					return err
 				}
@@ -217,7 +215,7 @@ func StaticWithConfig(config StaticConfig) echo.MiddlewareFunc {
 			}
 
 			if info.IsDir() {
-				index, err := openFile(config.Filesystem, path.Join(name, config.Index))
+				index, err := openFile(config.Filesystem, filepath.Join(name, config.Index))
 				if err != nil {
 					if config.Browse {
 						return listDir(t, name, file, c.Response())
@@ -244,11 +242,8 @@ func StaticWithConfig(config StaticConfig) echo.MiddlewareFunc {
 }
 
 func openFile(fs http.FileSystem, name string) (http.File, error) {
-	if filepath.Separator != '/' && strings.ContainsRune(name, filepath.Separator) {
-		return nil, os.ErrNotExist
-	}
-
-	return fs.Open(name)
+	pathWithSlashes := filepath.ToSlash(name)
+	return fs.Open(pathWithSlashes)
 }
 
 func serveFile(c echo.Context, file http.File, info os.FileInfo) error {

--- a/middleware/static.go
+++ b/middleware/static.go
@@ -42,6 +42,10 @@ type (
 		// the filesystem path is not doubled
 		// Optional. Default value false.
 		IgnoreBase bool `yaml:"ignoreBase"`
+
+		// Filesystem provides access to the static content.
+		// Optional. Defaults to http.Dir(config.Root)
+		Filesystem http.FileSystem `yaml:"-"`
 	}
 )
 
@@ -146,6 +150,10 @@ func StaticWithConfig(config StaticConfig) echo.MiddlewareFunc {
 	if config.Index == "" {
 		config.Index = DefaultStaticConfig.Index
 	}
+	if config.Filesystem == nil {
+		config.Filesystem = http.Dir(config.Root)
+		config.Root = "."
+	}
 
 	// Index template
 	t, err := template.New("index").Parse(html)
@@ -178,49 +186,68 @@ func StaticWithConfig(config StaticConfig) echo.MiddlewareFunc {
 				}
 			}
 
-			fi, err := os.Stat(name)
+			file, err := config.Filesystem.Open(name)
 			if err != nil {
-				if os.IsNotExist(err) {
-					if err = next(c); err != nil {
-						if he, ok := err.(*echo.HTTPError); ok {
-							if config.HTML5 && he.Code == http.StatusNotFound {
-								return c.File(filepath.Join(config.Root, config.Index))
-							}
-						}
-						return
-					}
-				}
-				return
-			}
-
-			if fi.IsDir() {
-				index := filepath.Join(name, config.Index)
-				fi, err = os.Stat(index)
-
-				if err != nil {
-					if config.Browse {
-						return listDir(t, name, c.Response())
-					}
-					if os.IsNotExist(err) {
-						return next(c)
-					}
+				if !os.IsNotExist(err) {
 					return
 				}
 
-				return c.File(index)
+				if err = next(c); err == nil {
+					return err
+				}
+
+				he, ok := err.(*echo.HTTPError)
+				if !(ok && config.HTML5 && he.Code == http.StatusNotFound) {
+					return err
+				}
+
+				file, err = config.Filesystem.Open(filepath.Join(config.Root, config.Index))
+				if err != nil {
+					return err
+				}
 			}
 
-			return c.File(name)
+			defer file.Close()
+
+			info, err := file.Stat()
+			if err != nil {
+				return err
+			}
+
+			if info.IsDir() {
+				index, err := config.Filesystem.Open(filepath.Join(name, config.Index))
+				if err != nil {
+					if config.Browse {
+						return listDir(t, name, file, c.Response())
+					}
+
+					if os.IsNotExist(err) {
+						return next(c)
+					}
+				}
+
+				defer index.Close()
+
+				info, err = index.Stat()
+				if err != nil {
+					return err
+				}
+
+				return serveFile(c, index, info)
+			}
+
+			return serveFile(c, file, info)
 		}
 	}
 }
 
-func listDir(t *template.Template, name string, res *echo.Response) (err error) {
-	file, err := os.Open(name)
-	if err != nil {
-		return
-	}
-	files, err := file.Readdir(-1)
+func serveFile(c echo.Context, file http.File, info os.FileInfo) error {
+	http.ServeContent(c.Response(), c.Request(), info.Name(), info.ModTime(), file)
+	return nil
+}
+
+func listDir(t *template.Template, name string, dir http.File, res *echo.Response) (err error) {
+	files, err := dir.Readdir(-1)
 	if err != nil {
 		return
 	}

--- a/middleware/static_1_16_test.go
+++ b/middleware/static_1_16_test.go
@@ -30,6 +30,14 @@ func TestStatic_CustomFS(t *testing.T) {
 			expectCode:     http.StatusOK,
 			expectContains: "<title>Echo</title>",
 		},
+
+		{
+			name:           "ok, serve index with Echo message",
+			whenURL:        "/_fixture/",
+			filesystem:     os.DirFS(".."),
+			expectCode:     http.StatusOK,
+			expectContains: "<title>Echo</title>",
+		},
 		{
 			name:    "ok, serve file from map fs",
 			whenURL: "/file.txt",

--- a/middleware/static_1_16_test.go
+++ b/middleware/static_1_16_test.go
@@ -1,0 +1,98 @@
+// +build go1.16
+
+package middleware
+
+import (
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"testing/fstest"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatic_CustomFS(t *testing.T) {
+	var testCases = []struct {
+		name           string
+		filesystem     fs.FS
+		root           string
+		whenURL        string
+		expectContains string
+		expectCode     int
+	}{
+		{
+			name:           "ok, serve index with Echo message",
+			whenURL:        "/",
+			filesystem:     os.DirFS("../_fixture"),
+			expectCode:     http.StatusOK,
+			expectContains: "<title>Echo</title>",
+		},
+		{
+			name:    "ok, serve file from map fs",
+			whenURL: "/file.txt",
+			filesystem: fstest.MapFS{
+				"file.txt": &fstest.MapFile{Data: []byte("file.txt is ok")},
+			},
+			expectCode:     http.StatusOK,
+			expectContains: "file.txt is ok",
+		},
+		{
+			name:       "nok, missing file in map fs",
+			whenURL:    "/file.txt",
+			expectCode: http.StatusNotFound,
+			filesystem: fstest.MapFS{
+				"file2.txt": &fstest.MapFile{Data: []byte("file2.txt is ok")},
+			},
+		},
+		{
+			name:    "nok, file is not a subpath of root",
+			whenURL: `/../../secret.txt`,
+			root:    "/nested/folder",
+			filesystem: fstest.MapFS{
+				"secret.txt": &fstest.MapFile{Data: []byte("this is a secret")},
+			},
+			expectCode: http.StatusNotFound,
+		},
+		{
+			name:       "nok, backslash is forbidden",
+			whenURL:    `/..\..\secret.txt`,
+			expectCode: http.StatusNotFound,
+			root:       "/nested/folder",
+			filesystem: fstest.MapFS{
+				"secret.txt": &fstest.MapFile{Data: []byte("this is a secret")},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := echo.New()
+
+			config := StaticConfig{
+				Root:       ".",
+				Filesystem: http.FS(tc.filesystem),
+			}
+
+			if tc.root != "" {
+				config.Root = tc.root
+			}
+
+			middlewareFunc := StaticWithConfig(config)
+			e.Use(middlewareFunc)
+
+			req := httptest.NewRequest(http.MethodGet, tc.whenURL, nil)
+			rec := httptest.NewRecorder()
+
+			e.ServeHTTP(rec, req)
+
+			assert.Equal(t, tc.expectCode, rec.Code)
+			if tc.expectContains != "" {
+				responseBody := rec.Body.String()
+				assert.Contains(t, responseBody, tc.expectContains)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR is related to #1787.

By supporting `http.Filesystem` we also provide support for the new `fs.FS` while maintaining compatibility with versions prior to go1.16.