### PR TITLE
Allow different params' names in different methods

### DIFF
--- a/router_test.go
+++ b/router_test.go
@@ -2318,6 +2318,27 @@ func TestRouterPanicWhenParamNoRootOnlyChildsFailsFind(t *testing.T) {
 	}
 }
 
+// Issue #1726
+func TestRouterDifferentParamsInPath(t *testing.T) {
+	e := New()
+	r := e.router
+	r.Add(http.MethodPut, "/users/:vid/files/:gid", func(Context) error {
+		return nil
+	})
+	r.Add(http.MethodGet, "/users/:uid/files/:fid", func(Context) error {
+		return nil
+	})
+	c := e.NewContext(nil, nil).(*context)
+
+	r.Find(http.MethodGet, "/users/1/files/2", c)
+	assert.Equal(t, "1", c.Param("uid"))
+	assert.Equal(t, "2", c.Param("fid"))
+
+	r.Find(http.MethodPut, "/users/3/files/4", c)
+	assert.Equal(t, "3", c.Param("vid"))
+	assert.Equal(t, "4", c.Param("gid"))
+}
+
 func TestRouterHandleMethodOptions(t *testing.T) {
 	e := New()
 	r := e.router
@@ -2380,7 +2401,9 @@ func TestRouterHandleMethodOptions(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, tc.expectStatus, rec.Code)
 			}
-			assert.Equal(t, tc.expectAllowHeader, c.Response().Header().Get("Allow"))
+			expect := strings.Split(tc.expectAllowHeader, ",")
+			actual := strings.Split(c.Response().Header().Get("Allow"), ",")
+			assert.ElementsMatch(t, expect, actual)
 		})
 	}
 }


### PR DESCRIPTION
Relates to issues  https://github.com/labstack/echo/issues/1726 and https://github.com/labstack/echo/issues/2201

Parameters and paths are now separated by methods within the same node. 
Add test from https://github.com/labstack/echo/issues/1726. 


cc @aldas 