### PR TITLE
Upgrade to the v4 release of golang-jwt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/labstack/echo/v4
 go 1.17
 
 require (
-	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/golang-jwt/jwt/v4 v4.3.0
 	github.com/labstack/gommon v0.3.1
 	github.com/stretchr/testify v1.7.0
 	github.com/valyala/fasttemplate v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v4 v4.3.0 h1:kHL1vqdqWNfATmA0FNMdmZNMyZI1U6O31X4rlIPoBog=
+github.com/golang-jwt/jwt/v4 v4.3.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/labstack/gommon v0.3.1 h1:OomWaJXm7xR6L1HmEtGyQf26TEn7V6X88mktX9kee9o=
 github.com/labstack/gommon v0.3.1/go.mod h1:uW6kP17uPlLJsD3ijUYn3/M5bAxtlZhMI6m3MFxTMTM=
 github.com/mattn/go-colorable v0.1.11 h1:nQ+aFkoE2TMGc0b68U2OKSexC+eq46+XwZzWXHRmPYs=

--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -6,7 +6,7 @@ package middleware
 import (
 	"errors"
 	"fmt"
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/labstack/echo/v4"
 	"net/http"
 	"reflect"

--- a/middleware/jwt_test.go
+++ b/middleware/jwt_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 )


### PR DESCRIPTION
There have been a bunch of improvements to the jwt dependency.

According to the [golang-jwt/jwt Releases](https://github.com/golang-jwt/jwt/releases), "any future `/v4` work is intended to be backwards-compatible with existing v3.x.y tags."

This appears to be true; all tests pass for recent versions.

```
bribera@flask:~/code/foss/echo 👻 $ git status
On branch abscondment/jwt-v4
Your branch is up to date with 'abscondment/abscondment/jwt-v4'.

nothing to commit, working tree clean
bribera@flask:~/code/foss/echo 👻 $ git log -1
commit 130b4572b5bd24e75c8657d2699c04cf858c0bd6 (HEAD -> abscondment/jwt-v4, abscondment/abscondment/jwt-v4)
Author: Brendan Ribera <bribera@axon.com>
Date:   Wed Mar 9 11:16:37 2022 -0800

    Upgrade to the v4 release of golang-jwt
    
    According to the [4.0.0 Version History](https://github.com/golang-jwt/jwt/blob/main/VERSION_HISTORY.md#400),
    the v4 version is backwards compatible with v3.x
bribera@flask:~/code/foss/echo 👻 $ go version
go version go1.17.6 linux/amd64
bribera@flask:~/code/foss/echo 👻 $ go clean -testcache
bribera@flask:~/code/foss/echo 👻 $ make test
ok  	github.com/labstack/echo/v4	0.206s
ok  	github.com/labstack/echo/v4/middleware	0.093s
bribera@flask:~/code/foss/echo 👻 $ make race
ok  	github.com/labstack/echo/v4	0.484s
ok  	github.com/labstack/echo/v4/middleware	0.610s
bribera@flask:~/code/foss/echo 👻 $ make test_version
Unable to find image 'golang:1.15' locally
1.15: Pulling from library/golang
[... snip ...]
ok  	github.com/labstack/echo/v4	1.928s
ok  	github.com/labstack/echo/v4/middleware	0.672s
bribera@flask:~/code/foss/echo 👻 $ make test_version goversion=1.14
Unable to find image 'golang:1.14' locally
1.14: Pulling from library/golang
[...]
ok  	github.com/labstack/echo/v4	0.451s
ok  	github.com/labstack/echo/v4/middleware	0.740s
```

I noted that `make test_version` fail for go1.9.7 and go1.10.3 on the `master` branch, so I omitted them from my testing:

```
bribera@flask:~/code/foss/echo 👻 $ git status
On branch master
Your branch is up to date with 'origin/master'.

nothing to commit, working tree clean
bribera@flask:~/code/foss/echo 👻 $ git log -1
commit 5ebed440aeec1abf7f08cca41cb02f6aaf0d7f6a (HEAD -> master, tag: v4.7.0, origin/master, origin/HEAD)
Author: Roland Lammel <rl@neotel.at>
Date:   Wed Mar 2 23:16:19 2022 +0100

    Update version to v4.7.0
bribera@flask:~/code/foss/echo 👻 $ make test_version goversion=1.9.7
warning: "github.com/labstack/echo/..." matched no packages
# golang.org/x/tools/internal/typeparams
/go/src/golang.org/x/tools/internal/typeparams/normalize.go:162:17: u.EmbeddedType undefined (type *types.Interface has no field or method EmbeddedType)
Makefile:12: recipe for target 'init' failed
make: *** [init] Error 2
make: *** [Makefile:34: test_version] Error 2
bribera@flask:~/code/foss/echo 👻 $ make test_version goversion=1.10.3
warning: "github.com/labstack/echo/..." matched no packages
# golang.org/x/tools/internal/typeparams
/go/src/golang.org/x/tools/internal/typeparams/normalize.go:162:17: u.EmbeddedType undefined (type *types.Interface has no field or method EmbeddedType)
Makefile:12: recipe for target 'init' failed
make: *** [init] Error 2
make: *** [Makefile:34: test_version] Error 2
```