### PR TITLE
refactor timeout middleware with copy of http.timeoutWriter and Echolike error handling

### DIFF
--- a/middleware/timeout.go
+++ b/middleware/timeout.go
@@ -3,9 +3,13 @@
 package middleware
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"github.com/labstack/echo/v4"
 	"net/http"
+	"sync"
 	"time"
 )
 
@@ -15,15 +19,16 @@ type (
 		// Skipper defines a function to skip middleware.
 		Skipper Skipper
 
-		// ErrorMessage is written to response on timeout in addition to http.StatusServiceUnavailable (503) status code
-		// It can be used to define a custom timeout error message
-		ErrorMessage string
-
 		// OnTimeoutRouteErrorHandler is an error handler that is executed for error that was returned from wrapped route after
 		// request timeouted and we already had sent the error code (503) and message response to the client.
 		// NB: do not write headers/body inside this handler. The response has already been sent to the client and response writer
 		// will not accept anything no more. If you want to know what actual route middleware timeouted use `c.Path()`
 		OnTimeoutRouteErrorHandler func(err error, c echo.Context)
+
+		// DefaultTimeoutErrorHandler is an error handler that is executed when handler context timeouts or is cancelled.
+		// Overwrite this with our custom implementation when want to send your own custom error code etc.
+		// NB: OnTimeoutRouteErrorHandler will still be called when handler function eventually finishes.
+		DefaultTimeoutErrorHandler func(contextError error, c echo.Context) error
 
 		// Timeout configures a timeout for the middleware, defaults to 0 for no timeout
 		// NOTE: when difference between timeout duration and handler execution time is almost the same (in range of 100microseconds)
@@ -36,9 +41,8 @@ type (
 var (
 	// DefaultTimeoutConfig is the default Timeout middleware config.
 	DefaultTimeoutConfig = TimeoutConfig{
-		Skipper:      DefaultSkipper,
-		Timeout:      0,
-		ErrorMessage: "",
+		Skipper: DefaultSkipper,
+		Timeout: 0,
 	}
 )
 
@@ -55,6 +59,19 @@ func TimeoutWithConfig(config TimeoutConfig) echo.MiddlewareFunc {
 	if config.Skipper == nil {
 		config.Skipper = DefaultTimeoutConfig.Skipper
 	}
+	if config.DefaultTimeoutErrorHandler == nil {
+		config.DefaultTimeoutErrorHandler = func(contextError error, c echo.Context) error {
+			return echo.NewHTTPError(http.StatusServiceUnavailable, contextError.Error())
+		}
+	}
+	if config.OnTimeoutRouteErrorHandler == nil {
+		config.OnTimeoutRouteErrorHandler = func(err error, c echo.Context) {
+			if c.Logger() == nil {
+				return
+			}
+			c.Logger().Errorf("handler for path %v returned an error after request timeouted", c.Path())
+		}
+	}
 
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
@@ -62,55 +79,143 @@ func TimeoutWithConfig(config TimeoutConfig) echo.MiddlewareFunc {
 				return next(c)
 			}
 
-			handlerWrapper := echoHandlerFuncWrapper{
-				ctx:        c,
-				handler:    next,
-				errChan:    make(chan error, 1),
-				errHandler: config.OnTimeoutRouteErrorHandler,
+			ctx, cancelCtx := context.WithTimeout(c.Request().Context(), config.Timeout)
+			defer cancelCtx()
+
+			r := c.Request().WithContext(ctx)
+
+			tw := &timeoutWriter{
+				w:   c.Response(),
+				h:   make(map[string][]string),
+				req: r,
 			}
-			handler := http.TimeoutHandler(handlerWrapper, config.Timeout, config.ErrorMessage)
-			handler.ServeHTTP(c.Response().Writer, c.Request())
+			originalWriter := c.Response().Writer
+			c.Response().Writer = tw
+
+			done := make(chan error)
+			defer close(done)
+			panicChan := make(chan interface{})
+			defer close(panicChan)
+
+			go func() {
+				defer func() {
+					if p := recover(); p != nil {
+						panicChan <- p
+					}
+				}()
+
+				err := next(c)
+				// NB: when timeout occurs this functions returns after timeout response has already been sent to the client
+				// only thing we can do with error is to log it as we can not send anything to client anymore
+				select {
+				case <-ctx.Done():
+					config.OnTimeoutRouteErrorHandler(err, c)
+				default:
+					done <- err
+				}
+			}()
 
 			select {
-			case err := <-handlerWrapper.errChan:
+			case p := <-panicChan:
+				panic(p)
+			case err := <-done: // where are here before timeout has been exceeded
+				tw.mu.Lock()
+				defer tw.mu.Unlock()
+
+				// restore writer for context
+				c.Response().Writer = originalWriter
+				dst := c.Response().Header()
+				for k, vv := range tw.h {
+					dst[k] = vv
+				}
+				// as handler could call `c.JSON` etc methods that write to response and therefore commit request we need unlock
+				// response and set values from timeoutWriter had wrapped
+				if c.Response().Committed {
+					c.Response().Committed = false
+					c.Response().WriteHeader(tw.code)
+					c.Response().Committed = true
+				}
+				if tw.wbuf.Len() != 0 {
+					c.Response().Write(tw.wbuf.Bytes())
+				}
+
 				return err
-			default:
-				return nil
+			case <-ctx.Done(): // where are here after timeout has been exceeded or context was cancelled
+				tw.mu.Lock()
+				defer tw.mu.Unlock()
+
+				tw.timedOut = true
+				return config.DefaultTimeoutErrorHandler(ctx.Err(), c)
 			}
 		}
 	}
 }
 
-type echoHandlerFuncWrapper struct {
-	ctx        echo.Context
-	handler    echo.HandlerFunc
-	errHandler func(err error, c echo.Context)
-	errChan    chan error
+// ErrHandlerTimeout is returned on ResponseWriter Write calls
+// in handlers which have timed out.
+var ErrHandlerTimeout = errors.New("http: Handler timeout")
+
+// NOTE: this is copy of http.timeoutWriter
+type timeoutWriter struct {
+	w    http.ResponseWriter
+	h    map[string][]string
+	wbuf bytes.Buffer
+	req  *http.Request
+
+	logger echo.Logger
+
+	mu          sync.Mutex
+	timedOut    bool
+	wroteHeader bool
+	code        int
 }
 
-func (t echoHandlerFuncWrapper) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
-	// replace writer with TimeoutHandler custom one. This will guarantee that
-	// `writes by h to its ResponseWriter will return ErrHandlerTimeout.`
-	originalWriter := t.ctx.Response().Writer
-	t.ctx.Response().Writer = rw
+// Push implements the Pusher interface.
+func (tw *timeoutWriter) Push(target string, opts *http.PushOptions) error {
+	if pusher, ok := tw.w.(http.Pusher); ok {
+		return pusher.Push(target, opts)
+	}
+	return http.ErrNotSupported
+}
 
-	err := t.handler(t.ctx)
-	if ctxErr := r.Context().Err(); ctxErr == context.DeadlineExceeded {
-		if err != nil && t.errHandler != nil {
-			t.errHandler(err, t.ctx)
+func (tw *timeoutWriter) Header() http.Header { return tw.h }
+
+func (tw *timeoutWriter) Write(p []byte) (int, error) {
+	tw.mu.Lock()
+	defer tw.mu.Unlock()
+	if tw.timedOut {
+		return 0, ErrHandlerTimeout
+	}
+	if !tw.wroteHeader {
+		tw.writeHeaderLocked(http.StatusOK)
+	}
+	return tw.wbuf.Write(p)
+}
+
+func (tw *timeoutWriter) writeHeaderLocked(code int) {
+	if code < 100 || code > 999 {
+		panic(fmt.Sprintf("invalid WriteHeader code %v", code))
+	}
+
+	switch {
+	case tw.timedOut:
+		return
+	case tw.wroteHeader:
+		if tw.req != nil {
+			if tw.logger != nil {
+				tw.logger.Errorf("http: superfluous response.WriteHeader call: %v", tw.req.RequestURI)
+			} else {
+				fmt.Printf("http: superfluous response.WriteHeader call: %v", tw.req.RequestURI)
+			}
 		}
-		return // on timeout we can not send handler error to client because `http.TimeoutHandler` has already sent headers
+	default:
+		tw.wroteHeader = true
+		tw.code = code
 	}
-	// we restore original writer only for cases we did not timeout. On timeout we have already sent response to client
-	// and should not anymore send additional headers/data
-	// so on timeout writer stays what http.TimeoutHandler uses and prevents writing headers/body
-	t.ctx.Response().Writer = originalWriter
-	if err != nil {
-		// call global error handler to write error to the client. This is needed or `http.TimeoutHandler` will send status code by itself
-		// and after that our tries to write status code will not work anymore
-		t.ctx.Error(err)
-		// we pass error from handler to middlewares up in handler chain to act on it if needed. But this means that
-		// global error handler is probably be called twice as `t.ctx.Error` already does that.
-		t.errChan <- err
-	}
+}
+
+func (tw *timeoutWriter) WriteHeader(code int) {
+	tw.mu.Lock()
+	defer tw.mu.Unlock()
+	tw.writeHeaderLocked(code)
 }


### PR DESCRIPTION
copy Go std library http.timeoutWriter for timeout middleware so Echolike error handling could be used (fix #1804)

p.s. (my personal opinion)
I really do not like this middleware. its complexity is potential landmine. it feels like something is conceptional wrong when you want to wrap your handler inside something like that.  most of the cases you are better off just getting context from request and creating new with timeout and making sure that your handler code knows how to stop on context cancellation/timeout