### PR TITLE
DefaultHTTPErrorHandler: return error if marshalling JSON fails

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -401,6 +401,22 @@ func (e *Echo) DefaultHTTPErrorHandler(err error, c Context) {
 	}
 	if err != nil {
 		e.Logger.Error(err)
+
+		if e.Debug {
+			message = Map{"message": http.StatusText(http.StatusInternalServerError), "error": err.Error()}
+		} else {
+			message = Map{"message": http.StatusText(http.StatusInternalServerError)}
+		}
+
+		if c.Request().Method == http.MethodHead {
+			err = c.NoContent(http.StatusInternalServerError)
+		} else {
+			err = c.JSON(http.StatusInternalServerError, message)
+		}
+		if err != nil {
+			e.Logger.Error("Sending internal  message failed as well:", err)
+			// TODO maybe cancel whole connection here?
+		}
 	}
 }
 


### PR DESCRIPTION
Before this commit, when passing a message to echo.NewHTTPError() that is not serializable, no error is returned, but a 200 Ok response with no content.
I triggered this behavior by accident when using `err.Error` instead of `err.Error()` as message.

I added test cases which trigger the problem for both `c.JSON()` as well as `echo.NewHttpError()`. With the fix, both of them now return the same result (500 Internal Server Error).

One thing open is to maybe close the whole connection if even the sending of the new error message fails.
