### PR TITLE
Remove square brackets from ipv6 addresses in XFF

### DIFF
--- a/context.go
+++ b/context.go
@@ -282,7 +282,7 @@ func (c *context) RealIP() string {
 	if ip := c.request.Header.Get(HeaderXForwardedFor); ip != "" {
 		i := strings.IndexAny(ip, ",")
 		if i > 0 {
-			xffip := ip[:i]
+			xffip := strings.TrimSpace(ip[:i])
 			xffip = strings.TrimPrefix(xffip, "[")
 			xffip = strings.TrimSuffix(xffip, "]")
 			return xffip

--- a/context.go
+++ b/context.go
@@ -282,7 +282,10 @@ func (c *context) RealIP() string {
 	if ip := c.request.Header.Get(HeaderXForwardedFor); ip != "" {
 		i := strings.IndexAny(ip, ",")
 		if i > 0 {
-			return strings.TrimSpace(ip[:i])
+			xffip := ip[:i]
+			xffip = strings.ReplaceAll(xffip, "[", "")
+			xffip = strings.ReplaceAll(xffip, "]", "")
+			return xffip
 		}
 		return ip
 	}

--- a/context.go
+++ b/context.go
@@ -283,13 +283,15 @@ func (c *context) RealIP() string {
 		i := strings.IndexAny(ip, ",")
 		if i > 0 {
 			xffip := ip[:i]
-			xffip = strings.ReplaceAll(xffip, "[", "")
-			xffip = strings.ReplaceAll(xffip, "]", "")
+			xffip = strings.TrimPrefix(xffip, "[")
+			xffip = strings.TrimSuffix(xffip, "]")
 			return xffip
 		}
 		return ip
 	}
 	if ip := c.request.Header.Get(HeaderXRealIP); ip != "" {
+		ip = strings.TrimPrefix(ip, "[")
+		ip = strings.TrimSuffix(ip, "]")
 		return ip
 	}
 	ra, _, _ := net.SplitHostPort(c.request.RemoteAddr)

--- a/context_test.go
+++ b/context_test.go
@@ -907,6 +907,30 @@ func TestContext_RealIP(t *testing.T) {
 		{
 			&context{
 				request: &http.Request{
+					Header: http.Header{HeaderXForwardedFor: []string{"[2001:db8:85a3:8d3:1319:8a2e:370:7348], 2001:db8::1, "}},
+				},
+			},
+			"2001:db8:85a3:8d3:1319:8a2e:370:7348",
+		},
+		{
+			&context{
+				request: &http.Request{
+					Header: http.Header{HeaderXForwardedFor: []string{"[2001:db8:85a3:8d3:1319:8a2e:370:7348],[2001:db8::1]"}},
+				},
+			},
+			"2001:db8:85a3:8d3:1319:8a2e:370:7348",
+		},
+		{
+			&context{
+				request: &http.Request{
+					Header: http.Header{HeaderXForwardedFor: []string{"2001:db8:85a3:8d3:1319:8a2e:370:7348"}},
+				},
+			},
+			"2001:db8:85a3:8d3:1319:8a2e:370:7348",
+		},
+		{
+			&context{
+				request: &http.Request{
 					Header: http.Header{
 						"X-Real-Ip": []string{"192.168.0.1"},
 					},

--- a/context_test.go
+++ b/context_test.go
@@ -97,7 +97,6 @@ func (responseWriterErr) Write([]byte) (int, error) {
 }
 
 func (responseWriterErr) WriteHeader(statusCode int) {
-
 }
 
 func TestContext(t *testing.T) {
@@ -938,6 +937,17 @@ func TestContext_RealIP(t *testing.T) {
 			},
 			"192.168.0.1",
 		},
+		{
+			&context{
+				request: &http.Request{
+					Header: http.Header{
+						"X-Real-Ip": []string{"[2001:db8::1]"},
+					},
+				},
+			},
+			"2001:db8::1",
+		},
+
 		{
 			&context{
 				request: &http.Request{

--- a/ip.go
+++ b/ip.go
@@ -227,6 +227,8 @@ func ExtractIPFromRealIPHeader(options ...TrustOption) IPExtractor {
 	return func(req *http.Request) string {
 		realIP := req.Header.Get(HeaderXRealIP)
 		if realIP != "" {
+			realIP = strings.TrimPrefix(realIP, "[")
+			realIP = strings.TrimSuffix(realIP, "]")
 			if ip := net.ParseIP(realIP); ip != nil && checker.trust(ip) {
 				return realIP
 			}
@@ -248,9 +250,10 @@ func ExtractIPFromXFFHeader(options ...TrustOption) IPExtractor {
 		}
 		ips := append(strings.Split(strings.Join(xffs, ","), ","), directIP)
 		for i := len(ips) - 1; i >= 0; i-- {
-			ips[i] = strings.ReplaceAll(ips[i], "[", "")
-			ips[i] = strings.ReplaceAll(ips[i], "]", "")
-			ip := net.ParseIP(strings.TrimSpace(ips[i]))
+			ips[i] = strings.TrimSpace(ips[i])
+			ips[i] = strings.TrimPrefix(ips[i], "[")
+			ips[i] = strings.TrimSuffix(ips[i], "]")
+			ip := net.ParseIP(ips[i])
 			if ip == nil {
 				// Unable to parse IP; cannot trust entire records
 				return directIP

--- a/ip.go
+++ b/ip.go
@@ -248,6 +248,8 @@ func ExtractIPFromXFFHeader(options ...TrustOption) IPExtractor {
 		}
 		ips := append(strings.Split(strings.Join(xffs, ","), ","), directIP)
 		for i := len(ips) - 1; i >= 0; i-- {
+			ips[i] = strings.ReplaceAll(ips[i], "[", "")
+			ips[i] = strings.ReplaceAll(ips[i], "]", "")
 			ip := net.ParseIP(strings.TrimSpace(ips[i]))
 			if ip == nil {
 				// Unable to parse IP; cannot trust entire records


### PR DESCRIPTION
Some loadbalancers (eg citrix ADC / netscaler) add square brackets around the ipv6 address in the X-Forwarded-For header.
This PR removes them so that RealIP() and friends work correctly.