### PR TITLE
Add start time to request logger middleware values

### DIFF
--- a/middleware/request_logger.go
+++ b/middleware/request_logger.go
@@ -124,6 +124,8 @@ type RequestLoggerConfig struct {
 
 // RequestLoggerValues contains extracted values from logger.
 type RequestLoggerValues struct {
+	// StartTime is time recorded before next middleware/handler is executed.
+	StartTime time.Time
 	// Latency is duration it took to execute rest of the handler chain (next(c) call).
 	Latency time.Duration
 	// Protocol is request protocol (i.e. `HTTP/1.1` or `HTTP/2`)
@@ -215,7 +217,9 @@ func (config RequestLoggerConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
 			}
 			err := next(c)
 
-			v := RequestLoggerValues{}
+			v := RequestLoggerValues{
+				StartTime: start,
+			}
 			if config.LogLatency {
 				v.Latency = now().Sub(start)
 			}

--- a/middleware/request_logger_test.go
+++ b/middleware/request_logger_test.go
@@ -296,6 +296,7 @@ func TestRequestLogger_allFields(t *testing.T) {
 	err := mw(c)
 
 	assert.NoError(t, err)
+	assert.Equal(t, time.Unix(1631045377, 0), expect.StartTime)
 	assert.Equal(t, 10*time.Second, expect.Latency)
 	assert.Equal(t, "HTTP/1.1", expect.Protocol)
 	assert.Equal(t, "8.8.8.8", expect.RemoteIP)


### PR DESCRIPTION
Add start time to request logger middleware values to get time value just before next middleware/handler was called. Logger middlewares timestamps are for instants after handler `next(c)` has returned back to request logger scope. `v.StartTime` gives you time before. 

See https://github.com/labstack/echo/issues/1989#issuecomment-923493225