### PR TITLE
Proxy middleware: add ModifyRequest function to modify http.Request before proxy

### DIFF
--- a/middleware/proxy.go
+++ b/middleware/proxy.go
@@ -54,6 +54,9 @@ type (
 		// Examples: If custom TLS certificates are required.
 		Transport http.RoundTripper
 
+		// ModifyRequest defines function to modify request before passing to ReverseProxy
+		ModifyRequest func(*http.Request) error
+
 		// ModifyResponse defines function to modify response from ProxyTarget.
 		ModifyResponse func(*http.Response) error
 	}
@@ -230,6 +233,13 @@ func ProxyWithConfig(config ProxyConfig) echo.MiddlewareFunc {
 			}
 
 			req := c.Request()
+
+			if config.ModifyRequest != nil {
+				err := config.ModifyRequest(req)
+				if err != nil {
+					return err
+				}
+			}
 			res := c.Response()
 			tgt := config.Balancer.Next(c)
 			c.Set(config.ContextKey, tgt)


### PR DESCRIPTION
The proxy middleware currently does not allow any modification to the request, only ModifyResponse. This PR adds that option so caller can pass a custom function to be applied to requests before it hits reverse proxy.

I have also added passing test. 

Please consider merging this as it would allow for more flexibility when proxy with Echo. 

Thanks!