### PR TITLE
Rework timeout middleware to use http.TimeoutHandler implementation. …

### DIFF
--- a/middleware/timeout.go
+++ b/middleware/timeout.go
@@ -4,8 +4,8 @@ package middleware
 
 import (
 	"context"
-	"fmt"
 	"github.com/labstack/echo/v4"
+	"net/http"
 	"time"
 )
 
@@ -14,16 +14,23 @@ type (
 	TimeoutConfig struct {
 		// Skipper defines a function to skip middleware.
 		Skipper Skipper
-		// ErrorHandler defines a function which is executed for a timeout
-		// It can be used to define a custom timeout error
-		ErrorHandler TimeoutErrorHandlerWithContext
+
+		// ErrorMessage is written to response on timeout in addition to http.StatusServiceUnavailable (503) status code
+		// It can be used to define a custom timeout error message
+		ErrorMessage string
+
+		// OnTimeoutRouteErrorHandler is an error handler that is executed for error that was returned from wrapped route after
+		// request timeouted and we already had sent the error code (503) and message response to the client.
+		// NB: do not write headers/body inside this handler. The response has already been sent to the client and response writer
+		// will not accept anything no more. If you want to know what actual route middleware timeouted use `c.Path()`
+		OnTimeoutRouteErrorHandler func(err error, c echo.Context)
+
 		// Timeout configures a timeout for the middleware, defaults to 0 for no timeout
+		// NOTE: when difference between timeout duration and handler execution time is almost the same (in range of 100microseconds)
+		// the result of timeout does not seem to be reliable - could respond timeout, could respond handler output
+		// difference over 500microseconds (0.5millisecond) response seems to be reliable
 		Timeout time.Duration
 	}
-
-	// TimeoutErrorHandlerWithContext is an error handler that is used with the timeout middleware so we can
-	// handle the error as we see fit
-	TimeoutErrorHandlerWithContext func(error, echo.Context) error
 )
 
 var (
@@ -31,7 +38,7 @@ var (
 	DefaultTimeoutConfig = TimeoutConfig{
 		Skipper:      DefaultSkipper,
 		Timeout:      0,
-		ErrorHandler: nil,
+		ErrorMessage: "",
 	}
 )
 
@@ -55,39 +62,50 @@ func TimeoutWithConfig(config TimeoutConfig) echo.MiddlewareFunc {
 				return next(c)
 			}
 
-			ctx, cancel := context.WithTimeout(c.Request().Context(), config.Timeout)
-			defer cancel()
-
-			// this does a deep clone of the context, wondering if there is a better way to do this?
-			c.SetRequest(c.Request().Clone(ctx))
-
-			done := make(chan error, 1)
-			go func() {
-				defer func() {
-					if r := recover(); r != nil {
-						err, ok := r.(error)
-						if !ok {
-							err = fmt.Errorf("panic recovered in timeout middleware: %v", r)
-						}
-						c.Logger().Error(err)
-						done <- err
-					}
-				}()
-
-				// This goroutine will keep running even if this middleware times out and
-				// will be stopped when ctx.Done() is called down the next(c) call chain
-				done <- next(c)
-			}()
+			handlerWrapper := echoHandlerFuncWrapper{
+				ctx:        c,
+				handler:    next,
+				errChan:    make(chan error, 1),
+				errHandler: config.OnTimeoutRouteErrorHandler,
+			}
+			handler := http.TimeoutHandler(handlerWrapper, config.Timeout, config.ErrorMessage)
+			handler.ServeHTTP(c.Response().Writer, c.Request())
 
 			select {
-			case <-ctx.Done():
-				if config.ErrorHandler != nil {
-					return config.ErrorHandler(ctx.Err(), c)
-				}
-				return ctx.Err()
-			case err := <-done:
+			case err := <-handlerWrapper.errChan:
 				return err
+			default:
+				return nil
 			}
 		}
+	}
+}
+
+type echoHandlerFuncWrapper struct {
+	ctx        echo.Context
+	handler    echo.HandlerFunc
+	errHandler func(err error, c echo.Context)
+	errChan    chan error
+}
+
+func (t echoHandlerFuncWrapper) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	// replace writer with TimeoutHandler custom one. This will guarantee that
+	// `writes by h to its ResponseWriter will return ErrHandlerTimeout.`
+	originalWriter := t.ctx.Response().Writer
+	t.ctx.Response().Writer = rw
+
+	err := t.handler(t.ctx)
+	if ctxErr := r.Context().Err(); ctxErr == context.DeadlineExceeded {
+		if err != nil && t.errHandler != nil {
+			t.errHandler(err, t.ctx)
+		}
+		return // on timeout we can not send handler error to client because `http.TimeoutHandler` has already sent headers
+	}
+	// we restore original writer only for cases we did not timeout. On timeout we have already sent response to client
+	// and should not anymore send additional headers/data
+	// so on timeout writer stays what http.TimeoutHandler uses and prevents writing headers/body
+	t.ctx.Response().Writer = originalWriter
+	if err != nil {
+		t.errChan <- err
 	}
 }


### PR DESCRIPTION
Fix #1761 - Reworked timeout middleware to use `http.TimeoutHandler` implementation. 

NB: Replaced `ErrorHandler` with `ErrorMessage` and `OnTimeoutRouteErrorHandler` on config struct (fix #1761) - this is **breaking change** but for `http.TimeoutHandler` there is no special case for timeout errors - that handler will take care of it itself.