### PR TITLE
Fixed a problem that returned wrong content-encoding when the gzip co…

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -27,7 +27,7 @@ type (
 	gzipResponseWriter struct {
 		io.Writer
 		http.ResponseWriter
-		wroteHeader bool
+		wroteBody bool
 	}
 )
 
@@ -81,7 +81,7 @@ func GzipWithConfig(config GzipConfig) echo.MiddlewareFunc {
 				w.Reset(rw)
 				grw := &gzipResponseWriter{Writer: w, ResponseWriter: rw}
 				defer func() {
-					if res.Size == 0 && !grw.wroteHeader {
+					if res.Size == 0 && !grw.wroteBody {
 						if res.Header().Get(echo.HeaderContentEncoding) == gzipScheme {
 							res.Header().Del(echo.HeaderContentEncoding)
 						}
@@ -113,7 +113,7 @@ func (w *gzipResponseWriter) Write(b []byte) (int, error) {
 	if w.Header().Get(echo.HeaderContentType) == "" {
 		w.Header().Set(echo.HeaderContentType, http.DetectContentType(b))
 	}
-	w.wroteHeader = true
+	w.wroteBody = true
 	return w.Writer.Write(b)
 }
 

--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -81,7 +81,7 @@ func GzipWithConfig(config GzipConfig) echo.MiddlewareFunc {
 				w.Reset(rw)
 				grw := &gzipResponseWriter{Writer: w, ResponseWriter: rw}
 				defer func() {
-					if res.Size == 0 && !grw.wroteBody {
+					if !grw.wroteBody {
 						if res.Header().Get(echo.HeaderContentEncoding) == gzipScheme {
 							res.Header().Del(echo.HeaderContentEncoding)
 						}

--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -102,9 +102,6 @@ func GzipWithConfig(config GzipConfig) echo.MiddlewareFunc {
 }
 
 func (w *gzipResponseWriter) WriteHeader(code int) {
-	if code == http.StatusNoContent { // Issue #489
-		w.ResponseWriter.Header().Del(echo.HeaderContentEncoding)
-	}
 	w.Header().Del(echo.HeaderContentLength) // Issue #444
 	w.ResponseWriter.WriteHeader(code)
 }


### PR DESCRIPTION
I fixed a problem that returned wrong content-encoding when the gzip compressed content was empty.

`gzip.Writer` writes a gzip header if Write is called even once, and does not return the length of the header.
we need to record the Write call and make sure that the gzip header is written.

