### PR TITLE
Use Logger for startup message "http[s] server started on ..."

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -769,7 +769,7 @@ func (e *Echo) configureServer(s *http.Server) (err error) {
 			}
 		}
 		if !e.HidePort {
-			e.colorer.Printf("⇨ http server started on %s\n", e.colorer.Green(e.Listener.Addr()))
+			e.Logger.Infof("⇨ http server started on %s\n", e.colorer.Green(e.Listener.Addr()))
 		}
 		return nil
 	}
@@ -781,7 +781,7 @@ func (e *Echo) configureServer(s *http.Server) (err error) {
 		e.TLSListener = tls.NewListener(l, s.TLSConfig)
 	}
 	if !e.HidePort {
-		e.colorer.Printf("⇨ https server started on %s\n", e.colorer.Green(e.TLSListener.Addr()))
+		e.Logger.Infof("⇨ https server started on %s\n", e.colorer.Green(e.TLSListener.Addr()))
 	}
 	return nil
 }
@@ -831,7 +831,7 @@ func (e *Echo) StartH2CServer(address string, h2s *http2.Server) (err error) {
 		}
 	}
 	if !e.HidePort {
-		e.colorer.Printf("⇨ http server started on %s\n", e.colorer.Green(e.Listener.Addr()))
+		e.Logger.Infof("⇨ http server started on %s\n", e.colorer.Green(e.Listener.Addr()))
 	}
 	e.startupMutex.Unlock()
 	return s.Serve(e.Listener)


### PR DESCRIPTION
**What type of PR is this?**

feature/enhancement

**What this PR does / why we need it**:

When a new echo server is started, a message will be written to the defined output like

```
http server started on [::]:8282
```

The echo framework is supporting a logging interface including logging levels.
When using this interface, the first message (when the banner is disabled), has no logging level.

In my opinion (feel free to challenge), booting up the server can be treated as an INFO log event.

In my use case, I use https://github.com/ziflex/lecho. A logging implementation for echo based on https://github.com/rs/zerolog.
This leads to a logging output like
```
2021-03-28T18:43:14+02:00 ??? ⇨ http server started on [::]:8282
```

The `???` is typically a logging level like `INF` or `WRN`.

**Does this PR introduce a user-facing change?**:

No

**Additional Information**

This PR might be opinionated. Let me know what you think.