### PR TITLE
JWT, KeyAuth, CSRF multivalue extractors

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -113,10 +113,10 @@ type (
 	}
 
 	// MiddlewareFunc defines a function to process middleware.
-	MiddlewareFunc func(HandlerFunc) HandlerFunc
+	MiddlewareFunc func(next HandlerFunc) HandlerFunc
 
 	// HandlerFunc defines a function to serve HTTP requests.
-	HandlerFunc func(Context) error
+	HandlerFunc func(c Context) error
 
 	// HTTPErrorHandler is a centralized HTTP error handler.
 	HTTPErrorHandler func(error, Context)

--- a/middleware/csrf.go
+++ b/middleware/csrf.go
@@ -2,9 +2,7 @@ package middleware
 
 import (
 	"crypto/subtle"
-	"errors"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -21,13 +19,15 @@ type (
 		TokenLength uint8 `yaml:"token_length"`
 		// Optional. Default value 32.
 
-		// TokenLookup is a string in the form of "<source>:<key>" that is used
+		// TokenLookup is a string in the form of "<source>:<name>" or "<source>:<name>,<source>:<name>" that is used
 		// to extract token from the request.
 		// Optional. Default value "header:X-CSRF-Token".
 		// Possible values:
-		// - "header:<name>"
-		// - "form:<name>"
+		// - "header:<name>" or "header:<name>:<cut-prefix>"
 		// - "query:<name>"
+		// - "form:<name>"
+		// Multiple sources example:
+		// - "header:X-CSRF-Token,query:csrf"
 		TokenLookup string `yaml:"token_lookup"`
 
 		// Context key to store generated CSRF token into context.
@@ -62,11 +62,10 @@ type (
 		// Optional. Default value SameSiteDefaultMode.
 		CookieSameSite http.SameSite `yaml:"cookie_same_site"`
 	}
-
-	// csrfTokenExtractor defines a function that takes `echo.Context` and returns
-	// either a token or an error.
-	csrfTokenExtractor func(echo.Context) (string, error)
 )
+
+// ErrCSRFInvalid is returned when CSRF check fails
+var ErrCSRFInvalid = echo.NewHTTPError(http.StatusForbidden, "invalid csrf token")
 
 var (
 	// DefaultCSRFConfig is the default CSRF middleware config.
@@ -114,14 +113,9 @@ func CSRFWithConfig(config CSRFConfig) echo.MiddlewareFunc {
 		config.CookieSecure = true
 	}
 
-	// Initialize
-	parts := strings.Split(config.TokenLookup, ":")
-	extractor := csrfTokenFromHeader(parts[1])
-	switch parts[0] {
-	case "form":
-		extractor = csrfTokenFromForm(parts[1])
-	case "query":
-		extractor = csrfTokenFromQuery(parts[1])
+	extractors, err := createExtractors(config.TokenLookup, "")
+	if err != nil {
+		panic(err)
 	}
 
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
@@ -130,28 +124,50 @@ func CSRFWithConfig(config CSRFConfig) echo.MiddlewareFunc {
 				return next(c)
 			}
 
-			req := c.Request()
-			k, err := c.Cookie(config.CookieName)
 			token := ""
-
-			// Generate token
-			if err != nil {
-				token = random.String(config.TokenLength)
+			if k, err := c.Cookie(config.CookieName); err != nil {
+				token = random.String(config.TokenLength) // Generate token
 			} else {
-				// Reuse token
-				token = k.Value
+				token = k.Value // Reuse token
 			}
 
-			switch req.Method {
+			switch c.Request().Method {
 			case http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace:
 			default:
 				// Validate token only for requests which are not defined as 'safe' by RFC7231
-				clientToken, err := extractor(c)
-				if err != nil {
-					return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+				var lastExtractorErr error
+				var lastTokenErr error
+			outer:
+				for _, extractor := range extractors {
+					clientTokens, err := extractor(c)
+					if err != nil {
+						lastExtractorErr = err
+						continue
+					}
+
+					for _, clientToken := range clientTokens {
+						if validateCSRFToken(token, clientToken) {
+							lastTokenErr = nil
+							lastExtractorErr = nil
+							break outer
+						}
+						lastTokenErr = ErrCSRFInvalid
+					}
 				}
-				if !validateCSRFToken(token, clientToken) {
-					return echo.NewHTTPError(http.StatusForbidden, "invalid csrf token")
+				if lastTokenErr != nil {
+					return lastTokenErr
+				} else if lastExtractorErr != nil {
+					// ugly part to preserve backwards compatible errors. someone could rely on them
+					if lastExtractorErr == errQueryExtractorValueMissing {
+						lastExtractorErr = echo.NewHTTPError(http.StatusBadRequest, "missing csrf token in the query string")
+					} else if lastExtractorErr == errFormExtractorValueMissing {
+						lastExtractorErr = echo.NewHTTPError(http.StatusBadRequest, "missing csrf token in the form parameter")
+					} else if lastExtractorErr == errHeaderExtractorValueMissing {
+						lastExtractorErr = echo.NewHTTPError(http.StatusBadRequest, "missing csrf token in request header")
+					} else {
+						lastExtractorErr = echo.NewHTTPError(http.StatusBadRequest, lastExtractorErr.Error())
+					}
+					return lastExtractorErr
 				}
 			}
 
@@ -181,38 +197,6 @@ func CSRFWithConfig(config CSRFConfig) echo.MiddlewareFunc {
 
 			return next(c)
 		}
-	}
-}
-
-// csrfTokenFromForm returns a `csrfTokenExtractor` that extracts token from the
-// provided request header.
-func csrfTokenFromHeader(header string) csrfTokenExtractor {
-	return func(c echo.Context) (string, error) {
-		return c.Request().Header.Get(header), nil
-	}
-}
-
-// csrfTokenFromForm returns a `csrfTokenExtractor` that extracts token from the
-// provided form parameter.
-func csrfTokenFromForm(param string) csrfTokenExtractor {
-	return func(c echo.Context) (string, error) {
-		token := c.FormValue(param)
-		if token == "" {
-			return "", errors.New("missing csrf token in the form parameter")
-		}
-		return token, nil
-	}
-}
-
-// csrfTokenFromQuery returns a `csrfTokenExtractor` that extracts token from the
-// provided query parameter.
-func csrfTokenFromQuery(param string) csrfTokenExtractor {
-	return func(c echo.Context) (string, error) {
-		token := c.QueryParam(param)
-		if token == "" {
-			return "", errors.New("missing csrf token in the query string")
-		}
-		return token, nil
 	}
 }
 

--- a/middleware/csrf_test.go
+++ b/middleware/csrf_test.go
@@ -25,6 +25,18 @@ func TestCSRF_tokenExtractors(t *testing.T) {
 		expectError       string
 	}{
 		{
+			name:            "ok, multiple token lookups sources, succeeds on last one",
+			whenTokenLookup: "header:X-CSRF-Token,form:csrf",
+			givenCSRFCookie: "token",
+			givenMethod:     http.MethodPost,
+			givenHeaderTokens: map[string][]string{
+				echo.HeaderXCSRFToken: {"invalid_token"},
+			},
+			givenFormTokens: map[string][]string{
+				"csrf": {"token"},
+			},
+		},
+		{
 			name:            "ok, token from POST form",
 			whenTokenLookup: "form:csrf",
 			givenCSRFCookie: "token",

--- a/middleware/csrf_test.go
+++ b/middleware/csrf_test.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -13,14 +12,193 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestCSRF_tokenExtractors(t *testing.T) {
+	var testCases = []struct {
+		name              string
+		whenTokenLookup   string
+		whenCookieName    string
+		givenCSRFCookie   string
+		givenMethod       string
+		givenQueryTokens  map[string][]string
+		givenFormTokens   map[string][]string
+		givenHeaderTokens map[string][]string
+		expectError       string
+	}{
+		{
+			name:            "ok, token from POST form",
+			whenTokenLookup: "form:csrf",
+			givenCSRFCookie: "token",
+			givenMethod:     http.MethodPost,
+			givenFormTokens: map[string][]string{
+				"csrf": {"token"},
+			},
+		},
+		{
+			name:            "ok, token from POST form, second token passes",
+			whenTokenLookup: "form:csrf",
+			givenCSRFCookie: "token",
+			givenMethod:     http.MethodPost,
+			givenFormTokens: map[string][]string{
+				"csrf": {"invalid", "token"},
+			},
+		},
+		{
+			name:            "nok, invalid token from POST form",
+			whenTokenLookup: "form:csrf",
+			givenCSRFCookie: "token",
+			givenMethod:     http.MethodPost,
+			givenFormTokens: map[string][]string{
+				"csrf": {"invalid_token"},
+			},
+			expectError: "code=403, message=invalid csrf token",
+		},
+		{
+			name:            "nok, missing token from POST form",
+			whenTokenLookup: "form:csrf",
+			givenCSRFCookie: "token",
+			givenMethod:     http.MethodPost,
+			givenFormTokens: map[string][]string{},
+			expectError:     "code=400, message=missing csrf token in the form parameter",
+		},
+		{
+			name:            "ok, token from POST header",
+			whenTokenLookup: "", // will use defaults
+			givenCSRFCookie: "token",
+			givenMethod:     http.MethodPost,
+			givenHeaderTokens: map[string][]string{
+				echo.HeaderXCSRFToken: {"token"},
+			},
+		},
+		{
+			name:            "ok, token from POST header, second token passes",
+			whenTokenLookup: "header:" + echo.HeaderXCSRFToken,
+			givenCSRFCookie: "token",
+			givenMethod:     http.MethodPost,
+			givenHeaderTokens: map[string][]string{
+				echo.HeaderXCSRFToken: {"invalid", "token"},
+			},
+		},
+		{
+			name:            "nok, invalid token from POST header",
+			whenTokenLookup: "header:" + echo.HeaderXCSRFToken,
+			givenCSRFCookie: "token",
+			givenMethod:     http.MethodPost,
+			givenHeaderTokens: map[string][]string{
+				echo.HeaderXCSRFToken: {"invalid_token"},
+			},
+			expectError: "code=403, message=invalid csrf token",
+		},
+		{
+			name:              "nok, missing token from POST header",
+			whenTokenLookup:   "header:" + echo.HeaderXCSRFToken,
+			givenCSRFCookie:   "token",
+			givenMethod:       http.MethodPost,
+			givenHeaderTokens: map[string][]string{},
+			expectError:       "code=400, message=missing csrf token in request header",
+		},
+		{
+			name:            "ok, token from PUT query param",
+			whenTokenLookup: "query:csrf-param",
+			givenCSRFCookie: "token",
+			givenMethod:     http.MethodPut,
+			givenQueryTokens: map[string][]string{
+				"csrf-param": {"token"},
+			},
+		},
+		{
+			name:            "ok, token from PUT query form, second token passes",
+			whenTokenLookup: "query:csrf",
+			givenCSRFCookie: "token",
+			givenMethod:     http.MethodPut,
+			givenQueryTokens: map[string][]string{
+				"csrf": {"invalid", "token"},
+			},
+		},
+		{
+			name:            "nok, invalid token from PUT query form",
+			whenTokenLookup: "query:csrf",
+			givenCSRFCookie: "token",
+			givenMethod:     http.MethodPut,
+			givenQueryTokens: map[string][]string{
+				"csrf": {"invalid_token"},
+			},
+			expectError: "code=403, message=invalid csrf token",
+		},
+		{
+			name:             "nok, missing token from PUT query form",
+			whenTokenLookup:  "query:csrf",
+			givenCSRFCookie:  "token",
+			givenMethod:      http.MethodPut,
+			givenQueryTokens: map[string][]string{},
+			expectError:      "code=400, message=missing csrf token in the query string",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := echo.New()
+
+			q := make(url.Values)
+			for queryParam, values := range tc.givenQueryTokens {
+				for _, v := range values {
+					q.Add(queryParam, v)
+				}
+			}
+
+			f := make(url.Values)
+			for formKey, values := range tc.givenFormTokens {
+				for _, v := range values {
+					f.Add(formKey, v)
+				}
+			}
+
+			var req *http.Request
+			switch tc.givenMethod {
+			case http.MethodGet:
+				req = httptest.NewRequest(http.MethodGet, "/?"+q.Encode(), nil)
+			case http.MethodPost, http.MethodPut:
+				req = httptest.NewRequest(http.MethodPost, "/?"+q.Encode(), strings.NewReader(f.Encode()))
+				req.Header.Add(echo.HeaderContentType, echo.MIMEApplicationForm)
+			}
+
+			for header, values := range tc.givenHeaderTokens {
+				for _, v := range values {
+					req.Header.Add(header, v)
+				}
+			}
+
+			if tc.givenCSRFCookie != "" {
+				req.Header.Set(echo.HeaderCookie, "_csrf="+tc.givenCSRFCookie)
+			}
+
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			csrf := CSRFWithConfig(CSRFConfig{
+				TokenLookup: tc.whenTokenLookup,
+				CookieName:  tc.whenCookieName,
+			})
+
+			h := csrf(func(c echo.Context) error {
+				return c.String(http.StatusOK, "test")
+			})
+
+			err := h(c)
+			if tc.expectError != "" {
+				assert.EqualError(t, err, tc.expectError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestCSRF(t *testing.T) {
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
-	csrf := CSRFWithConfig(CSRFConfig{
-		TokenLength: 16,
-	})
+	csrf := CSRF()
 	h := csrf(func(c echo.Context) error {
 		return c.String(http.StatusOK, "test")
 	})
@@ -43,44 +221,12 @@ func TestCSRF(t *testing.T) {
 	assert.Error(t, h(c))
 
 	// Valid CSRF token
-	token := random.String(16)
+	token := random.String(32)
 	req.Header.Set(echo.HeaderCookie, "_csrf="+token)
 	req.Header.Set(echo.HeaderXCSRFToken, token)
 	if assert.NoError(t, h(c)) {
 		assert.Equal(t, http.StatusOK, rec.Code)
 	}
-}
-
-func TestCSRFTokenFromForm(t *testing.T) {
-	f := make(url.Values)
-	f.Set("csrf", "token")
-	e := echo.New()
-	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(f.Encode()))
-	req.Header.Add(echo.HeaderContentType, echo.MIMEApplicationForm)
-	c := e.NewContext(req, nil)
-	token, err := csrfTokenFromForm("csrf")(c)
-	if assert.NoError(t, err) {
-		assert.Equal(t, "token", token)
-	}
-	_, err = csrfTokenFromForm("invalid")(c)
-	assert.Error(t, err)
-}
-
-func TestCSRFTokenFromQuery(t *testing.T) {
-	q := make(url.Values)
-	q.Set("csrf", "token")
-	e := echo.New()
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	req.Header.Add(echo.HeaderContentType, echo.MIMEApplicationForm)
-	req.URL.RawQuery = q.Encode()
-	c := e.NewContext(req, nil)
-	token, err := csrfTokenFromQuery("csrf")(c)
-	if assert.NoError(t, err) {
-		assert.Equal(t, "token", token)
-	}
-	_, err = csrfTokenFromQuery("invalid")(c)
-	assert.Error(t, err)
-	csrfTokenFromQuery("csrf")
 }
 
 func TestCSRFSetSameSiteMode(t *testing.T) {
@@ -135,7 +281,6 @@ func TestCSRFWithSameSiteDefaultMode(t *testing.T) {
 
 	r := h(c)
 	assert.NoError(t, r)
-	fmt.Println(rec.Header()["Set-Cookie"])
 	assert.NotRegexp(t, "SameSite=", rec.Header()["Set-Cookie"])
 }
 
@@ -157,4 +302,47 @@ func TestCSRFWithSameSiteModeNone(t *testing.T) {
 	assert.NoError(t, r)
 	assert.Regexp(t, "SameSite=None", rec.Header()["Set-Cookie"])
 	assert.Regexp(t, "Secure", rec.Header()["Set-Cookie"])
+}
+
+func TestCSRFConfig_skipper(t *testing.T) {
+	var testCases = []struct {
+		name          string
+		whenSkip      bool
+		expectCookies int
+	}{
+		{
+			name:          "do skip",
+			whenSkip:      true,
+			expectCookies: 0,
+		},
+		{
+			name:          "do not skip",
+			whenSkip:      false,
+			expectCookies: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			csrf := CSRFWithConfig(CSRFConfig{
+				Skipper: func(c echo.Context) bool {
+					return tc.whenSkip
+				},
+			})
+
+			h := csrf(func(c echo.Context) error {
+				return c.String(http.StatusOK, "test")
+			})
+
+			r := h(c)
+			assert.NoError(t, r)
+			cookie := rec.Header()["Set-Cookie"]
+			assert.Len(t, cookie, tc.expectCookies)
+		})
+	}
 }

--- a/middleware/extractor.go
+++ b/middleware/extractor.go
@@ -1,0 +1,179 @@
+package middleware
+
+import (
+	"errors"
+	"fmt"
+	"github.com/labstack/echo/v4"
+	"net/textproto"
+	"strings"
+)
+
+const (
+	// extractorLimit is arbitrary number to limit values extractor can return. this limits possible resource exhaustion
+	// attack vector
+	extractorLimit = 20
+)
+
+var errHeaderExtractorValueMissing = errors.New("missing value in request header")
+var errHeaderExtractorValueInvalid = errors.New("invalid value in request header")
+var errQueryExtractorValueMissing = errors.New("missing value in the query string")
+var errParamExtractorValueMissing = errors.New("missing value in path params")
+var errCookieExtractorValueMissing = errors.New("missing value in cookies")
+var errFormExtractorValueMissing = errors.New("missing value in the form")
+
+// ValuesExtractor defines a function for extracting values (keys/tokens) from the given context.
+type ValuesExtractor func(c echo.Context) ([]string, error)
+
+func createExtractors(lookups string, authScheme string) ([]ValuesExtractor, error) {
+	if lookups == "" {
+		return nil, nil
+	}
+	sources := strings.Split(lookups, ",")
+	var extractors = make([]ValuesExtractor, 0)
+	for _, source := range sources {
+		parts := strings.Split(source, ":")
+		if len(parts) < 2 {
+			return nil, fmt.Errorf("extractor source for lookup could not be split into needed parts: %v", source)
+		}
+
+		switch parts[0] {
+		case "query":
+			extractors = append(extractors, valuesFromQuery(parts[1]))
+		case "param":
+			extractors = append(extractors, valuesFromParam(parts[1]))
+		case "cookie":
+			extractors = append(extractors, valuesFromCookie(parts[1]))
+		case "form":
+			extractors = append(extractors, valuesFromForm(parts[1]))
+		case "header":
+			prefix := ""
+			if len(parts) > 2 {
+				prefix = parts[2]
+			} else if authScheme != "" && parts[1] == echo.HeaderAuthorization {
+				// backwards compatibility for JWT and KeyAuth:
+				// * we only apply this fix to Authorization as header we use and uses prefixes like "Bearer <token-value>" etc
+				// * previously header extractor assumed that auth-scheme/prefix had a space as suffix we need to retain that
+				//   behaviour for default values and Authorization header.
+				prefix = authScheme
+				if !strings.HasSuffix(prefix, " ") {
+					prefix += " "
+				}
+			}
+			extractors = append(extractors, valuesFromHeader(parts[1], prefix))
+		}
+	}
+	return extractors, nil
+}
+
+// valuesFromHeader returns a functions that extracts values from the request header.
+func valuesFromHeader(header string, valuePrefix string) ValuesExtractor {
+	prefixLen := len(valuePrefix)
+	// standard library parses http.Request header keys in canonical form but we may provide something else so fix this
+	header = textproto.CanonicalMIMEHeaderKey(header)
+	return func(c echo.Context) ([]string, error) {
+		values := c.Request().Header.Values(header)
+		if len(values) == 0 {
+			return nil, errHeaderExtractorValueMissing
+		}
+
+		result := make([]string, 0)
+		for i, value := range values {
+			if prefixLen == 0 {
+				result = append(result, value)
+				if i >= extractorLimit-1 {
+					break
+				}
+				continue
+			}
+			if len(value) > prefixLen && strings.EqualFold(value[:prefixLen], valuePrefix) {
+				result = append(result, value[prefixLen:])
+				if i >= extractorLimit-1 {
+					break
+				}
+			}
+		}
+
+		if len(result) == 0 {
+			if prefixLen > 0 {
+				return nil, errHeaderExtractorValueInvalid
+			}
+			return nil, errHeaderExtractorValueMissing
+		}
+		return result, nil
+	}
+}
+
+// valuesFromQuery returns a function that extracts values from the query string.
+func valuesFromQuery(param string) ValuesExtractor {
+	return func(c echo.Context) ([]string, error) {
+		result := c.QueryParams()[param]
+		if len(result) == 0 {
+			return nil, errQueryExtractorValueMissing
+		} else if len(result) > extractorLimit-1 {
+			result = result[:extractorLimit]
+		}
+		return result, nil
+	}
+}
+
+// valuesFromParam returns a function that extracts values from the url param string.
+func valuesFromParam(param string) ValuesExtractor {
+	return func(c echo.Context) ([]string, error) {
+		result := make([]string, 0)
+		paramVales := c.ParamValues()
+		for i, p := range c.ParamNames() {
+			if param == p {
+				result = append(result, paramVales[i])
+				if i >= extractorLimit-1 {
+					break
+				}
+			}
+		}
+		if len(result) == 0 {
+			return nil, errParamExtractorValueMissing
+		}
+		return result, nil
+	}
+}
+
+// valuesFromCookie returns a function that extracts values from the named cookie.
+func valuesFromCookie(name string) ValuesExtractor {
+	return func(c echo.Context) ([]string, error) {
+		cookies := c.Cookies()
+		if len(cookies) == 0 {
+			return nil, errCookieExtractorValueMissing
+		}
+
+		result := make([]string, 0)
+		for i, cookie := range cookies {
+			if name == cookie.Name {
+				result = append(result, cookie.Value)
+				if i >= extractorLimit-1 {
+					break
+				}
+			}
+		}
+		if len(result) == 0 {
+			return nil, errCookieExtractorValueMissing
+		}
+		return result, nil
+	}
+}
+
+// valuesFromForm returns a function that extracts values from the form field.
+func valuesFromForm(name string) ValuesExtractor {
+	return func(c echo.Context) ([]string, error) {
+		if parseErr := c.Request().ParseForm(); parseErr != nil {
+			return nil, fmt.Errorf("valuesFromForm parse form failed: %w", parseErr)
+		}
+		values := c.Request().Form[name]
+		if len(values) == 0 {
+			return nil, errFormExtractorValueMissing
+		}
+		if len(values) > extractorLimit-1 {
+			values = values[:extractorLimit]
+		}
+		result := append([]string{}, values...)
+		return result, nil
+	}
+}

--- a/middleware/extractor.go
+++ b/middleware/extractor.go
@@ -66,6 +66,11 @@ func createExtractors(lookups string, authScheme string) ([]ValuesExtractor, err
 }
 
 // valuesFromHeader returns a functions that extracts values from the request header.
+// valuePrefix is parameter to remove first part (prefix) of the extracted value. This is useful if header value has static
+// prefix like `Authorization: <auth-scheme> <authorisation-parameters>` where part that we want to remove is `<auth-scheme> `
+// note the space at the end. In case of basic authentication `Authorization: Basic <credentials>` prefix we want to remove
+// is `Basic `. In case of JWT tokens `Authorization: Bearer <token>` prefix is `Bearer `.
+// If prefix is left empty the whole value is returned.
 func valuesFromHeader(header string, valuePrefix string) ValuesExtractor {
 	prefixLen := len(valuePrefix)
 	// standard library parses http.Request header keys in canonical form but we may provide something else so fix this

--- a/middleware/extractor_test.go
+++ b/middleware/extractor_test.go
@@ -1,0 +1,587 @@
+package middleware
+
+import (
+	"fmt"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+type pathParam struct {
+	name  string
+	value string
+}
+
+func setPathParams(c echo.Context, params []pathParam) {
+	names := make([]string, 0, len(params))
+	values := make([]string, 0, len(params))
+	for _, pp := range params {
+		names = append(names, pp.name)
+		values = append(values, pp.value)
+	}
+	c.SetParamNames(names...)
+	c.SetParamValues(values...)
+}
+
+func TestCreateExtractors(t *testing.T) {
+	var testCases = []struct {
+		name              string
+		givenRequest      func() *http.Request
+		givenPathParams   []pathParam
+		whenLoopups       string
+		expectValues      []string
+		expectCreateError string
+		expectError       string
+	}{
+		{
+			name: "ok, header",
+			givenRequest: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				req.Header.Set(echo.HeaderAuthorization, "Bearer token")
+				return req
+			},
+			whenLoopups:  "header:Authorization:Bearer ",
+			expectValues: []string{"token"},
+		},
+		{
+			name: "ok, form",
+			givenRequest: func() *http.Request {
+				f := make(url.Values)
+				f.Set("name", "Jon Snow")
+
+				req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(f.Encode()))
+				req.Header.Add(echo.HeaderContentType, echo.MIMEApplicationForm)
+				return req
+			},
+			whenLoopups:  "form:name",
+			expectValues: []string{"Jon Snow"},
+		},
+		{
+			name: "ok, cookie",
+			givenRequest: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				req.Header.Set(echo.HeaderCookie, "_csrf=token")
+				return req
+			},
+			whenLoopups:  "cookie:_csrf",
+			expectValues: []string{"token"},
+		},
+		{
+			name: "ok, param",
+			givenPathParams: []pathParam{
+				{name: "id", value: "123"},
+			},
+			whenLoopups:  "param:id",
+			expectValues: []string{"123"},
+		},
+		{
+			name: "ok, query",
+			givenRequest: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "/?id=999", nil)
+				return req
+			},
+			whenLoopups:  "query:id",
+			expectValues: []string{"999"},
+		},
+		{
+			name:              "nok, invalid lookup",
+			whenLoopups:       "query",
+			expectCreateError: "extractor source for lookup could not be split into needed parts: query",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := echo.New()
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tc.givenRequest != nil {
+				req = tc.givenRequest()
+			}
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			if tc.givenPathParams != nil {
+				setPathParams(c, tc.givenPathParams)
+			}
+
+			extractors, err := createExtractors(tc.whenLoopups, "")
+			if tc.expectCreateError != "" {
+				assert.EqualError(t, err, tc.expectCreateError)
+				return
+			}
+			assert.NoError(t, err)
+
+			for _, e := range extractors {
+				values, eErr := e(c)
+				assert.Equal(t, tc.expectValues, values)
+				if tc.expectError != "" {
+					assert.EqualError(t, eErr, tc.expectError)
+					return
+				}
+				assert.NoError(t, eErr)
+			}
+		})
+	}
+}
+
+func TestValuesFromHeader(t *testing.T) {
+	exampleRequest := func(req *http.Request) {
+		req.Header.Set(echo.HeaderAuthorization, "basic dXNlcjpwYXNzd29yZA==")
+	}
+
+	var testCases = []struct {
+		name            string
+		givenRequest    func(req *http.Request)
+		whenName        string
+		whenValuePrefix string
+		expectValues    []string
+		expectError     string
+	}{
+		{
+			name:            "ok, single value",
+			givenRequest:    exampleRequest,
+			whenName:        echo.HeaderAuthorization,
+			whenValuePrefix: "basic ",
+			expectValues:    []string{"dXNlcjpwYXNzd29yZA=="},
+		},
+		{
+			name:            "ok, single value, case insensitive",
+			givenRequest:    exampleRequest,
+			whenName:        echo.HeaderAuthorization,
+			whenValuePrefix: "Basic ",
+			expectValues:    []string{"dXNlcjpwYXNzd29yZA=="},
+		},
+		{
+			name: "ok, multiple value",
+			givenRequest: func(req *http.Request) {
+				req.Header.Set(echo.HeaderAuthorization, "basic dXNlcjpwYXNzd29yZA==")
+				req.Header.Add(echo.HeaderAuthorization, "basic dGVzdDp0ZXN0")
+			},
+			whenName:        echo.HeaderAuthorization,
+			whenValuePrefix: "basic ",
+			expectValues:    []string{"dXNlcjpwYXNzd29yZA==", "dGVzdDp0ZXN0"},
+		},
+		{
+			name:            "ok, empty prefix",
+			givenRequest:    exampleRequest,
+			whenName:        echo.HeaderAuthorization,
+			whenValuePrefix: "",
+			expectValues:    []string{"basic dXNlcjpwYXNzd29yZA=="},
+		},
+		{
+			name: "nok, no matching due different prefix",
+			givenRequest: func(req *http.Request) {
+				req.Header.Set(echo.HeaderAuthorization, "basic dXNlcjpwYXNzd29yZA==")
+				req.Header.Add(echo.HeaderAuthorization, "basic dGVzdDp0ZXN0")
+			},
+			whenName:        echo.HeaderAuthorization,
+			whenValuePrefix: "Bearer ",
+			expectError:     errHeaderExtractorValueInvalid.Error(),
+		},
+		{
+			name: "nok, no matching due different prefix",
+			givenRequest: func(req *http.Request) {
+				req.Header.Set(echo.HeaderAuthorization, "basic dXNlcjpwYXNzd29yZA==")
+				req.Header.Add(echo.HeaderAuthorization, "basic dGVzdDp0ZXN0")
+			},
+			whenName:        echo.HeaderWWWAuthenticate,
+			whenValuePrefix: "",
+			expectError:     errHeaderExtractorValueMissing.Error(),
+		},
+		{
+			name:            "nok, no headers",
+			givenRequest:    nil,
+			whenName:        echo.HeaderAuthorization,
+			whenValuePrefix: "basic ",
+			expectError:     errHeaderExtractorValueMissing.Error(),
+		},
+		{
+			name: "ok, prefix, cut values over extractorLimit",
+			givenRequest: func(req *http.Request) {
+				for i := 1; i <= 25; i++ {
+					req.Header.Add(echo.HeaderAuthorization, fmt.Sprintf("basic %v", i))
+				}
+			},
+			whenName:        echo.HeaderAuthorization,
+			whenValuePrefix: "basic ",
+			expectValues: []string{
+				"1", "2", "3", "4", "5", "6", "7", "8", "9", "10",
+				"11", "12", "13", "14", "15", "16", "17", "18", "19", "20",
+			},
+		},
+		{
+			name: "ok, cut values over extractorLimit",
+			givenRequest: func(req *http.Request) {
+				for i := 1; i <= 25; i++ {
+					req.Header.Add(echo.HeaderAuthorization, fmt.Sprintf("%v", i))
+				}
+			},
+			whenName:        echo.HeaderAuthorization,
+			whenValuePrefix: "",
+			expectValues: []string{
+				"1", "2", "3", "4", "5", "6", "7", "8", "9", "10",
+				"11", "12", "13", "14", "15", "16", "17", "18", "19", "20",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := echo.New()
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tc.givenRequest != nil {
+				tc.givenRequest(req)
+			}
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			extractor := valuesFromHeader(tc.whenName, tc.whenValuePrefix)
+
+			values, err := extractor(c)
+			assert.Equal(t, tc.expectValues, values)
+			if tc.expectError != "" {
+				assert.EqualError(t, err, tc.expectError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValuesFromQuery(t *testing.T) {
+	var testCases = []struct {
+		name           string
+		givenQueryPart string
+		whenName       string
+		expectValues   []string
+		expectError    string
+	}{
+		{
+			name:           "ok, single value",
+			givenQueryPart: "?id=123&name=test",
+			whenName:       "id",
+			expectValues:   []string{"123"},
+		},
+		{
+			name:           "ok, multiple value",
+			givenQueryPart: "?id=123&id=456&name=test",
+			whenName:       "id",
+			expectValues:   []string{"123", "456"},
+		},
+		{
+			name:           "nok, missing value",
+			givenQueryPart: "?id=123&name=test",
+			whenName:       "nope",
+			expectError:    errQueryExtractorValueMissing.Error(),
+		},
+		{
+			name: "ok, cut values over extractorLimit",
+			givenQueryPart: "?name=test" +
+				"&id=1&id=2&id=3&id=4&id=5&id=6&id=7&id=8&id=9&id=10" +
+				"&id=11&id=12&id=13&id=14&id=15&id=16&id=17&id=18&id=19&id=20" +
+				"&id=21&id=22&id=23&id=24&id=25",
+			whenName: "id",
+			expectValues: []string{
+				"1", "2", "3", "4", "5", "6", "7", "8", "9", "10",
+				"11", "12", "13", "14", "15", "16", "17", "18", "19", "20",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := echo.New()
+
+			req := httptest.NewRequest(http.MethodGet, "/"+tc.givenQueryPart, nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			extractor := valuesFromQuery(tc.whenName)
+
+			values, err := extractor(c)
+			assert.Equal(t, tc.expectValues, values)
+			if tc.expectError != "" {
+				assert.EqualError(t, err, tc.expectError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValuesFromParam(t *testing.T) {
+	examplePathParams := []pathParam{
+		{name: "id", value: "123"},
+		{name: "gid", value: "456"},
+		{name: "gid", value: "789"},
+	}
+	examplePathParams20 := make([]pathParam, 0)
+	for i := 1; i < 25; i++ {
+		examplePathParams20 = append(examplePathParams20, pathParam{name: "id", value: fmt.Sprintf("%v", i)})
+	}
+
+	var testCases = []struct {
+		name            string
+		givenPathParams []pathParam
+		whenName        string
+		expectValues    []string
+		expectError     string
+	}{
+		{
+			name:            "ok, single value",
+			givenPathParams: examplePathParams,
+			whenName:        "id",
+			expectValues:    []string{"123"},
+		},
+		{
+			name:            "ok, multiple value",
+			givenPathParams: examplePathParams,
+			whenName:        "gid",
+			expectValues:    []string{"456", "789"},
+		},
+		{
+			name:            "nok, no values",
+			givenPathParams: nil,
+			whenName:        "nope",
+			expectValues:    nil,
+			expectError:     errParamExtractorValueMissing.Error(),
+		},
+		{
+			name:            "nok, no matching value",
+			givenPathParams: examplePathParams,
+			whenName:        "nope",
+			expectValues:    nil,
+			expectError:     errParamExtractorValueMissing.Error(),
+		},
+		{
+			name:            "ok, cut values over extractorLimit",
+			givenPathParams: examplePathParams20,
+			whenName:        "id",
+			expectValues: []string{
+				"1", "2", "3", "4", "5", "6", "7", "8", "9", "10",
+				"11", "12", "13", "14", "15", "16", "17", "18", "19", "20",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := echo.New()
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			if tc.givenPathParams != nil {
+				setPathParams(c, tc.givenPathParams)
+			}
+
+			extractor := valuesFromParam(tc.whenName)
+
+			values, err := extractor(c)
+			assert.Equal(t, tc.expectValues, values)
+			if tc.expectError != "" {
+				assert.EqualError(t, err, tc.expectError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValuesFromCookie(t *testing.T) {
+	exampleRequest := func(req *http.Request) {
+		req.Header.Set(echo.HeaderCookie, "_csrf=token")
+	}
+
+	var testCases = []struct {
+		name         string
+		givenRequest func(req *http.Request)
+		whenName     string
+		expectValues []string
+		expectError  string
+	}{
+		{
+			name:         "ok, single value",
+			givenRequest: exampleRequest,
+			whenName:     "_csrf",
+			expectValues: []string{"token"},
+		},
+		{
+			name: "ok, multiple value",
+			givenRequest: func(req *http.Request) {
+				req.Header.Add(echo.HeaderCookie, "_csrf=token")
+				req.Header.Add(echo.HeaderCookie, "_csrf=token2")
+			},
+			whenName:     "_csrf",
+			expectValues: []string{"token", "token2"},
+		},
+		{
+			name:         "nok, no matching cookie",
+			givenRequest: exampleRequest,
+			whenName:     "xxx",
+			expectValues: nil,
+			expectError:  errCookieExtractorValueMissing.Error(),
+		},
+		{
+			name:         "nok, no cookies at all",
+			givenRequest: nil,
+			whenName:     "xxx",
+			expectValues: nil,
+			expectError:  errCookieExtractorValueMissing.Error(),
+		},
+		{
+			name: "ok, cut values over extractorLimit",
+			givenRequest: func(req *http.Request) {
+				for i := 1; i < 25; i++ {
+					req.Header.Add(echo.HeaderCookie, fmt.Sprintf("_csrf=%v", i))
+				}
+			},
+			whenName: "_csrf",
+			expectValues: []string{
+				"1", "2", "3", "4", "5", "6", "7", "8", "9", "10",
+				"11", "12", "13", "14", "15", "16", "17", "18", "19", "20",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := echo.New()
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tc.givenRequest != nil {
+				tc.givenRequest(req)
+			}
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			extractor := valuesFromCookie(tc.whenName)
+
+			values, err := extractor(c)
+			assert.Equal(t, tc.expectValues, values)
+			if tc.expectError != "" {
+				assert.EqualError(t, err, tc.expectError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValuesFromForm(t *testing.T) {
+	examplePostFormRequest := func(mod func(v *url.Values)) *http.Request {
+		f := make(url.Values)
+		f.Set("name", "Jon Snow")
+		f.Set("emails[]", "jon@labstack.com")
+		if mod != nil {
+			mod(&f)
+		}
+
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(f.Encode()))
+		req.Header.Add(echo.HeaderContentType, echo.MIMEApplicationForm)
+
+		return req
+	}
+	exampleGetFormRequest := func(mod func(v *url.Values)) *http.Request {
+		f := make(url.Values)
+		f.Set("name", "Jon Snow")
+		f.Set("emails[]", "jon@labstack.com")
+		if mod != nil {
+			mod(&f)
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/?"+f.Encode(), nil)
+		return req
+	}
+
+	var testCases = []struct {
+		name         string
+		givenRequest *http.Request
+		whenName     string
+		expectValues []string
+		expectError  string
+	}{
+		{
+			name:         "ok, POST form, single value",
+			givenRequest: examplePostFormRequest(nil),
+			whenName:     "emails[]",
+			expectValues: []string{"jon@labstack.com"},
+		},
+		{
+			name: "ok, POST form, multiple value",
+			givenRequest: examplePostFormRequest(func(v *url.Values) {
+				v.Add("emails[]", "snow@labstack.com")
+			}),
+			whenName:     "emails[]",
+			expectValues: []string{"jon@labstack.com", "snow@labstack.com"},
+		},
+		{
+			name:         "ok, GET form, single value",
+			givenRequest: exampleGetFormRequest(nil),
+			whenName:     "emails[]",
+			expectValues: []string{"jon@labstack.com"},
+		},
+		{
+			name: "ok, GET form, multiple value",
+			givenRequest: examplePostFormRequest(func(v *url.Values) {
+				v.Add("emails[]", "snow@labstack.com")
+			}),
+			whenName:     "emails[]",
+			expectValues: []string{"jon@labstack.com", "snow@labstack.com"},
+		},
+		{
+			name:         "nok, POST form, value missing",
+			givenRequest: examplePostFormRequest(nil),
+			whenName:     "nope",
+			expectError:  errFormExtractorValueMissing.Error(),
+		},
+		{
+			name: "nok, POST form, form parsing error",
+			givenRequest: func() *http.Request {
+				req := httptest.NewRequest(http.MethodPost, "/", nil)
+				req.Body = nil
+				return req
+			}(),
+			whenName:    "name",
+			expectError: "valuesFromForm parse form failed: missing form body",
+		},
+		{
+			name: "ok, cut values over extractorLimit",
+			givenRequest: examplePostFormRequest(func(v *url.Values) {
+				for i := 1; i < 25; i++ {
+					v.Add("id[]", fmt.Sprintf("%v", i))
+				}
+			}),
+			whenName: "id[]",
+			expectValues: []string{
+				"1", "2", "3", "4", "5", "6", "7", "8", "9", "10",
+				"11", "12", "13", "14", "15", "16", "17", "18", "19", "20",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := echo.New()
+
+			req := tc.givenRequest
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			extractor := valuesFromForm(tc.whenName)
+
+			values, err := extractor(c)
+			assert.Equal(t, tc.expectValues, values)
+			if tc.expectError != "" {
+				assert.EqualError(t, err, tc.expectError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -69,6 +69,11 @@ type (
 		// Optional. Default value "header:Authorization".
 		// Possible values:
 		// - "header:<name>" or "header:<name>:<cut-prefix>"
+		// 			`<cut-prefix>` is argument value to cut/trim prefix of the extracted value. This is useful if header
+		//			value has static prefix like `Authorization: <auth-scheme> <authorisation-parameters>` where part that we
+		//			want to cut is `<auth-scheme> ` note the space at the end.
+		//			In case of JWT tokens `Authorization: Bearer <token>` prefix we cut is `Bearer `.
+		// If prefix is left empty the whole value is returned.
 		// - "query:<name>"
 		// - "param:<name>"
 		// - "cookie:<name>"

--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -32,12 +32,12 @@ type (
 		// ErrorHandlerWithContext is almost identical to ErrorHandler, but it's passed the current context.
 		ErrorHandlerWithContext JWTErrorHandlerWithContext
 
-		// NoErrorContinuesExecution allows next middleware/handler to be called when ErrorHandlerWithContext decides to
-		// swallow the error (returns nil).
-		// This is useful in cases when portion of your site/api is publicly accessible and has extra features for authorized
-		// users. In that case you can use ErrorHandlerWithContext to set default public JWT token value to request and
-		// continue with handler chain. Assuming logic downstream execution chain has to check that (public) token value.
-		NoErrorContinuesExecution bool
+		// ContinueOnIgnoredError allows the next middleware/handler to be called when ErrorHandlerWithContext decides to
+		// ignore the error (by returning `nil`).
+		// This is useful when parts of your site/api allow public access and some authorized routes provide extra functionality.
+		// In that case you can use ErrorHandlerWithContext to set a default public JWT token value in the request context
+		// and continue. Some logic down the remaining execution chain needs to check that (public) token value then.
+		ContinueOnIgnoredError bool
 
 		// Signing key to validate token.
 		// This is one of the three options to provide a token validation key.
@@ -79,7 +79,7 @@ type (
 		// - "cookie:<name>"
 		// - "form:<name>"
 		// Multiple sources example:
-		// - "header:Authorization ,cookie:myowncookie"
+		// - "header:Authorization,cookie:myowncookie"
 		TokenLookup string
 
 		// TokenLookupFuncs defines a list of user-defined functions that extract JWT token from the given context.
@@ -242,7 +242,7 @@ func JWTWithConfig(config JWTConfig) echo.MiddlewareFunc {
 			}
 			if config.ErrorHandlerWithContext != nil {
 				tmpErr := config.ErrorHandlerWithContext(err, c)
-				if config.NoErrorContinuesExecution && tmpErr == nil {
+				if config.ContinueOnIgnoredError && tmpErr == nil {
 					return next(c)
 				}
 				return tmpErr

--- a/middleware/jwt_test.go
+++ b/middleware/jwt_test.go
@@ -704,42 +704,42 @@ func TestJWTConfig_SuccessHandler(t *testing.T) {
 	}
 }
 
-func TestJWTConfig_NoErrorContinuesExecution(t *testing.T) {
+func TestJWTConfig_ContinueOnIgnoredError(t *testing.T) {
 	var testCases = []struct {
-		name                          string
-		whenNoErrorContinuesExecution bool
-		givenToken                    string
-		expectStatus                  int
-		expectBody                    string
+		name                       string
+		whenContinueOnIgnoredError bool
+		givenToken                 string
+		expectStatus               int
+		expectBody                 string
 	}{
 		{
-			name:                          "no error handler is called",
-			whenNoErrorContinuesExecution: true,
-			givenToken:                    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ",
-			expectStatus:                  http.StatusTeapot,
-			expectBody:                    "",
+			name:                       "no error handler is called",
+			whenContinueOnIgnoredError: true,
+			givenToken:                 "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ",
+			expectStatus:               http.StatusTeapot,
+			expectBody:                 "",
 		},
 		{
-			name:                          "NoErrorContinuesExecution is false and error handler is called for missing token",
-			whenNoErrorContinuesExecution: false,
-			givenToken:                    "",
+			name:                       "ContinueOnIgnoredError is false and error handler is called for missing token",
+			whenContinueOnIgnoredError: false,
+			givenToken:                 "",
 			// empty response with 200. This emulates previous behaviour when error handler swallowed the error
 			expectStatus: http.StatusOK,
 			expectBody:   "",
 		},
 		{
-			name:                          "error handler is called for missing token",
-			whenNoErrorContinuesExecution: true,
-			givenToken:                    "",
-			expectStatus:                  http.StatusTeapot,
-			expectBody:                    "public-token",
+			name:                       "error handler is called for missing token",
+			whenContinueOnIgnoredError: true,
+			givenToken:                 "",
+			expectStatus:               http.StatusTeapot,
+			expectBody:                 "public-token",
 		},
 		{
-			name:                          "error handler is called for invalid token",
-			whenNoErrorContinuesExecution: true,
-			givenToken:                    "x.x.x",
-			expectStatus:                  http.StatusUnauthorized,
-			expectBody:                    "{\"message\":\"Unauthorized\"}\n",
+			name:                       "error handler is called for invalid token",
+			whenContinueOnIgnoredError: true,
+			givenToken:                 "x.x.x",
+			expectStatus:               http.StatusUnauthorized,
+			expectBody:                 "{\"message\":\"Unauthorized\"}\n",
 		},
 	}
 
@@ -753,8 +753,8 @@ func TestJWTConfig_NoErrorContinuesExecution(t *testing.T) {
 			})
 
 			e.Use(JWTWithConfig(JWTConfig{
-				NoErrorContinuesExecution: tc.whenNoErrorContinuesExecution,
-				SigningKey:                []byte("secret"),
+				ContinueOnIgnoredError: tc.whenContinueOnIgnoredError,
+				SigningKey:             []byte("secret"),
 				ErrorHandlerWithContext: func(err error, c echo.Context) error {
 					if err == ErrJWTMissing {
 						c.Set("test", "public-token")

--- a/middleware/key_auth.go
+++ b/middleware/key_auth.go
@@ -40,12 +40,12 @@ type (
 		// It may be used to define a custom error.
 		ErrorHandler KeyAuthErrorHandler
 
-		// NoErrorContinuesExecution allows next middleware/handler to be called when ErrorHandler decides to swallow
-		// the error (returns nil).
-		// This is useful in cases when portion of your site/api is publicly accessible and has extra features for valid
-		// requests. In that case you can use ErrorHandler to set default public auth values to request and continue with
-		// handler chain. Assuming logic downstream execution chain has to check that (public) auth value.
-		NoErrorContinuesExecution bool
+		// ContinueOnIgnoredError allows the next middleware/handler to be called when ErrorHandler decides to
+		// ignore the error (by returning `nil`).
+		// This is useful when parts of your site/api allow public access and some authorized routes provide extra functionality.
+		// In that case you can use ErrorHandler to set a default public key auth value in the request context
+		// and continue. Some logic down the remaining execution chain needs to check that (public) key auth value then.
+		ContinueOnIgnoredError bool
 	}
 
 	// KeyAuthValidator defines a function to validate KeyAuth credentials.
@@ -162,7 +162,7 @@ func KeyAuthWithConfig(config KeyAuthConfig) echo.MiddlewareFunc {
 
 			if config.ErrorHandler != nil {
 				tmpErr := config.ErrorHandler(err, c)
-				if config.NoErrorContinuesExecution && tmpErr == nil {
+				if config.ContinueOnIgnoredError && tmpErr == nil {
 					return next(c)
 				}
 				return tmpErr

--- a/middleware/key_auth.go
+++ b/middleware/key_auth.go
@@ -17,6 +17,10 @@ type (
 		// Optional. Default value "header:Authorization".
 		// Possible values:
 		// - "header:<name>" or "header:<name>:<cut-prefix>"
+		// 			`<cut-prefix>` is argument value to cut/trim prefix of the extracted value. This is useful if header
+		//			value has static prefix like `Authorization: <auth-scheme> <authorisation-parameters>` where part that we
+		//			want to cut is `<auth-scheme> ` note the space at the end.
+		//			In case of basic authentication `Authorization: Basic <credentials>` prefix we want to remove is `Basic `.
 		// - "query:<name>"
 		// - "form:<name>"
 		// - "cookie:<name>"

--- a/middleware/key_auth.go
+++ b/middleware/key_auth.go
@@ -2,11 +2,8 @@ package middleware
 
 import (
 	"errors"
-	"fmt"
-	"net/http"
-	"strings"
-
 	"github.com/labstack/echo/v4"
+	"net/http"
 )
 
 type (
@@ -15,15 +12,17 @@ type (
 		// Skipper defines a function to skip middleware.
 		Skipper Skipper
 
-		// KeyLookup is a string in the form of "<source>:<name>" that is used
+		// KeyLookup is a string in the form of "<source>:<name>" or "<source>:<name>,<source>:<name>" that is used
 		// to extract key from the request.
 		// Optional. Default value "header:Authorization".
 		// Possible values:
-		// - "header:<name>"
+		// - "header:<name>" or "header:<name>:<cut-prefix>"
 		// - "query:<name>"
 		// - "form:<name>"
 		// - "cookie:<name>"
-		KeyLookup string `yaml:"key_lookup"`
+		// Multiple sources example:
+		// - "header:Authorization,header:X-Api-Key"
+		KeyLookup string
 
 		// AuthScheme to be used in the Authorization header.
 		// Optional. Default value "Bearer".
@@ -39,12 +38,10 @@ type (
 	}
 
 	// KeyAuthValidator defines a function to validate KeyAuth credentials.
-	KeyAuthValidator func(string, echo.Context) (bool, error)
-
-	keyExtractor func(echo.Context) (string, error)
+	KeyAuthValidator func(auth string, c echo.Context) (bool, error)
 
 	// KeyAuthErrorHandler defines a function which is executed for an invalid key.
-	KeyAuthErrorHandler func(error, echo.Context) error
+	KeyAuthErrorHandler func(err error, c echo.Context) error
 )
 
 var (
@@ -85,16 +82,9 @@ func KeyAuthWithConfig(config KeyAuthConfig) echo.MiddlewareFunc {
 		panic("echo: key-auth middleware requires a validator function")
 	}
 
-	// Initialize
-	parts := strings.Split(config.KeyLookup, ":")
-	extractor := keyFromHeader(parts[1], config.AuthScheme)
-	switch parts[0] {
-	case "query":
-		extractor = keyFromQuery(parts[1])
-	case "form":
-		extractor = keyFromForm(parts[1])
-	case "cookie":
-		extractor = keyFromCookie(parts[1])
+	extractors, err := createExtractors(config.KeyLookup, config.AuthScheme)
+	if err != nil {
+		panic(err)
 	}
 
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
@@ -103,79 +93,57 @@ func KeyAuthWithConfig(config KeyAuthConfig) echo.MiddlewareFunc {
 				return next(c)
 			}
 
-			// Extract and verify key
-			key, err := extractor(c)
-			if err != nil {
-				if config.ErrorHandler != nil {
-					return config.ErrorHandler(err, c)
+			var lastExtractorErr error
+			var lastValidatorErr error
+			for _, extractor := range extractors {
+				keys, err := extractor(c)
+				if err != nil {
+					lastExtractorErr = err
+					continue
 				}
-				return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+				for _, key := range keys {
+					valid, err := config.Validator(key, c)
+					if err != nil {
+						lastValidatorErr = err
+						continue
+					}
+					if valid {
+						return next(c)
+					}
+					lastValidatorErr = errors.New("invalid key")
+				}
 			}
-			valid, err := config.Validator(key, c)
-			if err != nil {
-				if config.ErrorHandler != nil {
-					return config.ErrorHandler(err, c)
+
+			// we are here only when we did not successfully extract and validate any of keys
+			err := lastValidatorErr
+			if err == nil { // prioritize validator errors over extracting errors
+				// ugly part to preserve backwards compatible errors. someone could rely on them
+				if lastExtractorErr == errQueryExtractorValueMissing {
+					err = errors.New("missing key in the query string")
+				} else if lastExtractorErr == errCookieExtractorValueMissing {
+					err = errors.New("missing key in cookies")
+				} else if lastExtractorErr == errFormExtractorValueMissing {
+					err = errors.New("missing key in the form")
+				} else if lastExtractorErr == errHeaderExtractorValueMissing {
+					err = errors.New("missing key in request header")
+				} else if lastExtractorErr == errHeaderExtractorValueInvalid {
+					err = errors.New("invalid key in the request header")
+				} else {
+					err = lastExtractorErr
 				}
+			}
+
+			if config.ErrorHandler != nil {
+				return config.ErrorHandler(err, c)
+			}
+			if lastValidatorErr != nil { // prioritize validator errors over extracting errors
 				return &echo.HTTPError{
 					Code:     http.StatusUnauthorized,
-					Message:  "invalid key",
-					Internal: err,
+					Message:  "Unauthorized",
+					Internal: lastValidatorErr,
 				}
-			} else if valid {
-				return next(c)
 			}
-			return echo.ErrUnauthorized
+			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
-	}
-}
-
-// keyFromHeader returns a `keyExtractor` that extracts key from the request header.
-func keyFromHeader(header string, authScheme string) keyExtractor {
-	return func(c echo.Context) (string, error) {
-		auth := c.Request().Header.Get(header)
-		if auth == "" {
-			return "", errors.New("missing key in request header")
-		}
-		if header == echo.HeaderAuthorization {
-			l := len(authScheme)
-			if len(auth) > l+1 && auth[:l] == authScheme {
-				return auth[l+1:], nil
-			}
-			return "", errors.New("invalid key in the request header")
-		}
-		return auth, nil
-	}
-}
-
-// keyFromQuery returns a `keyExtractor` that extracts key from the query string.
-func keyFromQuery(param string) keyExtractor {
-	return func(c echo.Context) (string, error) {
-		key := c.QueryParam(param)
-		if key == "" {
-			return "", errors.New("missing key in the query string")
-		}
-		return key, nil
-	}
-}
-
-// keyFromForm returns a `keyExtractor` that extracts key from the form.
-func keyFromForm(param string) keyExtractor {
-	return func(c echo.Context) (string, error) {
-		key := c.FormValue(param)
-		if key == "" {
-			return "", errors.New("missing key in the form")
-		}
-		return key, nil
-	}
-}
-
-// keyFromCookie returns a `keyExtractor` that extracts key from the form.
-func keyFromCookie(cookieName string) keyExtractor {
-	return func(c echo.Context) (string, error) {
-		key, err := c.Cookie(cookieName)
-		if err != nil {
-			return "", fmt.Errorf("missing key in cookies: %w", err)
-		}
-		return key.Value, nil
 	}
 }

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -12,10 +12,10 @@ import (
 type (
 	// Skipper defines a function to skip middleware. Returning true skips processing
 	// the middleware.
-	Skipper func(echo.Context) bool
+	Skipper func(c echo.Context) bool
 
 	// BeforeFunc defines a function which is executed just before the middleware.
-	BeforeFunc func(echo.Context)
+	BeforeFunc func(c echo.Context)
 )
 
 func captureTokens(pattern *regexp.Regexp, input string) *strings.Replacer {


### PR DESCRIPTION
* Adds to JWT, KeyAuth, CSRF support for multivalue extractor - This is mostly useful with headers but this PR adds this other variants also. Usecase - You are using JWT middleware and expect `Authentication` header with value `Bearer xxxx` but your intracture has upstream proxy that adds  Basic authentication also. Now even if you fill basic auth in browser and your application sends requests with JWT token you would be in trouble as  previously JWT middleware knows only to extract first `Authentication` header value - which could be JWT token but could be also Basic Auth. This change allows extractor to return all those header values and run JWT token checks  or validation for Keyauth on them.
* Add flag `NoErrorContinuesExecution` to JWT and KeyAuth middleware to allow continuing execution `next(c)` when error handler decides to swallow the error (returns nil). Usecase: This is useful in cases when portion of your site/api is publicly accessible and has extra features for authorized users. In that case you can use ErrorHandlerWithContext to set default public JWT token value to request and continue with handler chain.  Note: this is similar to #2048

p.s. there are ugly error handling parts just to preserve similar/same errors that those middlewares previously returned. Unfortunately all these 3 are quite inconsistent how they do error handling - JWT has 2 generic types. Keyauth has specific error values.