### PR TITLE
fix performance regression. Do not escape request path in echo.ServeH…

### DIFF
--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -1,0 +1,69 @@
+package middleware
+
+import (
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+)
+
+func TestRewritePath(t *testing.T) {
+	var testCases = []struct {
+		whenURL       string
+		expectPath    string
+		expectRawPath string
+	}{
+		{
+			whenURL:       "http://localhost:8080/old",
+			expectPath:    "/new",
+			expectRawPath: "",
+		},
+		{ // encoded `ol%64` (decoded `old`) should not be rewritten to `/new`
+			whenURL:       "/ol%64", // `%64` is decoded `d`
+			expectPath:    "/old",
+			expectRawPath: "/ol%64",
+		},
+		{
+			whenURL:       "http://localhost:8080/users/+_+/orders/___++++?test=1",
+			expectPath:    "/user/+_+/order/___++++",
+			expectRawPath: "",
+		},
+		{
+			whenURL:       "http://localhost:8080/users/%20a/orders/%20aa",
+			expectPath:    "/user/ a/order/ aa",
+			expectRawPath: "",
+		},
+		{
+			whenURL:       "http://localhost:8080/%47%6f%2f",
+			expectPath:    "/Go/",
+			expectRawPath: "/%47%6f%2f",
+		},
+		{
+			whenURL:       "/users/jill/orders/T%2FcO4lW%2Ft%2FVp%2F",
+			expectPath:    "/user/jill/order/T/cO4lW/t/Vp/",
+			expectRawPath: "/user/jill/order/T%2FcO4lW%2Ft%2FVp%2F",
+		},
+		{ // do nothing, replace nothing
+			whenURL:       "http://localhost:8080/user/jill/order/T%2FcO4lW%2Ft%2FVp%2F",
+			expectPath:    "/user/jill/order/T/cO4lW/t/Vp/",
+			expectRawPath: "/user/jill/order/T%2FcO4lW%2Ft%2FVp%2F",
+		},
+	}
+
+	rules := map[*regexp.Regexp]string{
+		regexp.MustCompile("^/old$"):                      "/new",
+		regexp.MustCompile("^/users/(.*?)/orders/(.*?)$"): "/user/$1/order/$2",
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.whenURL, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.whenURL, nil)
+
+			rewritePath(rules, req)
+
+			assert.Equal(t, tc.expectPath, req.URL.Path)       // Path field is stored in decoded form: /%47%6f%2f becomes /Go/.
+			assert.Equal(t, tc.expectRawPath, req.URL.RawPath) // RawPath, an optional field which only gets set if the default encoding is different from Path.
+		})
+	}
+}


### PR DESCRIPTION
fix #1777 performance regression. Do not escape request path in echo.ServeHTTP. Make sure that path is not double escaped in rewrite/proxy middleware.

did 3 benchmarks

```bash
# before problem was introduced
go test -run="-" -bench="BenchmarkEcho.*" -count 10 > before_problem.out
# on current master
go test -run="-" -bench="BenchmarkEcho.*" -count 10 > before_fix.out
# on fix branch
go test -run="-" -bench="BenchmarkEcho.*" -count 10 > after_fix.out  
```

Results:

before versus after performance problem was commited
```bash
x@x:~/code/echo$ benchstat before_problem.out before_fix.out 
name                      old time/op    new time/op    delta
EchoStaticRoutes-6          19.9µs ± 2%    28.2µs ± 1%  +41.84%  (p=0.000 n=8+9)
EchoStaticRoutesMisses-6    22.6µs ±13%    28.4µs ± 1%  +25.61%  (p=0.000 n=10+8)
EchoGitHubAPI-6             32.7µs ± 2%    56.7µs ± 1%  +73.19%  (p=0.000 n=8+8)
EchoGitHubAPIMisses-6       33.1µs ± 1%    56.7µs ± 1%  +71.52%  (p=0.000 n=8+9)
EchoParseAPI-6              2.52µs ± 5%    3.89µs ± 2%  +54.44%  (p=0.000 n=10+10)
```

commit on master before problem was fixed versus after fix branch
```bash
x@x:~/code/echo$ benchstat before_fix.out after_fix.out 
name                      old time/op    new time/op    delta
EchoStaticRoutes-6          28.2µs ± 1%    17.7µs ± 9%   -37.14%  (p=0.000 n=9+10)
EchoStaticRoutesMisses-6    28.4µs ± 1%    17.3µs ± 2%   -39.04%  (p=0.000 n=8+9)
EchoGitHubAPI-6             56.7µs ± 1%    32.2µs ± 2%   -43.23%  (p=0.000 n=8+10)
EchoGitHubAPIMisses-6       56.7µs ± 1%    32.8µs ± 2%   -42.22%  (p=0.000 n=9+8)
EchoParseAPI-6              3.89µs ± 2%    2.14µs ± 3%   -44.99%  (p=0.000 n=10+9)
```

before problem was commits versus after fix
NB: these numbers include  also other changes we have done to router in master
```bash
x@x:~/code/echo$ benchstat before_problem.out after_fix.out 
name                      old time/op    new time/op    delta
EchoStaticRoutes-6          19.9µs ± 2%    17.7µs ± 9%  -10.83%  (p=0.000 n=8+10)
EchoStaticRoutesMisses-6    22.6µs ±13%    17.3µs ± 2%  -23.43%  (p=0.000 n=10+9)
EchoGitHubAPI-6             32.7µs ± 2%    32.2µs ± 2%   -1.67%  (p=0.008 n=8+10)
EchoGitHubAPIMisses-6       33.1µs ± 1%    32.8µs ± 2%   -0.90%  (p=0.021 n=8+8)
EchoParseAPI-6              2.52µs ± 5%    2.14µs ± 3%  -15.04%  (p=0.000 n=10+9)
```

I added similar benchmark tests as router has but this time we use full echo stack `e.ServeHTTP`
```go

func benchmarkEchoRoutes(b *testing.B, routes []*Route) {
	e := New()
	req := httptest.NewRequest("GET", "/", nil)
	u := req.URL
	w := httptest.NewRecorder()

	b.ReportAllocs()

	// Add routes
	for _, route := range routes {
		e.Add(route.Method, route.Path, func(c Context) error {
			return nil
		})
	}

	// Find routes
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		for _, route := range routes {
			req.Method = route.Method
			u.Path = route.Path
			e.ServeHTTP(w, req)
		}
	}
}

func BenchmarkEchoStaticRoutes(b *testing.B) {
	benchmarkEchoRoutes(b, staticRoutes)
}

func BenchmarkEchoStaticRoutesMisses(b *testing.B) {
	benchmarkEchoRoutes(b, staticRoutes)
}

func BenchmarkEchoGitHubAPI(b *testing.B) {
	benchmarkEchoRoutes(b, gitHubAPI)
}

func BenchmarkEchoGitHubAPIMisses(b *testing.B) {
	benchmarkEchoRoutes(b, gitHubAPI)
}

func BenchmarkEchoParseAPI(b *testing.B) {
	benchmarkEchoRoutes(b, parseAPI)
}
```



NB:  I think `Rewrite` and  `Proxy` has somewhat fundamental flaw by using `map` for rewrite rules. Map does not have guaranteed iteration order so  overlapping rules are not executed in expected order