### PR TITLE
Add queue middleware

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/valyala/fasttemplate v1.2.1
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57 // indirect
 	golang.org/x/text v0.3.6 // indirect
 	golang.org/x/time v0.0.0-20201208040808-7e3f01d25324

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 h1:4nGaVu0QrbjT/AK2PRLuQfQuh6DJve+pELhqTdAj3x0=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/middleware/queue.go
+++ b/middleware/queue.go
@@ -1,0 +1,117 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"golang.org/x/sync/semaphore"
+)
+
+type (
+	// QueueConfig defines the configuration for the queue
+	QueueConfig struct {
+		Skipper    Skipper
+		BeforeFunc BeforeFunc
+
+		QueueSize int64
+		Workers   int64
+
+		QueueTimeout  time.Duration
+		WorkerTimeout time.Duration
+	}
+)
+
+// errors
+var (
+	// ErrQueueFull denotes an error raised when queue limit is reached
+	ErrQueueFull = echo.NewHTTPError(http.StatusTooManyRequests, "queue limit reached")
+	// ErrQueueTimeout denotes an error raised when context times out
+	ErrQueueTimeout = echo.NewHTTPError(http.StatusRequestTimeout, "request took too long to process")
+)
+
+// DefaultQueueConfig defines default values for QueueConfig
+var DefaultQueueConfig = QueueConfig{
+	Skipper:       DefaultSkipper,
+	QueueSize:     100,
+	Workers:       8,
+	QueueTimeout:  30 * time.Second,
+	WorkerTimeout: 10 * time.Second,
+}
+
+/*
+Queue returns a queue middleware
+
+	e := echo.New()
+
+	e.GET("/queue", func(c echo.Context) error {
+		return c.String(http.StatusOK, "test")
+	}, Queue())
+
+*/
+func Queue() echo.MiddlewareFunc {
+	config := DefaultQueueConfig
+
+	return QueueWithConfig(config)
+}
+
+/*
+QueueWithConfig returns a queue middleware
+
+	e := echo.New()
+
+	config := middleware.QueueConfig{
+		Skipper: DefaultSkipper,
+		QueueSize:     2,
+		Workers:       1,
+		QueueTimeout:  20 * time.Second,
+		WorkerTimeout: 10 * time.Second,
+	}
+
+	e.GET("/queue", func(c echo.Context) error {
+		return c.String(http.StatusOK, "test")
+	}, middleware.QueueWithConfig(config))
+
+*/
+func QueueWithConfig(config QueueConfig) echo.MiddlewareFunc {
+	if config.Skipper == nil {
+		config.Skipper = DefaultQueueConfig.Skipper
+	}
+
+	queueSemaphore := semaphore.NewWeighted(config.QueueSize)
+	workersSemaphore := semaphore.NewWeighted(config.Workers)
+
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if config.Skipper(c) {
+				return next(c)
+			}
+			if config.BeforeFunc != nil {
+				config.BeforeFunc(c)
+			}
+
+			ctxQueue, _ := context.WithTimeout(context.Background(), config.QueueTimeout)
+
+			if err := queueSemaphore.Acquire(ctxQueue, 1); err != nil {
+				c.Error(ErrQueueFull)
+				return nil
+			}
+
+			ctxWorker, _ := context.WithTimeout(ctxQueue, config.WorkerTimeout)
+
+			if err := workersSemaphore.Acquire(ctxWorker, 1); err != nil {
+				queueSemaphore.Release(1)
+				c.Error(ErrQueueTimeout)
+				return nil
+			}
+
+			err := next(c)
+
+			workersSemaphore.Release(1)
+			queueSemaphore.Release(1)
+
+			return err
+		}
+	}
+}

--- a/middleware/queue_test.go
+++ b/middleware/queue_test.go
@@ -119,7 +119,7 @@ func TestQueueWithConfig_panic(t *testing.T) {
 	})
 
 	expectedCalls := 5
-	actualCalls := 0
+	actualCallsChan := make(chan struct{}, 5)
 	var wg sync.WaitGroup
 
 	for i := 0; i < 5; i++ {
@@ -140,13 +140,15 @@ func TestQueueWithConfig_panic(t *testing.T) {
 				return
 			}
 
-			actualCalls++
+			actualCallsChan <- struct{}{}
 
 		}()
 
 	}
 
 	wg.Wait()
+
+	actualCalls := len(actualCallsChan)
 
 	assert.Equal(t, expectedCalls, actualCalls)
 }

