### PR TITLE
Ignore case of auth scheme in request header

### DIFF
--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -295,7 +295,7 @@ func jwtFromHeader(header string, authScheme string) jwtExtractor {
 	return func(c echo.Context) (string, error) {
 		auth := c.Request().Header.Get(header)
 		l := len(authScheme)
-		if len(auth) > l+1 && auth[:l] == authScheme {
+		if len(auth) > l+1 && strings.EqualFold(auth[:l], authScheme) {
 			return auth[l+1:], nil
 		}
 		return "", ErrJWTMissing

--- a/middleware/jwt_test.go
+++ b/middleware/jwt_test.go
@@ -261,6 +261,11 @@ func TestJWT(t *testing.T) {
 			expErrCode: http.StatusUnauthorized,
 			info:       "Token verification does not pass using a user-defined KeyFunc",
 		},
+		{
+			hdrAuth: strings.ToLower(DefaultJWTConfig.AuthScheme) + " " + token,
+			config:  JWTConfig{SigningKey: validKey},
+			info:    "Valid JWT with lower case AuthScheme",
+		},
 	} {
 		if tc.reqURL == "" {
 			tc.reqURL = "/"


### PR DESCRIPTION
Some clients send an authorization header containing the `bearer` keyword in lower case. This led to echo responding with `missing or malformed jwt`.

`Request.BasicAuth` (net/http) ignores the basic auth scheme's case since a while: https://go-review.googlesource.com/c/go/+/111516/
