### PR TITLE
`Allow` header support in Router, MethodNotFoundHandler (405) and CORS middleware

### DIFF
--- a/context.go
+++ b/context.go
@@ -211,6 +211,13 @@ type (
 )
 
 const (
+	// ContextKeyHeaderAllow is set by Router for getting value for `Allow` header in later stages of handler call chain.
+	// Allow header is mandatory for status 405 (method not found) and useful for OPTIONS method requests.
+	// It is added to context only when Router does not find matching method handler for request.
+	ContextKeyHeaderAllow = "____echo____header_allow"
+)
+
+const (
 	defaultMemory = 32 << 20 // 32 MB
 	indexPage     = "index.html"
 	defaultIndent = "  "

--- a/context.go
+++ b/context.go
@@ -214,7 +214,7 @@ const (
 	// ContextKeyHeaderAllow is set by Router for getting value for `Allow` header in later stages of handler call chain.
 	// Allow header is mandatory for status 405 (method not found) and useful for OPTIONS method requests.
 	// It is added to context only when Router does not find matching method handler for request.
-	ContextKeyHeaderAllow = "____echo____header_allow"
+	ContextKeyHeaderAllow = "echo_header_allow"
 )
 
 const (

--- a/echo.go
+++ b/echo.go
@@ -190,8 +190,11 @@ const (
 
 // Headers
 const (
-	HeaderAccept              = "Accept"
-	HeaderAcceptEncoding      = "Accept-Encoding"
+	HeaderAccept         = "Accept"
+	HeaderAcceptEncoding = "Accept-Encoding"
+	// HeaderAllow is header field that lists the set of methods advertised as supported by the target resource.
+	// Allow header is mandatory for status 405 (method not found) and useful OPTIONS method responses.
+	// See: https://datatracker.ietf.org/doc/html/rfc7231#section-7.4.1
 	HeaderAllow               = "Allow"
 	HeaderAuthorization       = "Authorization"
 	HeaderContentDisposition  = "Content-Disposition"
@@ -301,6 +304,13 @@ var (
 	}
 
 	MethodNotAllowedHandler = func(c Context) error {
+		// 'Allow' header RFC: https://datatracker.ietf.org/doc/html/rfc7231#section-7.4.1
+		// >> An origin server MUST generate an Allow field in a 405 (Method Not Allowed) response
+		//    and MAY do so in any other response.
+		routerAllowMethods, ok := c.Get(ContextKeyHeaderAllow).(string)
+		if ok && routerAllowMethods != "" {
+			c.Response().Header().Set(HeaderAllow, routerAllowMethods)
+		}
 		return ErrMethodNotAllowed
 	}
 )

--- a/echo.go
+++ b/echo.go
@@ -192,9 +192,10 @@ const (
 const (
 	HeaderAccept         = "Accept"
 	HeaderAcceptEncoding = "Accept-Encoding"
-	// HeaderAllow is header field that lists the set of methods advertised as supported by the target resource.
-	// Allow header is mandatory for status 405 (method not found) and useful OPTIONS method responses.
-	// See: https://datatracker.ietf.org/doc/html/rfc7231#section-7.4.1
+	// HeaderAllow is the name of the "Allow" header field used to list the set of methods
+	// advertised as supported by the target resource. Returning an Allow header is mandatory
+	// for status 405 (method not found) and useful for the OPTIONS method in responses.
+	// See RFC 7231: https://datatracker.ietf.org/doc/html/rfc7231#section-7.4.1
 	HeaderAllow               = "Allow"
 	HeaderAuthorization       = "Authorization"
 	HeaderContentDisposition  = "Content-Disposition"
@@ -304,9 +305,8 @@ var (
 	}
 
 	MethodNotAllowedHandler = func(c Context) error {
-		// 'Allow' header RFC: https://datatracker.ietf.org/doc/html/rfc7231#section-7.4.1
-		// >> An origin server MUST generate an Allow field in a 405 (Method Not Allowed) response
-		//    and MAY do so in any other response.
+		// See RFC 7231 section 7.4.1: An origin server MUST generate an Allow field in a 405 (Method Not Allowed)
+		// response and MAY do so in any other response. For disabled resources an empty Allow header may be returned
 		routerAllowMethods, ok := c.Get(ContextKeyHeaderAllow).(string)
 		if ok && routerAllowMethods != "" {
 			c.Response().Header().Set(HeaderAllow, routerAllowMethods)

--- a/echo_test.go
+++ b/echo_test.go
@@ -716,13 +716,16 @@ func TestEchoNotFound(t *testing.T) {
 
 func TestEchoMethodNotAllowed(t *testing.T) {
 	e := New()
+
 	e.GET("/", func(c Context) error {
 		return c.String(http.StatusOK, "Echo!")
 	})
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
+
 	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+	assert.Equal(t, "OPTIONS, GET", rec.Header().Get(HeaderAllow))
 }
 
 func TestEchoContext(t *testing.T) {

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -172,7 +172,7 @@ func CORSWithConfig(config CORSConfig) echo.MiddlewareFunc {
 				checkPatterns := false
 				if allowOrigin == "" {
 					// to avoid regex cost by invalid (long) domains (253 is domain name max limit)
-					if len(origin) <= (253+3+4) && strings.Contains(origin, "://") {
+					if len(origin) <= (253+3+5) && strings.Contains(origin, "://") {
 						checkPatterns = true
 					}
 				}

--- a/router.go
+++ b/router.go
@@ -1,6 +1,7 @@
 package echo
 
 import (
+	"bytes"
 	"net/http"
 )
 
@@ -31,17 +32,18 @@ type (
 	kind          uint8
 	children      []*node
 	methodHandler struct {
-		connect  HandlerFunc
-		delete   HandlerFunc
-		get      HandlerFunc
-		head     HandlerFunc
-		options  HandlerFunc
-		patch    HandlerFunc
-		post     HandlerFunc
-		propfind HandlerFunc
-		put      HandlerFunc
-		trace    HandlerFunc
-		report   HandlerFunc
+		connect     HandlerFunc
+		delete      HandlerFunc
+		get         HandlerFunc
+		head        HandlerFunc
+		options     HandlerFunc
+		patch       HandlerFunc
+		post        HandlerFunc
+		propfind    HandlerFunc
+		put         HandlerFunc
+		trace       HandlerFunc
+		report      HandlerFunc
+		allowHeader string
 	}
 )
 
@@ -66,6 +68,51 @@ func (m *methodHandler) isHandler() bool {
 		m.put != nil ||
 		m.trace != nil ||
 		m.report != nil
+}
+
+func (m *methodHandler) updateAllowHeader() {
+	buf := new(bytes.Buffer)
+	buf.WriteString(http.MethodOptions)
+
+	if m.connect != nil {
+		buf.WriteString(", ")
+		buf.WriteString(http.MethodConnect)
+	}
+	if m.delete != nil {
+		buf.WriteString(", ")
+		buf.WriteString(http.MethodDelete)
+	}
+	if m.get != nil {
+		buf.WriteString(", ")
+		buf.WriteString(http.MethodGet)
+	}
+	if m.head != nil {
+		buf.WriteString(", ")
+		buf.WriteString(http.MethodHead)
+	}
+	if m.patch != nil {
+		buf.WriteString(", ")
+		buf.WriteString(http.MethodPatch)
+	}
+	if m.post != nil {
+		buf.WriteString(", ")
+		buf.WriteString(http.MethodPost)
+	}
+	if m.propfind != nil {
+		buf.WriteString(", PROPFIND")
+	}
+	if m.put != nil {
+		buf.WriteString(", ")
+		buf.WriteString(http.MethodPut)
+	}
+	if m.trace != nil {
+		buf.WriteString(", ")
+		buf.WriteString(http.MethodTrace)
+	}
+	if m.report != nil {
+		buf.WriteString(", REPORT")
+	}
+	m.allowHeader = buf.String()
 }
 
 // NewRouter returns a new Router instance.
@@ -323,6 +370,7 @@ func (n *node) addHandler(method string, h HandlerFunc) {
 		n.methodHandler.report = h
 	}
 
+	n.methodHandler.updateAllowHeader()
 	if h != nil {
 		n.isHandler = true
 	} else {
@@ -359,13 +407,14 @@ func (n *node) findHandler(method string) HandlerFunc {
 	}
 }
 
-func (n *node) checkMethodNotAllowed() HandlerFunc {
-	for _, m := range methods {
-		if h := n.findHandler(m); h != nil {
-			return MethodNotAllowedHandler
-		}
+func optionsMethodHandler(allowMethods string) func(c Context) error {
+	return func(c Context) error {
+		// Note: we are not handling most of the CORS headers here. CORS is handled by CORS middleware
+		// 'OPTIONS' method RFC: https://httpwg.org/specs/rfc7231.html#OPTIONS
+		// 'Allow' header RFC: https://datatracker.ietf.org/doc/html/rfc7231#section-7.4.1
+		c.Response().Header().Add(HeaderAllow, allowMethods)
+		return c.NoContent(http.StatusNoContent)
 	}
-	return NotFoundHandler
 }
 
 // Find lookup a handler registered for method and path. It also parses URL for path
@@ -560,7 +609,15 @@ func (r *Router) Find(method, path string, c Context) {
 		// use previous match as basis. although we have no matching handler we have path match.
 		// so we can send http.StatusMethodNotAllowed (405) instead of http.StatusNotFound (404)
 		currentNode = previousBestMatchNode
-		ctx.handler = currentNode.checkMethodNotAllowed()
+
+		ctx.handler = NotFoundHandler
+		if currentNode.isHandler {
+			ctx.Set(ContextKeyHeaderAllow, currentNode.methodHandler.allowHeader)
+			ctx.handler = MethodNotAllowedHandler
+			if method == http.MethodOptions {
+				ctx.handler = optionsMethodHandler(currentNode.methodHandler.allowHeader)
+			}
+		}
 	}
 	ctx.path = currentNode.ppath
 	ctx.pnames = currentNode.pnames

--- a/router_test.go
+++ b/router_test.go
@@ -3,6 +3,7 @@ package echo
 import (
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -725,12 +726,13 @@ func TestMethodNotAllowedAndNotFound(t *testing.T) {
 	r.Add(http.MethodPost, "/users/:id", handlerFunc)
 
 	var testCases = []struct {
-		name        string
-		whenMethod  string
-		whenURL     string
-		expectRoute interface{}
-		expectParam map[string]string
-		expectError error
+		name              string
+		whenMethod        string
+		whenURL           string
+		expectRoute       interface{}
+		expectParam       map[string]string
+		expectError       error
+		expectAllowHeader string
 	}{
 		{
 			name:        "exact match for route+method",
@@ -740,11 +742,12 @@ func TestMethodNotAllowedAndNotFound(t *testing.T) {
 			expectParam: map[string]string{"id": "1"},
 		},
 		{
-			name:        "matches node but not method. sends 405 from best match node",
-			whenMethod:  http.MethodPut,
-			whenURL:     "/users/1",
-			expectRoute: nil,
-			expectError: ErrMethodNotAllowed,
+			name:              "matches node but not method. sends 405 from best match node",
+			whenMethod:        http.MethodPut,
+			whenURL:           "/users/1",
+			expectRoute:       nil,
+			expectError:       ErrMethodNotAllowed,
+			expectAllowHeader: "OPTIONS, POST",
 		},
 		{
 			name:        "best match is any route up in tree",
@@ -756,7 +759,9 @@ func TestMethodNotAllowedAndNotFound(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			c := e.NewContext(nil, nil).(*context)
+			req := httptest.NewRequest(tc.whenMethod, tc.whenURL, nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec).(*context)
 
 			method := http.MethodGet
 			if tc.whenMethod != "" {
@@ -775,8 +780,34 @@ func TestMethodNotAllowedAndNotFound(t *testing.T) {
 				assert.Equal(t, expectedValue, c.Param(param))
 			}
 			checkUnusedParamValues(t, c, tc.expectParam)
+
+			assert.Equal(t, tc.expectAllowHeader, c.Response().Header().Get(HeaderAllow))
 		})
 	}
+}
+
+func TestRouterOptionsMethodHandler(t *testing.T) {
+	e := New()
+
+	var keyInContext interface{}
+	e.Use(func(next HandlerFunc) HandlerFunc {
+		return func(c Context) error {
+			err := next(c)
+			keyInContext = c.Get(ContextKeyHeaderAllow)
+			return err
+		}
+	})
+	e.GET("/test", func(c Context) error {
+		return c.String(http.StatusOK, "Echo!")
+	})
+
+	req := httptest.NewRequest(http.MethodOptions, "/test", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, "OPTIONS, GET", rec.Header().Get(HeaderAllow))
+	assert.Equal(t, "OPTIONS, GET", keyInContext)
 }
 
 func TestRouterTwoParam(t *testing.T) {
@@ -2272,6 +2303,73 @@ func TestRouterPanicWhenParamNoRootOnlyChildsFailsFind(t *testing.T) {
 				assert.Equal(t, expectedValue, c.Param(param))
 			}
 			checkUnusedParamValues(t, c, tc.expectParam)
+		})
+	}
+}
+
+func TestRouterHandleMethodOptions(t *testing.T) {
+	e := New()
+	r := e.router
+
+	r.Add(http.MethodGet, "/users", handlerFunc)
+	r.Add(http.MethodPost, "/users", handlerFunc)
+	r.Add(http.MethodPut, "/users/:id", handlerFunc)
+	r.Add(http.MethodGet, "/users/:id", handlerFunc)
+
+	var testCases = []struct {
+		name              string
+		whenMethod        string
+		whenURL           string
+		expectAllowHeader string
+		expectStatus      int
+	}{
+		{
+			name:              "allows GET and POST handlers",
+			whenMethod:        http.MethodOptions,
+			whenURL:           "/users",
+			expectAllowHeader: "OPTIONS, GET, POST",
+			expectStatus:      http.StatusNoContent,
+		},
+		{
+			name:              "allows GET and PUT handlers",
+			whenMethod:        http.MethodOptions,
+			whenURL:           "/users/1",
+			expectAllowHeader: "OPTIONS, GET, PUT",
+			expectStatus:      http.StatusNoContent,
+		},
+		{
+			name:              "GET does not have allows header",
+			whenMethod:        http.MethodGet,
+			whenURL:           "/users",
+			expectAllowHeader: "",
+			expectStatus:      http.StatusOK,
+		},
+		{
+			name:              "path with no handlers does not set Allows header",
+			whenMethod:        http.MethodOptions,
+			whenURL:           "/notFound",
+			expectAllowHeader: "",
+			expectStatus:      http.StatusNotFound,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.whenMethod, tc.whenURL, nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec).(*context)
+
+			r.Find(tc.whenMethod, tc.whenURL, c)
+			err := c.handler(c)
+
+			if tc.expectStatus >= 400 {
+				assert.Error(t, err)
+				he := err.(*HTTPError)
+				assert.Equal(t, tc.expectStatus, he.Code)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectStatus, rec.Code)
+			}
+			assert.Equal(t, tc.expectAllowHeader, c.Response().Header().Get("Allow"))
 		})
 	}
 }


### PR DESCRIPTION
This PR adds support for `Allow` header to 
* http OPTIONS method responses
* status 405 (method not found) responses
* [CORS](https://developer.mozilla.org/en-US/docs/Glossary/CORS) middleware

`Allow` header lists all method types registered for given routed url path.

Related RFCs:
* `Allow` RFC https://datatracker.ietf.org/doc/html/rfc7231#section-7.4.1 all 405 should have `Allow` header listing all methods that router has registered for given path.
* OPTIONS RFC https://httpwg.org/specs/rfc7231.html#OPTIONS `Allow` is optional but useful header to have

Implementation notes:
* Although in case of OPTIONS method router now add special options method handler instead of MethodNotFound handler as found/matched handler, we can not rely on that for CORS middleware. In CORS middleware we can not remove IF conditions for OPTIONS as when browser sends OPTIONS request it does not (by default) include cookie / authentication headers and therefore if we would blindly use `next(c)` and hope to meet our router optionshandler we probably not succeed because of different kinds of authentication middlewares (ala JWT or BasicAuth or KeyAuth) which check for stuff like that.
* The reason for adding `Allow` value to context `echo.ContextKeyHeaderAllow` is because default 405 handler needs to be able to access that value and possibly  CORS middleware is interested in that value.  As `echo.MethodNotAllowedHandler` is part of public API we can not change how that method is created due backwards compatibility. 
* `optionsMethodHandler` is kept private as it is router specific implementation detail. If you want your own then you can add them with `e.OPTIONS()` method for paths you choose.

Using context values in Echo core is so far unprecedented and potentially controversial decision. I did not want to introduce new field into `echo.context` struct as it is quite specific case and I know that Go standard library `http.Server` is using `context.Context` to add some info to each request context - so it is not so unheard of but probably should be avoided:

See: 
* [http.ServerContextKey](https://github.com/golang/go/blob/3396878af43752a7c25406dabd525754f80a1c40/src/net/http/server.go#L3037)
* [http.LocalAddrContextKey](https://github.com/golang/go/blob/3396878af43752a7c25406dabd525754f80a1c40/src/net/http/server.go#L1819)

Let's have a discussion