### PR TITLE
Fix #1858: Add query params binding support for anonymous struct pointer field

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -145,7 +145,7 @@ func (b *DefaultBinder) bindData(destination interface{}, data map[string][]stri
 		typeField := typ.Field(i)
 		structField := val.Field(i)
 		if typeField.Anonymous {
-			for structField.Kind() == reflect.Ptr {
+			if structField.Kind() == reflect.Ptr {
 				structField = structField.Elem()
 			}
 		}
@@ -155,8 +155,8 @@ func (b *DefaultBinder) bindData(destination interface{}, data map[string][]stri
 		structFieldKind := structField.Kind()
 		inputFieldName := typeField.Tag.Get(tag)
 		if typeField.Anonymous && structField.Kind() == reflect.Struct && inputFieldName != "" {
-			// if anonymous struct, ignore custom tag
-			inputFieldName = ""
+			// if anonymous struct with query/param/form tags, report an error
+			return errors.New("query/param/form tags are not allowed with anonymous struct field")
 		}
 
 		if inputFieldName == "" {

--- a/bind.go
+++ b/bind.go
@@ -144,11 +144,20 @@ func (b *DefaultBinder) bindData(destination interface{}, data map[string][]stri
 	for i := 0; i < typ.NumField(); i++ {
 		typeField := typ.Field(i)
 		structField := val.Field(i)
+		if typeField.Anonymous {
+			for structField.Kind() == reflect.Ptr {
+				structField = structField.Elem()
+			}
+		}
 		if !structField.CanSet() {
 			continue
 		}
 		structFieldKind := structField.Kind()
 		inputFieldName := typeField.Tag.Get(tag)
+		if typeField.Anonymous && structField.Kind() == reflect.Struct && inputFieldName != "" {
+			// if anonymous struct, ignore custom tag
+			inputFieldName = ""
+		}
 
 		if inputFieldName == "" {
 			// If tag is nil, we inspect if the field is a not BindUnmarshaler struct and try to bind data into it (might contains fields with tags).

--- a/bind_test.go
+++ b/bind_test.go
@@ -370,9 +370,7 @@ func TestBindUnmarshalParamAnonymousFieldPtrCustomTag(t *testing.T) {
 		*Bar `json:"bar" query:"bar"`
 	}{&Bar{}}
 	err := c.Bind(&result)
-	if assert.NoError(t, err) {
-		assert.Equal(t, 1, result.Baz)
-	}
+	assert.Contains(t, err.Error(), "query/param/form tags are not allowed with anonymous struct field")
 }
 
 func TestBindUnmarshalTextPtr(t *testing.T) {


### PR DESCRIPTION
try to fix #1858

if the anonymous struct filed is a pointer,  try dig one step deeper and get the underlaying struct