### PR TITLE
Recover middleware should not log panic for aborted handler (fix #2133)

### DIFF
--- a/middleware/recover.go
+++ b/middleware/recover.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"fmt"
+	"net/http"
 	"runtime"
 
 	"github.com/labstack/echo/v4"
@@ -77,6 +78,9 @@ func RecoverWithConfig(config RecoverConfig) echo.MiddlewareFunc {
 
 			defer func() {
 				if r := recover(); r != nil {
+					if r == http.ErrAbortHandler {
+						panic(r)
+					}
 					err, ok := r.(error)
 					if !ok {
 						err = fmt.Errorf("%v", r)


### PR DESCRIPTION
This is the fix for the issue #2133 

The fix is in explicit check in recover middleware defer function to re-throw (panic) the `http.ErrAbortHandler` error.

This specific error is recovered in `net/http/server.go` and per default ignored for logging.
https://github.com/golang/go/blob/88be85f18bf0244a2470fdf6719e1b5ca5a5e50a/src/net/http/server.go#L1799