### PR TITLE
Add pagoda (full-stack web dev kit) to the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ func hello(c echo.Context) error {
 | [github.com/ziflex/lecho](https://github.com/ziflex/lecho) | [Zerolog](https://github.com/rs/zerolog) logging library wrapper for Echo logger interface.                                                                                                                                                                                                                                                                    |
 | [github.com/brpaz/echozap](https://github.com/brpaz/echozap) | Uber´s [Zap](https://github.com/uber-go/zap) logging library wrapper for Echo logger interface.                                                                                                                                                                                                                                                              |
 | [github.com/darkweak/souin/plugins/echo](https://github.com/darkweak/souin/tree/master/plugins/echo) | HTTP cache system based on [Souin](https://github.com/darkweak/souin) to automatically get your endpoints cached. It supports some distributed and non-distributed storage systems depending your needs.                                                                                                             |
+| [github.com/mikestefanello/pagoda](https://github.com/mikestefanello/pagoda) | Rapid, easy full-stack web development starter kit built with Echo.
 
 Please send a PR to add your own library here.
 


### PR DESCRIPTION
I recently built and released [pagoda](https://github.com/mikestefanello/pagoda) which is a full-stack web development starter kit built with _Echo_ and _Ent_. I thought you may want to include it in the README. There's only a section for third-party middleware, so I included it in there. If you want to include the project but want it elsewhere, please let me know.