### PR TITLE
add Routers() call in echo.test

### DIFF
--- a/echo_test.go
+++ b/echo_test.go
@@ -61,6 +61,9 @@ func TestEcho(t *testing.T) {
 	// Router
 	assert.NotNil(t, e.Router())
 
+	// Routers
+	assert.NotNil(t, e.Routers())
+
 	// DefaultHTTPErrorHandler
 	e.DefaultHTTPErrorHandler(errors.New("error"), c)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)


### PR DESCRIPTION
Hi !
thanks you guys for this great repo,i really like using it.
i noticed that you call `Route()` in echo_test.go only once at `echo_test.go:62` for testing it,but did not call `Routers()` in echo.test for testing it which implement just below `Route()` in `echo.go:364`
i think that we may add this call in `echo_test.go` for consistency or something like this ?