### PR TITLE
Fix: split XFF header only by comma

### DIFF
--- a/context.go
+++ b/context.go
@@ -276,9 +276,9 @@ func (c *context) RealIP() string {
 	}
 	// Fall back to legacy behavior
 	if ip := c.request.Header.Get(HeaderXForwardedFor); ip != "" {
-		i := strings.IndexAny(ip, ", ")
+		i := strings.IndexAny(ip, ",")
 		if i > 0 {
-			return ip[:i]
+			return strings.TrimSpace(ip[:i])
 		}
 		return ip
 	}

--- a/context_test.go
+++ b/context_test.go
@@ -891,6 +891,14 @@ func TestContext_RealIP(t *testing.T) {
 		{
 			&context{
 				request: &http.Request{
+					Header: http.Header{HeaderXForwardedFor: []string{"127.0.0.1,127.0.1.1"}},
+				},
+			},
+			"127.0.0.1",
+		},
+		{
+			&context{
+				request: &http.Request{
 					Header: http.Header{HeaderXForwardedFor: []string{"127.0.0.1"}},
 				},
 			},


### PR DESCRIPTION
When splitting `X-Forwarded-For` header by `', '` (comma and space) I got an issue when valid value `127.0.0.1,127.0.1.1` can't be parsed correctly. I'm suggesting splitting just by `,` (comma) and trim a result. 