### PR TITLE
Making Echo#Reverse() deterministic

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -540,7 +540,7 @@ func (e *Echo) add(host, method, path string, handler HandlerFunc, middleware ..
 		Path:   path,
 		Name:   name,
 	}
-	e.router.routes[method+path] = r
+	e.router.routes = append(e.router.routes, r)
 	return r
 }
 
@@ -602,10 +602,8 @@ func (e *Echo) Reverse(name string, params ...interface{}) string {
 
 // Routes returns the registered routes.
 func (e *Echo) Routes() []*Route {
-	routes := make([]*Route, 0, len(e.router.routes))
-	for _, v := range e.router.routes {
-		routes = append(routes, v)
-	}
+	routes := make([]*Route, len(e.router.routes))
+	copy(routes, e.router.routes)
 	return routes
 }
 

--- a/echo_test.go
+++ b/echo_test.go
@@ -1152,6 +1152,8 @@ func TestEchoReverse(t *testing.T) {
 	e.GET("/params/:foo", dummyHandler).Name = "/params/:foo"
 	e.GET("/params/:foo/bar/:qux", dummyHandler).Name = "/params/:foo/bar/:qux"
 	e.GET("/params/:foo/bar/:qux/*", dummyHandler).Name = "/params/:foo/bar/:qux/*"
+	e.GET("/repeated_name_one", dummyHandler).Name = "/repeated_name"
+	e.GET("/repeated_name_two", dummyHandler).Name = "/repeated_name"
 
 	assert.Equal("/static", e.Reverse("/static"))
 	assert.Equal("/static", e.Reverse("/static", "missing param"))
@@ -1164,6 +1166,10 @@ func TestEchoReverse(t *testing.T) {
 	assert.Equal("/params/one/bar/:qux", e.Reverse("/params/:foo/bar/:qux", "one"))
 	assert.Equal("/params/one/bar/two", e.Reverse("/params/:foo/bar/:qux", "one", "two"))
 	assert.Equal("/params/one/bar/two/three", e.Reverse("/params/:foo/bar/:qux/*", "one", "two", "three"))
+
+	for i := 0; i < 100; i++ {
+		assert.Equal("/repeated_name_one", e.Reverse("/repeated_name"))
+	}
 }
 
 func TestEcho_ListenerAddr(t *testing.T) {

--- a/router.go
+++ b/router.go
@@ -9,7 +9,7 @@ type (
 	// request matching and URL path parameter parsing.
 	Router struct {
 		tree   *node
-		routes map[string]*Route
+		routes []*Route
 		echo   *Echo
 	}
 	node struct {
@@ -74,7 +74,7 @@ func NewRouter(e *Echo) *Router {
 		tree: &node{
 			methodHandler: new(methodHandler),
 		},
-		routes: map[string]*Route{},
+		routes: []*Route{},
 		echo:   e,
 	}
 }


### PR DESCRIPTION
When the same handler/name is assigned to more than one route, Echo now returns the first route every time.

Fixes #1237 