### PR TITLE
Update Github CI flow to use Go 1.18, bump actions versions

### DIFF
--- a/.github/workflows/echo.yml
+++ b/.github/workflows/echo.yml
@@ -19,6 +19,7 @@ on:
       - '_fixture/**'
       - '.github/**'
       - 'codecov.yml'
+  workflow_dispatch:
 
 jobs:
   test:
@@ -27,33 +28,22 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         # Each major Go release is supported until there are two newer major releases. https://golang.org/doc/devel/release.html#policy
         # Echo tests with last four major releases
-        go: [1.14, 1.15, 1.16, 1.17]
+        go: [1.16, 1.17, 1.18]
     name: ${{ matrix.os }} @ Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Set up Go ${{ matrix.go }}
-        uses: actions/setup-go@v1
-        with:
-          go-version: ${{ matrix.go }}
-
-      - name: Set GOPATH and PATH
-        run: |
-          echo "GOPATH=$(dirname $GITHUB_WORKSPACE)" >> $GITHUB_ENV
-          echo "$(dirname $GITHUB_WORKSPACE)/bin" >> $GITHUB_PATH
-        shell: bash
-
-      - name: Set build variables
-        run: |
-          echo "GOPROXY=https://proxy.golang.org" >> $GITHUB_ENV
-          echo "GO111MODULE=on" >> $GITHUB_ENV
-
       - name: Checkout Code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
 
+      - name: Set up Go ${{ matrix.go }}
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+
       - name: Install Dependencies
-        run: go get -v golang.org/x/lint/golint
+        run: go install golang.org/x/lint/golint@latest
 
       - name: Run Tests
         run: |
@@ -61,7 +51,7 @@ jobs:
           go test -race --coverprofile=coverage.coverprofile --covermode=atomic ./...
 
       - name: Upload coverage to Codecov
-        if: success() && matrix.go == 1.17 && matrix.os == 'ubuntu-latest'
+        if: success() && matrix.go == 1.18 && matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v1
         with:
           token:
@@ -71,39 +61,28 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go: [1.17]
+        go: [1.18]
     name: Benchmark comparison ${{ matrix.os }} @ Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Set up Go ${{ matrix.go }}
-        uses: actions/setup-go@v1
-        with:
-          go-version: ${{ matrix.go }}
-
-      - name: Set GOPATH and PATH
-        run: |
-          echo "GOPATH=$(dirname $GITHUB_WORKSPACE)" >> $GITHUB_ENV
-          echo "$(dirname $GITHUB_WORKSPACE)/bin" >> $GITHUB_PATH
-        shell: bash
-
-      - name: Set build variables
-        run: |
-          echo "GOPROXY=https://proxy.golang.org" >> $GITHUB_ENV
-          echo "GO111MODULE=on" >> $GITHUB_ENV
-
       - name: Checkout Code (Previous)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.base_ref }}
           path: previous
 
       - name: Checkout Code (New)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: new
 
+      - name: Set up Go ${{ matrix.go }}
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+
       - name: Install Dependencies
-        run: go get -v golang.org/x/perf/cmd/benchstat
+        run: go install golang.org/x/perf/cmd/benchstat@latest
 
       - name: Run Benchmark (Previous)
         run: |

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ tag:
 check: lint vet race ## Check project
 
 init:
-	@go get -u golang.org/x/lint/golint
+	@go install golang.org/x/lint/golint@latest
 
 lint: ## Lint the files
 	@golint -set_exit_status ${PKG_LIST}
@@ -29,6 +29,6 @@ benchmark: ## Run benchmarks
 help: ## Display this help screen
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-goversion ?= "1.15"
-test_version: ## Run tests inside Docker with given version (defaults to 1.15 oldest supported). Example: make test_version goversion=1.15
+goversion ?= "1.16"
+test_version: ## Run tests inside Docker with given version (defaults to 1.15 oldest supported). Example: make test_version goversion=1.16
 	@docker run --rm -it -v $(shell pwd):/project golang:$(goversion) /bin/sh -c "cd /project && make init check"


### PR DESCRIPTION
Update Github CI flow to use Go 1.18, bump action versions.

Note: Github flow used `go get -u golang.org/x/lint/golint@latest` but from Go 1.18 this way of installing commands is removed and `go install golang.org/x/lint/golint@latest` should be used. But go install is supported only from Go 1.16. So I dropped Go 1.15  from github flow at the moment.