### PR TITLE
Add Retry-After header constant

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -207,6 +207,7 @@ const (
 	HeaderIfModifiedSince     = "If-Modified-Since"
 	HeaderLastModified        = "Last-Modified"
 	HeaderLocation            = "Location"
+	HeaderRetryAfter          = "Retry-After"
 	HeaderUpgrade             = "Upgrade"
 	HeaderVary                = "Vary"
 	HeaderWWWAuthenticate     = "WWW-Authenticate"


### PR DESCRIPTION
The `Retry-After` header is often sent together with `429`s and `503`s to indicate the waiting time for the client. Having a constant for this header would be nice.