### PR TITLE
Fix body_limit middleware unit test

### DIFF
--- a/middleware/body_limit_test.go
+++ b/middleware/body_limit_test.go
@@ -33,12 +33,13 @@ func TestBodyLimit(t *testing.T) {
 		assert.Equal(hw, rec.Body.Bytes())
 	}
 
-	// Based on content read (overlimit)
+	// Based on content length (overlimit)
 	he := BodyLimit("2B")(h)(c).(*echo.HTTPError)
 	assert.Equal(http.StatusRequestEntityTooLarge, he.Code)
 
 	// Based on content read (within limit)
 	req = httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(hw))
+	req.ContentLength = -1
 	rec = httptest.NewRecorder()
 	c = e.NewContext(req, rec)
 	if assert.NoError(BodyLimit("2M")(h)(c)) {
@@ -48,6 +49,7 @@ func TestBodyLimit(t *testing.T) {
 
 	// Based on content read (overlimit)
 	req = httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(hw))
+	req.ContentLength = -1
 	rec = httptest.NewRecorder()
 	c = e.NewContext(req, rec)
 	he = BodyLimit("2B")(h)(c).(*echo.HTTPError)


### PR DESCRIPTION
Hello, the four test items in Testbodylimit are actually tests on content length, not content read, and there is no difference between the first two test items and the latter two. After modification, the latter two test items can test content read.