### PR TITLE
fix: duplicated findStaticChild process at findChildWithLabel

### DIFF
--- a/router.go
+++ b/router.go
@@ -333,10 +333,8 @@ func (n *node) findStaticChild(l byte) *node {
 }
 
 func (n *node) findChildWithLabel(l byte) *node {
-	for _, c := range n.staticChildren {
-		if c.label == l {
-			return c
-		}
+	if c := n.findStaticChild(l); c != nil {
+		return c
 	}
 	if l == paramLabel {
 		return n.paramChild


### PR DESCRIPTION
duplicated findStaticChild process at findChildWithLabel in router.go

I think less duplicate processing more readable except  performance decrement.