### PR TITLE
add tail middleware

### DIFF
--- a/echo_test.go
+++ b/echo_test.go
@@ -285,13 +285,21 @@ func TestEchoMiddleware(t *testing.T) {
 		}
 	})
 
+	e.Tail(func(next HandlerFunc) HandlerFunc {
+		return func(c Context) error {
+			buf.WriteString("4")
+			return next(c)
+		}
+	})
+
 	// Route
 	e.GET("/", func(c Context) error {
 		return c.String(http.StatusOK, "OK")
 	})
 
 	c, b := request(http.MethodGet, "/", e)
-	assert.Equal(t, "-1123", buf.String())
+	fmt.Println("buf.String():", buf.String())
+	assert.Equal(t, "-11234", buf.String())
 	assert.Equal(t, http.StatusOK, c)
 	assert.Equal(t, "OK", b)
 }


### PR DESCRIPTION
This is a post-middleware.
E.g:
If you need to count failed login requests based on IP, you can use it.
If you need to make a page cache, you can intercept the returned data and cache it here.