### PR TITLE
allow proxy middleware to pass rewritten query part (fix #1798)

### DIFF
--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"net/http"
-	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -49,30 +48,37 @@ func rewriteRulesRegex(rewrite map[string]string) map[*regexp.Regexp]string {
 	return rulesRegex
 }
 
-func rewritePath(rewriteRegex map[*regexp.Regexp]string, req *http.Request) {
-	for k, v := range rewriteRegex {
-		rawPath := req.URL.RawPath
-		if rawPath != "" {
-			// RawPath is only set when there has been escaping done. In that case Path must be deduced from rewritten RawPath
-			// because encoded Path could match rules that RawPath did not
-			if replacer := captureTokens(k, rawPath); replacer != nil {
-				rawPath = replacer.Replace(v)
+func rewriteURL(rewriteRegex map[*regexp.Regexp]string, req *http.Request) error {
+	if len(rewriteRegex) == 0 {
+		return nil
+	}
 
-				req.URL.RawPath = rawPath
-				req.URL.Path, _ = url.PathUnescape(rawPath)
-
-				return // rewrite only once
-			}
-
-			continue
+	rawURI := req.RequestURI
+	if rawURI != "" && rawURI[0] != '/' {
+		prefix := ""
+		if req.URL.Scheme != "" {
+			prefix = req.URL.Scheme + "://"
 		}
-
-		if replacer := captureTokens(k, req.URL.Path); replacer != nil {
-			req.URL.Path = replacer.Replace(v)
-
-			return // rewrite only once
+		if req.URL.Host != "" {
+			prefix += req.URL.Host
+		}
+		if prefix != "" {
+			rawURI = strings.TrimPrefix(rawURI, prefix)
 		}
 	}
+
+	for k, v := range rewriteRegex {
+		if replacer := captureTokens(k, rawURI); replacer != nil {
+			url, err := req.URL.Parse(replacer.Replace(v))
+			if err != nil {
+				return err
+			}
+			req.URL = url
+
+			return nil // rewrite only once
+		}
+	}
+	return nil
 }
 
 // DefaultSkipper returns false which processes the middleware.

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -53,6 +53,8 @@ func rewriteURL(rewriteRegex map[*regexp.Regexp]string, req *http.Request) error
 		return nil
 	}
 
+	// Depending how HTTP request is sent RequestURI could contain Scheme://Host/path or be just /path.
+	// We only want to use path part for rewriting and therefore trim prefix if it exists
 	rawURI := req.RequestURI
 	if rawURI != "" && rawURI[0] != '/' {
 		prefix := ""
@@ -60,7 +62,7 @@ func rewriteURL(rewriteRegex map[*regexp.Regexp]string, req *http.Request) error
 			prefix = req.URL.Scheme + "://"
 		}
 		if req.URL.Host != "" {
-			prefix += req.URL.Host
+			prefix += req.URL.Host // host or host:port
 		}
 		if prefix != "" {
 			rawURI = strings.TrimPrefix(rawURI, prefix)

--- a/middleware/proxy.go
+++ b/middleware/proxy.go
@@ -231,8 +231,9 @@ func ProxyWithConfig(config ProxyConfig) echo.MiddlewareFunc {
 			tgt := config.Balancer.Next(c)
 			c.Set(config.ContextKey, tgt)
 
-			// Set rewrite path and raw path
-			rewritePath(config.RegexRewrite, req)
+			if err := rewriteURL(config.RegexRewrite, req); err != nil {
+				return err
+			}
 
 			// Fix header
 			// Basically it's not good practice to unconditionally pass incoming x-real-ip header to upstream.

--- a/middleware/rewrite.go
+++ b/middleware/rewrite.go
@@ -72,9 +72,9 @@ func RewriteWithConfig(config RewriteConfig) echo.MiddlewareFunc {
 				return next(c)
 			}
 
-			req := c.Request()
-			// Set rewrite path and raw path
-			rewritePath(config.RegexRules, req)
+			if err := rewriteURL(config.RegexRules, c.Request()); err != nil {
+				return err
+			}
 			return next(c)
 		}
 	}


### PR DESCRIPTION
Alow proxy middleware to pass rewritten query part (fix #1798)