### PR TITLE
remove redundant 0 in make chan

### DIFF
--- a/echo_test.go
+++ b/echo_test.go
@@ -61,9 +61,6 @@ func TestEcho(t *testing.T) {
 	// Router
 	assert.NotNil(t, e.Router())
 
-	// Routers
-	assert.NotNil(t, e.Routers())
-
 	// DefaultHTTPErrorHandler
 	e.DefaultHTTPErrorHandler(errors.New("error"), c)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
@@ -964,7 +961,7 @@ func TestEchoStartTLSByteString(t *testing.T) {
 			e := New()
 			e.HideBanner = true
 
-			errChan := make(chan error, 0)
+			errChan := make(chan error)
 
 			go func() {
 				errChan <- e.StartTLS(":0", test.cert, test.key)
@@ -1002,7 +999,7 @@ func TestEcho_StartAutoTLS(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			e := New()
-			errChan := make(chan error, 0)
+			errChan := make(chan error)
 
 			go func() {
 				errChan <- e.StartAutoTLS(tc.addr)

--- a/echo_test.go
+++ b/echo_test.go
@@ -61,6 +61,9 @@ func TestEcho(t *testing.T) {
 	// Router
 	assert.NotNil(t, e.Router())
 
+	// Routers
+	assert.NotNil(t, e.Routers())
+
 	// DefaultHTTPErrorHandler
 	e.DefaultHTTPErrorHandler(errors.New("error"), c)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)


### PR DESCRIPTION
Hi !
thanks you guys for this great repo,i really like using it.
i pull your repo and notice there is some go-staticcheck warning, so i did some changes and `make(chan,0)` and `make(chan)` is exactly the same. acorrding to [go-dev.doc](https://go.dev/doc/effective_go#:~:text=The%20default%20is%20zero%2C%20for%20an%20unbuffered%20or%20synchronous%20channel.
)