### PR TITLE
Add httptest.Server to Echo struct

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -47,6 +47,7 @@ import (
 	stdLog "log"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"runtime"
 	"sync"
@@ -77,6 +78,7 @@ type (
 		routers          map[string]*Router
 		pool             sync.Pool
 		Server           *http.Server
+		TestServer       *httptest.Server
 		TLSServer        *http.Server
 		Listener         net.Listener
 		TLSListener      net.Listener


### PR DESCRIPTION
This pull request adds a pointer to an `httptest.Server` struct to the `Echo` struct, available via the `TestServer` field. This allows testing of handlers in a similar fashion to the typical httptest package. 

[Example usage.](https://gist.github.com/albrazeau/bc73d6126558451abf5f85b371a16c2e)

I am not sure where would add an example/docs, but would be happy to clean up the above gist as needed and put it there.