### PR TITLE
Fix Echo version number which was not incremented with Release 4.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v4.6.3 - 2022-01-10
+
+**Fixes**
+
+* Fixed Echo version number in greeting message which was not incremented to `4.6.2` [#2066](https://github.com/labstack/echo/issues/2066)
+
+
+## v4.6.2 - 2022-01-08
+
+**Fixes**
+
+* Fixed route containing escaped colon should be matchable but is not matched to request path [#2047](https://github.com/labstack/echo/pull/2047)
+* Fixed a problem that returned wrong content-encoding when the gzip compressed content was empty. [#1921](https://github.com/labstack/echo/pull/1921)
+* Update (test) dependencies [#2021](https://github.com/labstack/echo/pull/2021)
+
+
+**Enhancements**
+
+* Add support for configurable target header for the request_id middleware [#2040](https://github.com/labstack/echo/pull/2040)
+* Change decompress middleware to use stream decompression instead of buffering [#2018](https://github.com/labstack/echo/pull/2018)
+* Documentation updates
+
+
 ## v4.6.1 - 2021-09-26
 
 **Enhancements**

--- a/echo.go
+++ b/echo.go
@@ -242,7 +242,7 @@ const (
 
 const (
 	// Version of Echo
-	Version = "4.6.1"
+	Version = "4.6.3"
 	website = "https://echo.labstack.com"
 	// http://patorjk.com/software/taag/#p=display&f=Small%20Slant&t=Echo
 	banner = `


### PR DESCRIPTION
Fix Echo version number which was not incremented with Release 4.6.2 Now bumped to 4.6.3

Relates to https://github.com/labstack/echo/issues/2066
When I release 4.6.2 I did not use latest master branch commit but took  4 commits older commit https://github.com/labstack/echo/commit/6b5e62b27ea0bc459843e67014360dd35ae8147b as release point. Ofcourse this point version number was not bumped to `4.6.2` and is/was still `4.6.1`

I have created separate branch under labstack/echo repository to hold this fix commit as different pullable branch. But to include this change into master history this commit needs to be added into master (after those 4 commits which are not included in 4.6.2 and are already in master).

I will release 4.6.3 from this branch `fix_branch_4_6_2` so `4.6.3` would only have this version number fix.

Sorry for the mess.