--- a/middleware/queue_test.go
+++ b/middleware/queue_test.go
@@ -1,0 +1,182 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueueWithConfig(t *testing.T) {
+	e := echo.New()
+
+	handler := func(c echo.Context) error {
+		pts := c.Get("procTime")
+		procTime, ok := pts.(int)
+		if !ok {
+			return c.NoContent(http.StatusInternalServerError)
+		}
+
+		time.Sleep(time.Duration(procTime) * time.Millisecond)
+
+		return c.NoContent(http.StatusOK)
+	}
+
+	mw := QueueWithConfig(QueueConfig{
+		QueueSize:     2,
+		Workers:       1,
+		QueueTimeout:  200 * time.Millisecond,
+		WorkerTimeout: 100 * time.Millisecond,
+	})
+
+	testCases := []struct {
+		procTime int // in Milliseconds
+	}{
+		{50},
+		{95},
+		{95},
+		{95},
+		{95},
+		{120},
+		{250},
+	}
+
+	ch := make(chan int, len(testCases))
+	var wg sync.WaitGroup
+
+	for _, tc := range testCases {
+
+		wg.Add(1)
+
+		go func(pt int) {
+
+			defer wg.Done()
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+			rec := httptest.NewRecorder()
+
+			c := e.NewContext(req, rec)
+
+			c.Set("procTime", pt)
+
+			_ = mw(handler)(c)
+
+			ch <- rec.Code
+
+		}(tc.procTime)
+
+	}
+
+	wg.Wait()
+
+	var errQueueFull, errQueueTimeout, errInternalServerError bool
+
+	for i := 0; i < len(testCases); i++ {
+		c := <-ch
+
+		t.Log(c)
+
+		if c == http.StatusTooManyRequests {
+			errQueueFull = true
+		}
+
+		if c == http.StatusRequestTimeout {
+			errQueueTimeout = true
+		}
+
+		if c == http.StatusInternalServerError {
+			errInternalServerError = true
+		}
+	}
+
+	assert.Equal(t, true, errQueueFull)
+	assert.Equal(t, true, errQueueTimeout)
+	assert.Equal(t, false, errInternalServerError)
+
+}
+
+func TestQueueWithConfig_skipper(t *testing.T) {
+	e := echo.New()
+
+	var beforeFuncRan bool
+	handler := func(c echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	rec := httptest.NewRecorder()
+
+	c := e.NewContext(req, rec)
+
+	mw := QueueWithConfig(QueueConfig{
+		Skipper: func(c echo.Context) bool {
+			return true
+		},
+		BeforeFunc: func(c echo.Context) {
+			beforeFuncRan = true
+		},
+	})
+
+	_ = mw(handler)(c)
+
+	assert.Equal(t, false, beforeFuncRan)
+}
+
+func TestQueueWithConfig_skipperNoSkip(t *testing.T) {
+	e := echo.New()
+
+	var beforeFuncRan bool
+	handler := func(c echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	rec := httptest.NewRecorder()
+
+	c := e.NewContext(req, rec)
+
+	mw := QueueWithConfig(QueueConfig{
+		Skipper: func(c echo.Context) bool {
+			return false
+		},
+		BeforeFunc: func(c echo.Context) {
+			beforeFuncRan = true
+		},
+	})
+
+	_ = mw(handler)(c)
+
+	assert.Equal(t, true, beforeFuncRan)
+}
+
+func TestQueueWithConfig_beforeFunc(t *testing.T) {
+	e := echo.New()
+
+	var beforeRan bool
+	handler := func(c echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	rec := httptest.NewRecorder()
+
+	c := e.NewContext(req, rec)
+
+	mw := QueueWithConfig(QueueConfig{
+		BeforeFunc: func(c echo.Context) {
+			beforeRan = true
+		},
+	})
+
+	_ = mw(handler)(c)
+
+	assert.Equal(t, true, beforeRan)
+}

--- a/middleware/queue_test.go
+++ b/middleware/queue_test.go
@@ -16,10 +16,7 @@ func TestQueueWithConfig(t *testing.T) {
 
 	handler := func(c echo.Context) error {
 		pts := c.Get("procTime")
-		procTime, ok := pts.(int)
-		if !ok {
-			return c.NoContent(http.StatusInternalServerError)
-		}
+		procTime, _ := pts.(int)
 
 		time.Sleep(time.Duration(procTime) * time.Millisecond)
 
@@ -37,12 +34,16 @@ func TestQueueWithConfig(t *testing.T) {
 		procTime int // in Milliseconds
 	}{
 		{50},
-		{95},
-		{95},
-		{95},
-		{95},
-		{120},
-		{250},
+		{99},
+		{99},
+		{99},
+		{99},
+		{150},
+		{150},
+		{150},
+		{300},
+		{300},
+		{300},
 	}
 
 	ch := make(chan int, len(testCases))
@@ -76,7 +77,7 @@ func TestQueueWithConfig(t *testing.T) {
 
 	wg.Wait()
 
-	var errQueueFull, errQueueTimeout, errInternalServerError bool
+	var errQueueFull, errQueueTimeout bool
 
 	for i := 0; i < len(testCases); i++ {
 		c := <-ch
@@ -88,15 +89,10 @@ func TestQueueWithConfig(t *testing.T) {
 		if c == http.StatusRequestTimeout {
 			errQueueTimeout = true
 		}
-
-		if c == http.StatusInternalServerError {
-			errInternalServerError = true
-		}
 	}
 
 	assert.Equal(t, true, errQueueFull)
 	assert.Equal(t, true, errQueueTimeout)
-	assert.Equal(t, false, errInternalServerError)
 }
 
 func TestQueueWithConfig_panic(t *testing.T) {


### PR DESCRIPTION
Hoping this middleware might be useful for others, I'm submitting this PR that adds a Queue Middleware.

Basically, it creates a queue of size `x` and a worker pool of size `y` so no more than `y` requests can be processed at any given time while `x` requests can stack up in the queue.