### PR TITLE
New param to get clean route specified on server startup from echo.Co…

### DIFF
--- a/context.go
+++ b/context.go
@@ -48,6 +48,9 @@ type (
 		// Path returns the registered path for the handler.
 		Path() string
 
+		// RouterPath returns the registered path for the handler on server startup.
+		RouterPath() string
+
 		// SetPath sets the registered path for the handler.
 		SetPath(p string)
 
@@ -196,17 +199,18 @@ type (
 	}
 
 	context struct {
-		request  *http.Request
-		response *Response
-		path     string
-		pnames   []string
-		pvalues  []string
-		query    url.Values
-		handler  HandlerFunc
-		store    Map
-		echo     *Echo
-		logger   Logger
-		lock     sync.RWMutex
+		request    *http.Request
+		response   *Response
+		path       string
+		routerPath string
+		pnames     []string
+		pvalues    []string
+		query      url.Values
+		handler    HandlerFunc
+		store      Map
+		echo       *Echo
+		logger     Logger
+		lock       sync.RWMutex
 	}
 )
 
@@ -290,6 +294,10 @@ func (c *context) RealIP() string {
 
 func (c *context) Path() string {
 	return c.path
+}
+
+func (c *context) RouterPath() string {
+	return c.routerPath
 }
 
 func (c *context) SetPath(p string) {

--- a/context_test.go
+++ b/context_test.go
@@ -480,6 +480,26 @@ func TestContextPath(t *testing.T) {
 	assert.Equal("/users/:uid/files/:fid", c.Path())
 }
 
+func TestContextRouterPath(t *testing.T) {
+	e := New()
+	r := e.Router()
+
+	handler := func(c Context) error { return c.String(http.StatusOK, "OK") }
+
+	r.Add(http.MethodGet, "/users/:id", handler)
+	c := e.NewContext(nil, nil)
+	r.Find(http.MethodGet, "/users/1", c)
+
+	assert := testify.New(t)
+
+	assert.Equal("/users/:id", c.RouterPath())
+
+	r.Add(http.MethodGet, "/users/:uid/files/:fid", handler)
+	c = e.NewContext(nil, nil)
+	r.Find(http.MethodGet, "/users/1/files/1", c)
+	assert.Equal("/users/:uid/files/:fid", c.RouterPath())
+}
+
 func TestContextPathParam(t *testing.T) {
 	e := New()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)

--- a/router.go
+++ b/router.go
@@ -561,6 +561,7 @@ func (r *Router) Find(method, path string, c Context) {
 	}
 	ctx.path = currentNode.ppath
 	ctx.pnames = currentNode.pnames
+	ctx.routerPath = currentNode.ppath
 
 	return
 }


### PR DESCRIPTION
New param to get clean route specified on server startup from echo.Context

Motivation: i want easy way to get clean route from startup for example to use it in middlewares or something like this

So, I made new method RouterPath to get it from context. Path is not relevant for me, because we modify it next step with function GetPath()