### PR TITLE
Lock adding routes to map

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -545,6 +545,9 @@ func (e *Echo) File(path, file string, m ...MiddlewareFunc) *Route {
 }
 
 func (e *Echo) add(host, method, path string, handler HandlerFunc, middleware ...MiddlewareFunc) *Route {
+	e.router.lock.Lock()
+	defer e.router.lock.Unlock()
+
 	name := handlerName(handler)
 	router := e.findRouter(host)
 	router.Add(method, path, func(c Context) error {
@@ -594,6 +597,9 @@ func (e *Echo) URL(h HandlerFunc, params ...interface{}) string {
 
 // Reverse generates an URL from route name and provided parameters.
 func (e *Echo) Reverse(name string, params ...interface{}) string {
+	e.router.lock.RLock()
+	defer e.router.lock.RUnlock()
+
 	uri := new(bytes.Buffer)
 	ln := len(params)
 	n := 0
@@ -618,6 +624,9 @@ func (e *Echo) Reverse(name string, params ...interface{}) string {
 
 // Routes returns the registered routes.
 func (e *Echo) Routes() []*Route {
+	e.router.lock.RLock()
+	defer e.router.lock.RUnlock()
+
 	routes := make([]*Route, 0, len(e.router.routes))
 	for _, v := range e.router.routes {
 		routes = append(routes, v)

--- a/router.go
+++ b/router.go
@@ -2,6 +2,7 @@ package echo
 
 import (
 	"net/http"
+	"sync"
 )
 
 type (
@@ -10,6 +11,7 @@ type (
 	Router struct {
 		tree   *node
 		routes map[string]*Route
+		lock   sync.RWMutex
 		echo   *Echo
 	}
 	node struct {
@@ -74,6 +76,7 @@ func NewRouter(e *Echo) *Router {
 		tree: &node{
 			methodHandler: new(methodHandler),
 		},
+		lock:   sync.RWMutex{},
 		routes: map[string]*Route{},
 		echo:   e,
 	}


### PR DESCRIPTION
When adding routes in a go-routine, sometimes I get the error `fatal error: concurrent map writes` as routes aren't written to the map safely. This is intermittent so I'm not sure how to give you a good method of reproducing the issue. In my own project it seems to be fairly consistent only when running it in a debugger. Because of these reasons, I'm struggling to figure out a good test case for this. If you have ideas, I'd be happy to implement it.

Anyway, this PR fixes the issue by using `sync.RWMutex` when reading/writing from the map.

As an alternative I considered using `sync.Map`, but ended up using this as it keeps type safety. If `sync.Map` is preferred, happy to change it.