### PR TITLE
Added routable interface

### DIFF
--- a/routable.go
+++ b/routable.go
@@ -1,0 +1,23 @@
+package echo
+
+type (
+	// Routeable is an interface which allows dependency injection in place of using concrete types Echo, and Group while creating routes.
+	Routeable interface {
+		Use(middleware ...MiddlewareFunc)
+		CONNECT(path string, h HandlerFunc, m ...MiddlewareFunc) *Route
+		DELETE(path string, h HandlerFunc, m ...MiddlewareFunc) *Route
+		GET(path string, h HandlerFunc, m ...MiddlewareFunc) *Route
+		HEAD(path string, h HandlerFunc, m ...MiddlewareFunc) *Route
+		OPTIONS(path string, h HandlerFunc, m ...MiddlewareFunc) *Route
+		PATCH(path string, h HandlerFunc, m ...MiddlewareFunc) *Route
+		POST(path string, h HandlerFunc, m ...MiddlewareFunc) *Route
+		PUT(path string, h HandlerFunc, m ...MiddlewareFunc) *Route
+		TRACE(path string, h HandlerFunc, m ...MiddlewareFunc) *Route
+		Any(path string, handler HandlerFunc, middleware ...MiddlewareFunc) []*Route
+		Match(methods []string, path string, handler HandlerFunc, middleware ...MiddlewareFunc) []*Route
+		Group(prefix string, middleware ...MiddlewareFunc) (sg *Group)
+		Static(prefix, root string)
+		File(path, file string)
+		Add(method, path string, handler HandlerFunc, middleware ...MiddlewareFunc) *Route
+	}
+)


### PR DESCRIPTION
With this file added, users of the framework will be able to use routes files as the one in the following example

[https://github.com/vinayakj009/webProject1/tree/routable_pr](https://github.com/vinayakj009/webProject1/tree/routable_pr)

With this route file, users will be able to pass objects of both the "Group" and "Echo" types to the routing functions ("AddAdminRoute" function in the example).

Allowing such an interface will allow testing of functions similar to the "AddAdminRoutes" function, by passing a custom type to act as a group or as an app.