### PR TITLE
add WebDAV support(#1610)

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -183,6 +183,14 @@ const (
 	PROPFIND = "PROPFIND"
 	// REPORT Method can be used to get information about a resource, see rfc 3253
 	REPORT = "REPORT"
+	// RFC 4918: HTTP Extensions for Web Distributed Authoring and Versioning (WebDAV)
+	// https://tools.ietf.org/html/rfc4918
+	MKCOL     = "MKCOL"
+	COPY      = "COPY"
+	MOVE      = "MOVE"
+	LOCK      = "LOCK"
+	UNLOCK    = "UNLOCK"
+	PROPPATCH = "PROPPATCH"
 )
 
 // Headers
@@ -274,6 +282,12 @@ var (
 		http.MethodPut,
 		http.MethodTrace,
 		REPORT,
+		MKCOL,
+		COPY,
+		MOVE,
+		LOCK,
+		UNLOCK,
+		PROPPATCH,
 	}
 )
 

--- a/router.go
+++ b/router.go
@@ -73,7 +73,13 @@ func (m *methodHandler) isHandler() bool {
 		m.propfind != nil ||
 		m.put != nil ||
 		m.trace != nil ||
-		m.report != nil
+		m.report != nil ||
+		m.mkcol != nil ||
+		m.copy != nil ||
+		m.move != nil ||
+		m.lock != nil ||
+		m.unlock != nil ||
+		m.proppatch != nil
 }
 
 func (m *methodHandler) updateAllowHeader() {
@@ -118,6 +124,25 @@ func (m *methodHandler) updateAllowHeader() {
 	if m.report != nil {
 		buf.WriteString(", REPORT")
 	}
+	if m.mkcol != nil {
+		buf.WriteString(", MKCOL")
+	}
+	if m.copy != nil {
+		buf.WriteString(", COPY")
+	}
+	if m.move != nil {
+		buf.WriteString(", MOVE")
+	}
+	if m.lock != nil {
+		buf.WriteString(", LOCK")
+	}
+	if m.unlock != nil {
+		buf.WriteString(", UNLOCK")
+	}
+	if m.proppatch != nil {
+		buf.WriteString(", PROPPATCH")
+	}
+
 	m.allowHeader = buf.String()
 }
 

--- a/router.go
+++ b/router.go
@@ -43,6 +43,12 @@ type (
 		put         HandlerFunc
 		trace       HandlerFunc
 		report      HandlerFunc
+		mkcol       HandlerFunc
+		copy        HandlerFunc
+		move        HandlerFunc
+		lock        HandlerFunc
+		unlock      HandlerFunc
+		proppatch   HandlerFunc
 		allowHeader string
 	}
 )
@@ -371,6 +377,18 @@ func (n *node) addHandler(method string, h HandlerFunc) {
 		n.methodHandler.trace = h
 	case REPORT:
 		n.methodHandler.report = h
+	case MKCOL:
+		n.methodHandler.mkcol = h
+	case COPY:
+		n.methodHandler.copy = h
+	case MOVE:
+		n.methodHandler.move = h
+	case LOCK:
+		n.methodHandler.lock = h
+	case UNLOCK:
+		n.methodHandler.unlock = h
+	case PROPPATCH:
+		n.methodHandler.proppatch = h
 	}
 
 	n.methodHandler.updateAllowHeader()
@@ -405,6 +423,18 @@ func (n *node) findHandler(method string) HandlerFunc {
 		return n.methodHandler.trace
 	case REPORT:
 		return n.methodHandler.report
+	case MKCOL:
+		return n.methodHandler.mkcol
+	case COPY:
+		return n.methodHandler.copy
+	case MOVE:
+		return n.methodHandler.move
+	case LOCK:
+		return n.methodHandler.lock
+	case UNLOCK:
+		return n.methodHandler.unlock
+	case PROPPATCH:
+		return n.methodHandler.proppatch
 	default:
 		return nil
 	}


### PR DESCRIPTION
#1610 

WebDAV support by adding method : `MKCOL`,`COPY `,`MOVE `,`LOCK`,`UNLOCK`,  `PROPPATCH`, no  dependencies added.

**Working code using echo & golang.org/x/net/webdav**

```
package main

import (
	"flag"
	"fmt"
	"os"

	"github.com/labstack/echo/v4"
	"golang.org/x/net/webdav"
)

var (
	flagRootDir  = flag.String("dir", "", "webdav root dir")
	flagHttpAddr = flag.String("http", ":8080", "http or https address")
)

func init() {
	flag.Usage = func() {
		fmt.Fprintf(os.Stderr, "Usage of WebDAV Server\n")
		flag.PrintDefaults()
	}
}
func main() {
	flag.Parse()
	fs := &webdav.Handler{
		FileSystem: webdav.Dir(*flagRootDir),
		LockSystem: webdav.NewMemLS(),
	}

	e := echo.New()
	e.Pre(func(next echo.HandlerFunc) echo.HandlerFunc {
		return func(c echo.Context) error {
			fmt.Println(c.Request())
			return next(c)
		}
	})
	echoHandle := echo.WrapHandler(fs)
	e.Any("/*", echoHandle)
	fmt.Println(e.Start(*flagHttpAddr))
}

```

Signed-off-by: yixy <youzhilane01@gmail.com>