### PR TITLE
Bugs fixed in Gzip middleware 

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -28,6 +28,7 @@ type (
 	gzipResponseWriter struct {
 		io.Writer
 		http.ResponseWriter
+		wroteBody bool
 	}
 )
 
@@ -85,9 +86,10 @@ func GzipWithConfig(config GzipConfig) echo.MiddlewareFunc {
 				}
 				rw := res.Writer
 				w.Reset(rw)
+				grw := &gzipResponseWriter{Writer: w, ResponseWriter: rw}
 
 				defer func() {
-					if res.Size == 0 {
+					if !grw.wroteBody {
 						// undo the response alterations
 						if res.Header().Get(echo.HeaderContentEncoding) == gzipScheme {
 							res.Header().Del(echo.HeaderContentEncoding)
@@ -104,7 +106,6 @@ func GzipWithConfig(config GzipConfig) echo.MiddlewareFunc {
 					pool.Put(w)
 				}()
 
-				grw := &gzipResponseWriter{Writer: w, ResponseWriter: rw}
 				res.Writer = grw
 			}
 			return next(c)
@@ -113,9 +114,6 @@ func GzipWithConfig(config GzipConfig) echo.MiddlewareFunc {
 }
 
 func (w *gzipResponseWriter) WriteHeader(code int) {
-	if code == http.StatusNoContent { // Issue #489
-		w.ResponseWriter.Header().Del(echo.HeaderContentEncoding)
-	}
 	w.Header().Del(echo.HeaderContentLength) // Issue #444
 	w.ResponseWriter.WriteHeader(code)
 }
@@ -124,6 +122,7 @@ func (w *gzipResponseWriter) Write(b []byte) (int, error) {
 	if w.Header().Get(echo.HeaderContentType) == "" {
 		w.Header().Set(echo.HeaderContentType, http.DetectContentType(b))
 	}
+	w.wroteBody = true
 	return w.Writer.Write(b)
 }
 

--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -87,10 +87,8 @@ func GzipWithConfig(config GzipConfig) echo.MiddlewareFunc {
 				rw := res.Writer
 				w.Reset(rw)
 				grw := &gzipResponseWriter{Writer: w, ResponseWriter: rw}
-
 				defer func() {
 					if !grw.wroteBody {
-						// undo the response alterations
 						if res.Header().Get(echo.HeaderContentEncoding) == gzipScheme {
 							res.Header().Del(echo.HeaderContentEncoding)
 						}
@@ -105,7 +103,6 @@ func GzipWithConfig(config GzipConfig) echo.MiddlewareFunc {
 					w.Close()
 					pool.Put(w)
 				}()
-
 				res.Writer = grw
 			}
 			return next(c)

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -67,6 +67,7 @@ func TestGzip(t *testing.T) {
 		assert.True(rec.Flushed)
 		assert.Equal(gzipScheme, rec.Header().Get(echo.HeaderContentEncoding))
 		assert.Equal(echo.HeaderAcceptEncoding, rec.Header().Get(echo.HeaderVary))
+		assert.Empty(c.Request().Header.Get(echo.HeaderAcceptEncoding))
 		r.Reset(rec.Body)
 
 		_, err = io.ReadFull(r, chunkBuf)

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -110,6 +110,27 @@ func TestGzipNoContent(t *testing.T) {
 	}
 }
 
+func TestGzipEmpty(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(echo.HeaderAcceptEncoding, gzipScheme)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	h := Gzip()(func(c echo.Context) error {
+		return c.String(http.StatusOK, "")
+	})
+	if assert.NoError(t, h(c)) {
+		assert.Equal(t, gzipScheme, rec.Header().Get(echo.HeaderContentEncoding))
+		assert.Equal(t, "text/plain; charset=UTF-8", rec.Header().Get(echo.HeaderContentType))
+		r, err := gzip.NewReader(rec.Body)
+		if assert.NoError(t, err) {
+			var buf bytes.Buffer
+			buf.ReadFrom(r)
+			assert.Equal(t, "", buf.String())
+		}
+	}
+}
+
 func TestGzipErrorReturned(t *testing.T) {
 	e := echo.New()
 	e.Use(Gzip())


### PR DESCRIPTION
1. The Accept-Encoding header parser is more precise. Previously it had been a simple sub-string match, not aware of the possible header grammar.

2. Downstream middleware or handlers will not gzip the response twice now. This makes the middleware easier to use with packages such as Prometheus (which also implements gzipping).

3. Vary header is handled more cleanly. It is not sent unless it is needed. It is now removed from 204 or other empty responses. Although this was not strictly wrong, it was unnecessary and wasteful.