### PR TITLE
Allow for custom JSON encoding implementations

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -2,7 +2,6 @@ package echo
 
 import (
 	"encoding"
-	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -66,13 +65,13 @@ func (b *DefaultBinder) BindBody(c Context, i interface{}) (err error) {
 	ctype := req.Header.Get(HeaderContentType)
 	switch {
 	case strings.HasPrefix(ctype, MIMEApplicationJSON):
-		if err = json.NewDecoder(req.Body).Decode(i); err != nil {
-			if ute, ok := err.(*json.UnmarshalTypeError); ok {
-				return NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Unmarshal type error: expected=%v, got=%v, field=%v, offset=%v", ute.Type, ute.Value, ute.Field, ute.Offset)).SetInternal(err)
-			} else if se, ok := err.(*json.SyntaxError); ok {
-				return NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Syntax error: offset=%v, error=%v", se.Offset, se.Error())).SetInternal(err)
+		if err = c.Echo().JSONCodec.Decode(c, i); err != nil {
+			switch err.(type) {
+			case *HTTPError:
+				return err
+			default:
+				return NewHTTPError(http.StatusBadRequest, err.Error()).SetInternal(err)
 			}
-			return NewHTTPError(http.StatusBadRequest, err.Error()).SetInternal(err)
 		}
 	case strings.HasPrefix(ctype, MIMEApplicationXML), strings.HasPrefix(ctype, MIMETextXML):
 		if err = xml.NewDecoder(req.Body).Decode(i); err != nil {

--- a/bind.go
+++ b/bind.go
@@ -65,7 +65,7 @@ func (b *DefaultBinder) BindBody(c Context, i interface{}) (err error) {
 	ctype := req.Header.Get(HeaderContentType)
 	switch {
 	case strings.HasPrefix(ctype, MIMEApplicationJSON):
-		if err = c.Echo().JSONCodec.Decode(c, i); err != nil {
+		if err = c.Echo().JSONSerializer.Deserialize(c, i); err != nil {
 			switch err.(type) {
 			case *HTTPError:
 				return err

--- a/context.go
+++ b/context.go
@@ -465,7 +465,7 @@ func (c *context) jsonPBlob(code int, callback string, i interface{}) (err error
 	if _, err = c.response.Write([]byte(callback + "(")); err != nil {
 		return
 	}
-	if err = c.echo.JSONEncoder.JSON(i, indent, c); err != nil {
+	if err = c.echo.JSONCodec.Encode(c, i, indent); err != nil {
 		return
 	}
 	if _, err = c.response.Write([]byte(");")); err != nil {
@@ -477,7 +477,7 @@ func (c *context) jsonPBlob(code int, callback string, i interface{}) (err error
 func (c *context) json(code int, i interface{}, indent string) error {
 	c.writeContentType(MIMEApplicationJSONCharsetUTF8)
 	c.response.Status = code
-	return c.echo.JSONEncoder.JSON(i, indent, c)
+	return c.echo.JSONCodec.Encode(c, i, indent)
 }
 
 func (c *context) JSON(code int, i interface{}) (err error) {

--- a/context.go
+++ b/context.go
@@ -2,7 +2,6 @@ package echo
 
 import (
 	"bytes"
-	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -457,17 +456,16 @@ func (c *context) String(code int, s string) (err error) {
 }
 
 func (c *context) jsonPBlob(code int, callback string, i interface{}) (err error) {
-	enc := json.NewEncoder(c.response)
-	_, pretty := c.QueryParams()["pretty"]
-	if c.echo.Debug || pretty {
-		enc.SetIndent("", "  ")
+	indent := ""
+	if _, pretty := c.QueryParams()["pretty"]; c.echo.Debug || pretty {
+		indent = defaultIndent
 	}
 	c.writeContentType(MIMEApplicationJavaScriptCharsetUTF8)
 	c.response.WriteHeader(code)
 	if _, err = c.response.Write([]byte(callback + "(")); err != nil {
 		return
 	}
-	if err = enc.Encode(i); err != nil {
+	if err = c.echo.JSONEncoder.JSON(i, indent, c); err != nil {
 		return
 	}
 	if _, err = c.response.Write([]byte(");")); err != nil {
@@ -477,13 +475,9 @@ func (c *context) jsonPBlob(code int, callback string, i interface{}) (err error
 }
 
 func (c *context) json(code int, i interface{}, indent string) error {
-	enc := json.NewEncoder(c.response)
-	if indent != "" {
-		enc.SetIndent("", indent)
-	}
 	c.writeContentType(MIMEApplicationJSONCharsetUTF8)
 	c.response.Status = code
-	return enc.Encode(i)
+	return c.echo.JSONEncoder.JSON(i, indent, c)
 }
 
 func (c *context) JSON(code int, i interface{}) (err error) {

--- a/context.go
+++ b/context.go
@@ -465,7 +465,7 @@ func (c *context) jsonPBlob(code int, callback string, i interface{}) (err error
 	if _, err = c.response.Write([]byte(callback + "(")); err != nil {
 		return
 	}
-	if err = c.echo.JSONCodec.Encode(c, i, indent); err != nil {
+	if err = c.echo.JSONSerializer.Serialize(c, i, indent); err != nil {
 		return
 	}
 	if _, err = c.response.Write([]byte(");")); err != nil {
@@ -477,7 +477,7 @@ func (c *context) jsonPBlob(code int, callback string, i interface{}) (err error
 func (c *context) json(code int, i interface{}, indent string) error {
 	c.writeContentType(MIMEApplicationJSONCharsetUTF8)
 	c.response.Status = code
-	return c.echo.JSONCodec.Encode(c, i, indent)
+	return c.echo.JSONSerializer.Serialize(c, i, indent)
 }
 
 func (c *context) JSON(code int, i interface{}) (err error) {

--- a/echo.go
+++ b/echo.go
@@ -90,7 +90,7 @@ type (
 		HidePort         bool
 		HTTPErrorHandler HTTPErrorHandler
 		Binder           Binder
-		JSONCodec        JSONCodec
+		JSONSerializer   JSONSerializer
 		Validator        Validator
 		Renderer         Renderer
 		Logger           Logger
@@ -126,10 +126,10 @@ type (
 		Validate(i interface{}) error
 	}
 
-	// JSONCodec is the interface that encodes and decodes JSON to and from interfaces.
-	JSONCodec interface {
-		Encode(c Context, i interface{}, indent string) error
-		Decode(c Context, i interface{}) error
+	// JSONSerializer is the interface that encodes and decodes JSON to and from interfaces.
+	JSONSerializer interface {
+		Serialize(c Context, i interface{}, indent string) error
+		Deserialize(c Context, i interface{}) error
 	}
 
 	// Renderer is the interface that wraps the Render function.
@@ -322,7 +322,7 @@ func New() (e *Echo) {
 	e.TLSServer.Handler = e
 	e.HTTPErrorHandler = e.DefaultHTTPErrorHandler
 	e.Binder = &DefaultBinder{}
-	e.JSONCodec = &DefaultJSONCodec{}
+	e.JSONSerializer = &DefaultJSONSerializer{}
 	e.Logger.SetLevel(log.ERROR)
 	e.StdLogger = stdLog.New(e.Logger.Output(), e.Logger.Prefix()+": ", 0)
 	e.pool.New = func() interface{} {

--- a/echo.go
+++ b/echo.go
@@ -90,6 +90,7 @@ type (
 		HidePort         bool
 		HTTPErrorHandler HTTPErrorHandler
 		Binder           Binder
+		JSONEncoder      JSONEncoder
 		Validator        Validator
 		Renderer         Renderer
 		Logger           Logger
@@ -123,6 +124,11 @@ type (
 	// Validator is the interface that wraps the Validate function.
 	Validator interface {
 		Validate(i interface{}) error
+	}
+
+	// JSONEncoder is the interface that encodes an interface{} into a JSON string.
+	JSONEncoder interface {
+		JSON(i interface{}, indent string, c Context) error
 	}
 
 	// Renderer is the interface that wraps the Render function.
@@ -315,6 +321,7 @@ func New() (e *Echo) {
 	e.TLSServer.Handler = e
 	e.HTTPErrorHandler = e.DefaultHTTPErrorHandler
 	e.Binder = &DefaultBinder{}
+	e.JSONEncoder = &DefaultJSONEncoder{}
 	e.Logger.SetLevel(log.ERROR)
 	e.StdLogger = stdLog.New(e.Logger.Output(), e.Logger.Prefix()+": ", 0)
 	e.pool.New = func() interface{} {

--- a/echo.go
+++ b/echo.go
@@ -90,7 +90,7 @@ type (
 		HidePort         bool
 		HTTPErrorHandler HTTPErrorHandler
 		Binder           Binder
-		JSONEncoder      JSONEncoder
+		JSONCodec        JSONCodec
 		Validator        Validator
 		Renderer         Renderer
 		Logger           Logger
@@ -126,9 +126,10 @@ type (
 		Validate(i interface{}) error
 	}
 
-	// JSONEncoder is the interface that encodes an interface{} into a JSON string.
-	JSONEncoder interface {
-		JSON(i interface{}, indent string, c Context) error
+	// JSONCodec is the interface that encodes and decodes JSON to and from interfaces.
+	JSONCodec interface {
+		Encode(c Context, i interface{}, indent string) error
+		Decode(c Context, i interface{}) error
 	}
 
 	// Renderer is the interface that wraps the Render function.
@@ -321,7 +322,7 @@ func New() (e *Echo) {
 	e.TLSServer.Handler = e
 	e.HTTPErrorHandler = e.DefaultHTTPErrorHandler
 	e.Binder = &DefaultBinder{}
-	e.JSONEncoder = &DefaultJSONEncoder{}
+	e.JSONCodec = &DefaultJSONCodec{}
 	e.Logger.SetLevel(log.ERROR)
 	e.StdLogger = stdLog.New(e.Logger.Output(), e.Logger.Prefix()+": ", 0)
 	e.pool.New = func() interface{} {

--- a/json.go
+++ b/json.go
@@ -1,15 +1,31 @@
 package echo
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
 
-// DefaultJSONEncoder implements JSON encoding using encoding/json.
-type DefaultJSONEncoder struct{}
+// DefaultJSONCodec implements JSON encoding using encoding/json.
+type DefaultJSONCodec struct{}
 
-// JSON converts an interface into a json and writes it to the response.
-func (d DefaultJSONEncoder) JSON(i interface{}, indent string, c Context) error {
+// Encode converts an interface into a json and writes it to the response.
+// You can optionally use the indent parameter to produce pretty JSONs.
+func (d DefaultJSONCodec) Encode(c Context, i interface{}, indent string) error {
 	enc := json.NewEncoder(c.Response())
 	if indent != "" {
 		enc.SetIndent("", indent)
 	}
 	return enc.Encode(i)
+}
+
+// Decode reads a JSON from a request body and converts it into an interface.
+func (d DefaultJSONCodec) Decode(c Context, i interface{}) error {
+	err := json.NewDecoder(c.Request().Body).Decode(i)
+	if ute, ok := err.(*json.UnmarshalTypeError); ok {
+		return NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Unmarshal type error: expected=%v, got=%v, field=%v, offset=%v", ute.Type, ute.Value, ute.Field, ute.Offset)).SetInternal(err)
+	} else if se, ok := err.(*json.SyntaxError); ok {
+		return NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Syntax error: offset=%v, error=%v", se.Offset, se.Error())).SetInternal(err)
+	}
+	return err
 }

--- a/json.go
+++ b/json.go
@@ -1,0 +1,15 @@
+package echo
+
+import "encoding/json"
+
+// DefaultJSONEncoder implements JSON encoding using encoding/json.
+type DefaultJSONEncoder struct{}
+
+// JSON converts an interface into a json and writes it to the response.
+func (d DefaultJSONEncoder) JSON(i interface{}, indent string, c Context) error {
+	enc := json.NewEncoder(c.Response())
+	if indent != "" {
+		enc.SetIndent("", indent)
+	}
+	return enc.Encode(i)
+}

--- a/json.go
+++ b/json.go
@@ -6,12 +6,12 @@ import (
 	"net/http"
 )
 
-// DefaultJSONCodec implements JSON encoding using encoding/json.
-type DefaultJSONCodec struct{}
+// DefaultJSONSerializer implements JSON encoding using encoding/json.
+type DefaultJSONSerializer struct{}
 
-// Encode converts an interface into a json and writes it to the response.
+// Serialize converts an interface into a json and writes it to the response.
 // You can optionally use the indent parameter to produce pretty JSONs.
-func (d DefaultJSONCodec) Encode(c Context, i interface{}, indent string) error {
+func (d DefaultJSONSerializer) Serialize(c Context, i interface{}, indent string) error {
 	enc := json.NewEncoder(c.Response())
 	if indent != "" {
 		enc.SetIndent("", indent)
@@ -19,8 +19,8 @@ func (d DefaultJSONCodec) Encode(c Context, i interface{}, indent string) error 
 	return enc.Encode(i)
 }
 
-// Decode reads a JSON from a request body and converts it into an interface.
-func (d DefaultJSONCodec) Decode(c Context, i interface{}) error {
+// Deserialize reads a JSON from a request body and converts it into an interface.
+func (d DefaultJSONSerializer) Deserialize(c Context, i interface{}) error {
 	err := json.NewDecoder(c.Request().Body).Decode(i)
 	if ute, ok := err.(*json.UnmarshalTypeError); ok {
 		return NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Unmarshal type error: expected=%v, got=%v, field=%v, offset=%v", ute.Type, ute.Value, ute.Field, ute.Offset)).SetInternal(err)

--- a/json_test.go
+++ b/json_test.go
@@ -1,0 +1,47 @@
+package echo
+
+import (
+	testify "github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Note this test is deliberately simple as there's not a lot to test.
+// Just need to ensure it writes JSONs. The heavy work is done by the context methods.
+func TestDefaultJSONEncoder_JSON(t *testing.T) {
+	e := New()
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec).(*context)
+
+	assert := testify.New(t)
+
+	// Echo
+	assert.Equal(e, c.Echo())
+
+	// Request
+	assert.NotNil(c.Request())
+
+	// Response
+	assert.NotNil(c.Response())
+
+	//--------
+	// Default JSON encoder
+	//--------
+
+	enc := new(DefaultJSONEncoder)
+
+	err := enc.JSON(user{1, "Jon Snow"}, "", c)
+	if assert.NoError(err) {
+		assert.Equal(userJSON+"\n", rec.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/", nil)
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec).(*context)
+	err = enc.JSON(user{1, "Jon Snow"}, "  ", c)
+	if assert.NoError(err) {
+		assert.Equal(userJSONPretty+"\n", rec.Body.String())
+	}
+}

--- a/json_test.go
+++ b/json_test.go
@@ -31,9 +31,9 @@ func TestDefaultJSONCodec_Encode(t *testing.T) {
 	// Default JSON encoder
 	//--------
 
-	enc := new(DefaultJSONCodec)
+	enc := new(DefaultJSONSerializer)
 
-	err := enc.Encode(c, user{1, "Jon Snow"}, "")
+	err := enc.Serialize(c, user{1, "Jon Snow"}, "")
 	if assert.NoError(err) {
 		assert.Equal(userJSON+"\n", rec.Body.String())
 	}
@@ -41,7 +41,7 @@ func TestDefaultJSONCodec_Encode(t *testing.T) {
 	req = httptest.NewRequest(http.MethodPost, "/", nil)
 	rec = httptest.NewRecorder()
 	c = e.NewContext(req, rec).(*context)
-	err = enc.Encode(c, user{1, "Jon Snow"}, "  ")
+	err = enc.Serialize(c, user{1, "Jon Snow"}, "  ")
 	if assert.NoError(err) {
 		assert.Equal(userJSONPretty+"\n", rec.Body.String())
 	}
@@ -70,10 +70,10 @@ func TestDefaultJSONCodec_Decode(t *testing.T) {
 	// Default JSON encoder
 	//--------
 
-	enc := new(DefaultJSONCodec)
+	enc := new(DefaultJSONSerializer)
 
 	var u = user{}
-	err := enc.Decode(c, &u)
+	err := enc.Deserialize(c, &u)
 	if assert.NoError(err) {
 		assert.Equal(u, user{ID: 1, Name: "Jon Snow"})
 	}
@@ -82,7 +82,7 @@ func TestDefaultJSONCodec_Decode(t *testing.T) {
 	req = httptest.NewRequest(http.MethodPost, "/", strings.NewReader(invalidContent))
 	rec = httptest.NewRecorder()
 	c = e.NewContext(req, rec).(*context)
-	err = enc.Decode(c, &userUnmarshalSyntaxError)
+	err = enc.Deserialize(c, &userUnmarshalSyntaxError)
 	assert.IsType(&HTTPError{}, err)
 	assert.EqualError(err, "code=400, message=Syntax error: offset=1, error=invalid character 'i' looking for beginning of value, internal=invalid character 'i' looking for beginning of value")
 
@@ -94,7 +94,7 @@ func TestDefaultJSONCodec_Decode(t *testing.T) {
 	req = httptest.NewRequest(http.MethodPost, "/", strings.NewReader(userJSON))
 	rec = httptest.NewRecorder()
 	c = e.NewContext(req, rec).(*context)
-	err = enc.Decode(c, &userUnmarshalTypeError)
+	err = enc.Deserialize(c, &userUnmarshalTypeError)
 	assert.IsType(&HTTPError{}, err)
 	assert.EqualError(err, "code=400, message=Unmarshal type error: expected=string, got=number, field=id, offset=7, internal=json: cannot unmarshal number into Go struct field .id of type string")
 

--- a/json_test.go
+++ b/json_test.go
@@ -4,12 +4,13 @@ import (
 	testify "github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
 // Note this test is deliberately simple as there's not a lot to test.
 // Just need to ensure it writes JSONs. The heavy work is done by the context methods.
-func TestDefaultJSONEncoder_JSON(t *testing.T) {
+func TestDefaultJSONCodec_Encode(t *testing.T) {
 	e := New()
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
 	rec := httptest.NewRecorder()
@@ -30,9 +31,9 @@ func TestDefaultJSONEncoder_JSON(t *testing.T) {
 	// Default JSON encoder
 	//--------
 
-	enc := new(DefaultJSONEncoder)
+	enc := new(DefaultJSONCodec)
 
-	err := enc.JSON(user{1, "Jon Snow"}, "", c)
+	err := enc.Encode(c, user{1, "Jon Snow"}, "")
 	if assert.NoError(err) {
 		assert.Equal(userJSON+"\n", rec.Body.String())
 	}
@@ -40,8 +41,61 @@ func TestDefaultJSONEncoder_JSON(t *testing.T) {
 	req = httptest.NewRequest(http.MethodPost, "/", nil)
 	rec = httptest.NewRecorder()
 	c = e.NewContext(req, rec).(*context)
-	err = enc.JSON(user{1, "Jon Snow"}, "  ", c)
+	err = enc.Encode(c, user{1, "Jon Snow"}, "  ")
 	if assert.NoError(err) {
 		assert.Equal(userJSONPretty+"\n", rec.Body.String())
 	}
+}
+
+// Note this test is deliberately simple as there's not a lot to test.
+// Just need to ensure it writes JSONs. The heavy work is done by the context methods.
+func TestDefaultJSONCodec_Decode(t *testing.T) {
+	e := New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(userJSON))
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec).(*context)
+
+	assert := testify.New(t)
+
+	// Echo
+	assert.Equal(e, c.Echo())
+
+	// Request
+	assert.NotNil(c.Request())
+
+	// Response
+	assert.NotNil(c.Response())
+
+	//--------
+	// Default JSON encoder
+	//--------
+
+	enc := new(DefaultJSONCodec)
+
+	var u = user{}
+	err := enc.Decode(c, &u)
+	if assert.NoError(err) {
+		assert.Equal(u, user{ID: 1, Name: "Jon Snow"})
+	}
+
+	var userUnmarshalSyntaxError = user{}
+	req = httptest.NewRequest(http.MethodPost, "/", strings.NewReader(invalidContent))
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec).(*context)
+	err = enc.Decode(c, &userUnmarshalSyntaxError)
+	assert.IsType(&HTTPError{}, err)
+	assert.EqualError(err, "code=400, message=Syntax error: offset=1, error=invalid character 'i' looking for beginning of value, internal=invalid character 'i' looking for beginning of value")
+
+	var userUnmarshalTypeError = struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}{}
+
+	req = httptest.NewRequest(http.MethodPost, "/", strings.NewReader(userJSON))
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec).(*context)
+	err = enc.Decode(c, &userUnmarshalTypeError)
+	assert.IsType(&HTTPError{}, err)
+	assert.EqualError(err, "code=400, message=Unmarshal type error: expected=string, got=number, field=id, offset=7, internal=json: cannot unmarshal number into Go struct field .id of type string")
+
 }


### PR DESCRIPTION
This PR is an alternative implementation to #1774.

It allows users to give a custom JSON encoder implementation including jsoniter as has been requested multiple times. My use-case is slightly different, in that I wanted to use https://github.com/google/jsonapi as the default JSON implementation.

Happy to try and raise some examples in the cookbook for this if this gets approved/merged.

closes #1177
closes #1204
closes #1394
closes #1698
closes #1774 