### PR TITLE
allow escaping of colon in route path 

### DIFF
--- a/router.go
+++ b/router.go
@@ -98,6 +98,9 @@ func (r *Router) Add(method, path string, h HandlerFunc) {
 
 	for i, lcpIndex := 0, len(path); i < lcpIndex; i++ {
 		if path[i] == ':' {
+			if i > 0 && path[i-1] == '\\' {
+				continue
+			}
 			j := i + 1
 
 			r.insert(method, path[:i], nil, staticKind, "", nil)


### PR DESCRIPTION
allow escaping of colon in route path so Google Cloud API "custom methods" https://cloud.google.com/apis/design/custom_methods could be implemented (resolves #1987)