### PR TITLE
fix Bind() when target is slice and path/query params complain target not being struct.

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -134,6 +134,10 @@ func (b *DefaultBinder) bindData(destination interface{}, data map[string][]stri
 
 	// !struct
 	if typ.Kind() != reflect.Struct {
+		if tag == "param" || tag == "query" {
+			// incompatible type, data is probably to be found in the body
+			return nil
+		}
 		return errors.New("binding element must be a struct")
 	}
 

--- a/echo_test.go
+++ b/echo_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"reflect"
 	"strings"
@@ -30,6 +31,7 @@ type (
 
 const (
 	userJSON                    = `{"id":1,"name":"Jon Snow"}`
+	usersJSON                   = `[{"id":1,"name":"Jon Snow"}]`
 	userXML                     = `<user><id>1</id><name>Jon Snow</name></user>`
 	userForm                    = `id=1&name=Jon Snow`
 	invalidContent              = "invalid content"
@@ -47,6 +49,8 @@ const userXMLPretty = `<user>
   <id>1</id>
   <name>Jon Snow</name>
 </user>`
+
+var dummyQuery = url.Values{"dummy": []string{"useless"}}
 
 func TestEcho(t *testing.T) {
 	e := New()


### PR DESCRIPTION
fix Bind() when target is slice and path/query params complain target not being struct.

For path/query params binding we do not try (silently return) to bind when target is not struct.
Recreates PR #1574 and fixes #1565