### PR TITLE
Remove directory redirect from `echo.StaticDirectoryHandler`

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -489,17 +489,7 @@ func StaticDirectoryHandler(fileSystem fs.FS, disablePathUnescaping bool) Handle
 
 		// fs.FS.Open() already assumes that file names are relative to FS root path and considers name with prefix `/` as invalid
 		name := filepath.ToSlash(filepath.Clean(strings.TrimPrefix(p, "/")))
-		fi, err := fs.Stat(fileSystem, name)
-		if err != nil {
-			return ErrNotFound
-		}
 
-		// If the request is for a directory and does not end with "/"
-		p = c.Request().URL.Path // path must not be empty.
-		if fi.IsDir() && len(p) > 0 && p[len(p)-1] != '/' {
-			// Redirect to ends with "/"
-			return c.Redirect(http.StatusMovedPermanently, p+"/")
-		}
 		return fsFile(c, name, fileSystem)
 	}
 }

--- a/echo_test.go
+++ b/echo_test.go
@@ -105,39 +105,12 @@ func TestEcho_StaticFS(t *testing.T) {
 			expectBodyStartsWith: "{\"message\":\"Not Found\"}\n",
 		},
 		{
-			name:                 "Directory Redirect",
-			givenPrefix:          "/",
-			givenFs:              os.DirFS("_fixture/"),
-			whenURL:              "/folder",
-			expectStatus:         http.StatusMovedPermanently,
-			expectHeaderLocation: "/folder/",
-			expectBodyStartsWith: "",
-		},
-		{
-			name:                 "Directory Redirect with non-root path",
-			givenPrefix:          "/static",
-			givenFs:              os.DirFS("_fixture"),
-			whenURL:              "/static",
-			expectStatus:         http.StatusMovedPermanently,
-			expectHeaderLocation: "/static/",
-			expectBodyStartsWith: "",
-		},
-		{
 			name:                 "Prefixed directory 404 (request URL without slash)",
 			givenPrefix:          "/folder/", // trailing slash will intentionally not match "/folder"
 			givenFs:              os.DirFS("_fixture"),
 			whenURL:              "/folder", // no trailing slash
 			expectStatus:         http.StatusNotFound,
 			expectBodyStartsWith: "{\"message\":\"Not Found\"}\n",
-		},
-		{
-			name:                 "Prefixed directory redirect (without slash redirect to slash)",
-			givenPrefix:          "/folder", // no trailing slash shall match /folder and /folder/*
-			givenFs:              os.DirFS("_fixture"),
-			whenURL:              "/folder", // no trailing slash
-			expectStatus:         http.StatusMovedPermanently,
-			expectHeaderLocation: "/folder/",
-			expectBodyStartsWith: "",
 		},
 		{
 			name:                 "Directory with index.html",
@@ -156,7 +129,15 @@ func TestEcho_StaticFS(t *testing.T) {
 			expectBodyStartsWith: "<!doctype html>",
 		},
 		{
-			name:                 "Prefixed directory with index.html (prefix ending without slash)",
+			name:                 "Prefixed directory with index.html (prefix ending without slash and url without ending slash)",
+			givenPrefix:          "/assets",
+			givenFs:              os.DirFS("_fixture"),
+			whenURL:              "/assets",
+			expectStatus:         http.StatusOK,
+			expectBodyStartsWith: "<!doctype html>",
+		},
+		{
+			name:                 "Prefixed directory with index.html (prefix ending without slash and url with ending slash)",
 			givenPrefix:          "/assets",
 			givenFs:              os.DirFS("_fixture"),
 			whenURL:              "/assets/",
@@ -164,10 +145,18 @@ func TestEcho_StaticFS(t *testing.T) {
 			expectBodyStartsWith: "<!doctype html>",
 		},
 		{
-			name:                 "Sub-directory with index.html",
+			name:                 "Sub-directory with index.html (url with ending slash)",
 			givenPrefix:          "/",
 			givenFs:              os.DirFS("_fixture"),
 			whenURL:              "/folder/",
+			expectStatus:         http.StatusOK,
+			expectBodyStartsWith: "<!doctype html>",
+		},
+		{
+			name:                 "Sub-directory with index.html (url without ending slash)",
+			givenPrefix:          "/",
+			givenFs:              os.DirFS("_fixture"),
+			whenURL:              "/folder",
 			expectStatus:         http.StatusOK,
 			expectBodyStartsWith: "<!doctype html>",
 		},

--- a/group_test.go
+++ b/group_test.go
@@ -1,7 +1,6 @@
 package echo
 
 import (
-	"github.com/stretchr/testify/assert"
 	"io/fs"
 	"io/ioutil"
 	"net/http"
@@ -9,6 +8,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGroup_withoutRouteWillNotExecuteMiddleware(t *testing.T) {
@@ -485,39 +486,12 @@ func TestGroup_StaticMultiTest(t *testing.T) {
 			expectBodyStartsWith: "{\"message\":\"Not Found\"}\n",
 		},
 		{
-			name:                 "Directory Redirect",
-			givenPrefix:          "/",
-			givenRoot:            "_fixture",
-			whenURL:              "/test/folder",
-			expectStatus:         http.StatusMovedPermanently,
-			expectHeaderLocation: "/test/folder/",
-			expectBodyStartsWith: "",
-		},
-		{
-			name:                 "Directory Redirect with non-root path",
-			givenPrefix:          "/static",
-			givenRoot:            "_fixture",
-			whenURL:              "/test/static",
-			expectStatus:         http.StatusMovedPermanently,
-			expectHeaderLocation: "/test/static/",
-			expectBodyStartsWith: "",
-		},
-		{
 			name:                 "Prefixed directory 404 (request URL without slash)",
 			givenPrefix:          "/folder/", // trailing slash will intentionally not match "/folder"
 			givenRoot:            "_fixture",
 			whenURL:              "/test/folder", // no trailing slash
 			expectStatus:         http.StatusNotFound,
 			expectBodyStartsWith: "{\"message\":\"Not Found\"}\n",
-		},
-		{
-			name:                 "Prefixed directory redirect (without slash redirect to slash)",
-			givenPrefix:          "/folder", // no trailing slash shall match /folder and /folder/*
-			givenRoot:            "_fixture",
-			whenURL:              "/test/folder", // no trailing slash
-			expectStatus:         http.StatusMovedPermanently,
-			expectHeaderLocation: "/test/folder/",
-			expectBodyStartsWith: "",
 		},
 		{
 			name:                 "Directory with index.html",
@@ -536,7 +510,7 @@ func TestGroup_StaticMultiTest(t *testing.T) {
 			expectBodyStartsWith: "<!doctype html>",
 		},
 		{
-			name:                 "Prefixed directory with index.html (prefix ending without slash)",
+			name:                 "Prefixed directory with index.html (prefix ending without slash and url with ending slash)",
 			givenPrefix:          "/assets",
 			givenRoot:            "_fixture",
 			whenURL:              "/test/assets/",
@@ -544,10 +518,26 @@ func TestGroup_StaticMultiTest(t *testing.T) {
 			expectBodyStartsWith: "<!doctype html>",
 		},
 		{
-			name:                 "Sub-directory with index.html",
+			name:                 "Prefixed directory with index.html (prefix ending without slash and url without ending slash)",
+			givenPrefix:          "/assets",
+			givenRoot:            "_fixture",
+			whenURL:              "/test/assets",
+			expectStatus:         http.StatusOK,
+			expectBodyStartsWith: "<!doctype html>",
+		},
+		{
+			name:                 "Sub-directory with index.html (url with ending slash)",
 			givenPrefix:          "/",
 			givenRoot:            "_fixture",
 			whenURL:              "/test/folder/",
+			expectStatus:         http.StatusOK,
+			expectBodyStartsWith: "<!doctype html>",
+		},
+		{
+			name:                 "Sub-directory with index.html (url without ending slash)",
+			givenPrefix:          "/",
+			givenRoot:            "_fixture",
+			whenURL:              "/test/folder",
 			expectStatus:         http.StatusOK,
 			expectBodyStartsWith: "<!doctype html>",
 		},


### PR DESCRIPTION
This PR removes the directory redirect from `echo.StaticDirectoryHandler`.

As mentioned in the related issue (#2211), the redirect conflicts with the `RemoveTrailingSlash` middleware.

I'm not sure why the redirect was added (maybe it's a legacy from earlier versions?) but I don't think its necessary.

I'm tagging @aldas (git blame pointed to him) to correct me in case I'm missing something.
