### PR TITLE
Fix lint: redundant type inside map

### DIFF
--- a/ip_test.go
+++ b/ip_test.go
@@ -42,48 +42,48 @@ var (
 	}, ", ")
 
 	requests = map[string]*http.Request{
-		ipTestReqKeyNoHeader: &http.Request{
+		ipTestReqKeyNoHeader: {
 			RemoteAddr: sampleRemoteAddrExternal,
 		},
-		ipTestReqKeyRealIPExternal: &http.Request{
+		ipTestReqKeyRealIPExternal: {
 			Header: http.Header{
 				"X-Real-Ip": []string{ipForRealIP},
 			},
 			RemoteAddr: sampleRemoteAddrExternal,
 		},
-		ipTestReqKeyRealIPInternal: &http.Request{
+		ipTestReqKeyRealIPInternal: {
 			Header: http.Header{
 				"X-Real-Ip": []string{ipForRealIP},
 			},
 			RemoteAddr: sampleRemoteAddrLoopback,
 		},
-		ipTestReqKeyRealIPAndXFFExternal: &http.Request{
+		ipTestReqKeyRealIPAndXFFExternal: {
 			Header: http.Header{
 				"X-Real-Ip":         []string{ipForRealIP},
 				HeaderXForwardedFor: []string{sampleXFF},
 			},
 			RemoteAddr: sampleRemoteAddrExternal,
 		},
-		ipTestReqKeyRealIPAndXFFInternal: &http.Request{
+		ipTestReqKeyRealIPAndXFFInternal: {
 			Header: http.Header{
 				"X-Real-Ip":         []string{ipForRealIP},
 				HeaderXForwardedFor: []string{sampleXFF},
 			},
 			RemoteAddr: sampleRemoteAddrLoopback,
 		},
-		ipTestReqKeyXFFExternal: &http.Request{
+		ipTestReqKeyXFFExternal: {
 			Header: http.Header{
 				HeaderXForwardedFor: []string{sampleXFF},
 			},
 			RemoteAddr: sampleRemoteAddrExternal,
 		},
-		ipTestReqKeyXFFInternal: &http.Request{
+		ipTestReqKeyXFFInternal: {
 			Header: http.Header{
 				HeaderXForwardedFor: []string{sampleXFF},
 			},
 			RemoteAddr: sampleRemoteAddrLoopback,
 		},
-		ipTestReqKeyBrokenXFF: &http.Request{
+		ipTestReqKeyBrokenXFF: {
 			Header: http.Header{
 				HeaderXForwardedFor: []string{ipForXFFBroken + ", " + ipForXFF1LinkLocal},
 			},


### PR DESCRIPTION
The type of the map's value, *http.request is declared already. It is redundant to add the type for each key-value pair inside. Simply removing them works fine. This is a small change, which is why I did not open an issue to discuss this first.