### PR TITLE
Support to Default param and query param

### DIFF
--- a/context.go
+++ b/context.go
@@ -54,6 +54,9 @@ type (
 		// Param returns path parameter by name.
 		Param(name string) string
 
+		// ParamDefault sets default path parameter value if empty.
+		ParamDefault(name, value string) string
+
 		// ParamNames returns path parameter names.
 		ParamNames() []string
 
@@ -68,6 +71,9 @@ type (
 
 		// QueryParam returns the query param for the provided name.
 		QueryParam(name string) string
+
+		// QueryParamDefault sets default query param value if empty.
+		QueryParamDefault(name, value string) string
 
 		// QueryParams returns the query parameters as `url.Values`.
 		QueryParams() url.Values
@@ -307,6 +313,15 @@ func (c *context) Param(name string) string {
 	return ""
 }
 
+func (c *context) ParamDefault(name, value string) string {
+	param := c.Param(name)
+	if param == "" {
+		param = value
+	}
+
+	return param
+}
+
 func (c *context) ParamNames() []string {
 	return c.pnames
 }
@@ -349,6 +364,15 @@ func (c *context) QueryParam(name string) string {
 		c.query = c.request.URL.Query()
 	}
 	return c.query.Get(name)
+}
+
+func (c *context) QueryParamDefault(name, value string) string {
+	query := c.QueryParam(name)
+	if query == "" {
+		query = value
+	}
+
+	return query
 }
 
 func (c *context) QueryParams() url.Values {

--- a/context_test.go
+++ b/context_test.go
@@ -496,6 +496,10 @@ func TestContextPathParam(t *testing.T) {
 	// Param
 	testify.Equal(t, "501", c.Param("fid"))
 	testify.Equal(t, "", c.Param("undefined"))
+
+	// ParamDefault
+	testify.Equal(t, "901", c.ParamDefault("xid", "901"))
+	testify.Equal(t, "501", c.ParamDefault("fid", "901"))
 }
 
 func TestContextGetAndSetParam(t *testing.T) {
@@ -596,6 +600,10 @@ func TestContextQueryParam(t *testing.T) {
 	// QueryParam
 	testify.Equal(t, "Jon Snow", c.QueryParam("name"))
 	testify.Equal(t, "jon@labstack.com", c.QueryParam("email"))
+
+	// QueryParamDefault
+	testify.Equal(t, "Targaryen", c.QueryParamDefault("house", "Targaryen"))
+	testify.Equal(t, "Jon Snow", c.QueryParamDefault("name", "Aegon Targaryen"))
 
 	// QueryParams
 	testify.Equal(t, url.Values{


### PR DESCRIPTION
With this PR, I would like to add support for setting a default value if `c.Param` or `c.QueryParam` is empty.