### PR TITLE
Add route to request log

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -33,6 +33,7 @@ type (
 		// - host
 		// - method
 		// - path
+		// - route
 		// - protocol
 		// - referer
 		// - user_agent
@@ -154,6 +155,8 @@ func LoggerWithConfig(config LoggerConfig) echo.MiddlewareFunc {
 						p = "/"
 					}
 					return buf.WriteString(p)
+				case "route":
+					return buf.WriteString(c.Path())
 				case "protocol":
 					return buf.WriteString(req.Proto)
 				case "referer":

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -91,17 +91,17 @@ func TestLoggerTemplate(t *testing.T) {
 	e.Use(LoggerWithConfig(LoggerConfig{
 		Format: `{"time":"${time_rfc3339_nano}","id":"${id}","remote_ip":"${remote_ip}","host":"${host}","user_agent":"${user_agent}",` +
 			`"method":"${method}","uri":"${uri}","status":${status}, "latency":${latency},` +
-			`"latency_human":"${latency_human}","bytes_in":${bytes_in}, "path":"${path}", "referer":"${referer}",` +
+			`"latency_human":"${latency_human}","bytes_in":${bytes_in}, "path":"${path}", "route":"${route}" "referer":"${referer}",` +
 			`"bytes_out":${bytes_out},"ch":"${header:X-Custom-Header}", "protocol":"${protocol}"` +
 			`"us":"${query:username}", "cf":"${form:username}", "session":"${cookie:session}"}` + "\n",
 		Output: buf,
 	}))
 
-	e.GET("/", func(c echo.Context) error {
+	e.GET("/users/:id", func(c echo.Context) error {
 		return c.String(http.StatusOK, "Header Logged")
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/?username=apagano-param&password=secret", nil)
+	req := httptest.NewRequest(http.MethodGet, "/users/1?username=apagano-param&password=secret", nil)
 	req.RequestURI = "/"
 	req.Header.Add(echo.HeaderXRealIP, "127.0.0.1")
 	req.Header.Add("Referer", "google.com")
@@ -126,7 +126,8 @@ func TestLoggerTemplate(t *testing.T) {
 		"hexvalue":                             false,
 		"GET":                                  true,
 		"127.0.0.1":                            true,
-		"\"path\":\"/\"":                       true,
+		"\"path\":\"/users/1\"":                true,
+		"\"route\":\"/users/:id\"":             true,
 		"\"uri\":\"/\"":                        true,
 		"\"status\":200":                       true,
 		"\"bytes_in\":0":                       true,

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -91,7 +91,7 @@ func TestLoggerTemplate(t *testing.T) {
 	e.Use(LoggerWithConfig(LoggerConfig{
 		Format: `{"time":"${time_rfc3339_nano}","id":"${id}","remote_ip":"${remote_ip}","host":"${host}","user_agent":"${user_agent}",` +
 			`"method":"${method}","uri":"${uri}","status":${status}, "latency":${latency},` +
-			`"latency_human":"${latency_human}","bytes_in":${bytes_in}, "path":"${path}", "route":"${route}" "referer":"${referer}",` +
+			`"latency_human":"${latency_human}","bytes_in":${bytes_in}, "path":"${path}", "route":"${route}", "referer":"${referer}",` +
 			`"bytes_out":${bytes_out},"ch":"${header:X-Custom-Header}", "protocol":"${protocol}"` +
 			`"us":"${query:username}", "cf":"${form:username}", "session":"${cookie:session}"}` + "\n",
 		Output: buf,


### PR DESCRIPTION
This PR adds `route` to tags used for request logging to be able to log the route pattern.
There is a usecase that we want to log the route to aggregate the request in monitoring.