### PR TITLE
Allow arbitrary HTTP method types to be added as routes

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -492,8 +492,11 @@ func (e *Echo) RouteNotFound(path string, h HandlerFunc, m ...MiddlewareFunc) *R
 	return e.Add(RouteNotFound, path, h, m...)
 }
 
-// Any registers a new route for all HTTP methods and path with matching handler
+// Any registers a new route for all HTTP methods (supported by Echo) and path with matching handler
 // in the router with optional route-level middleware.
+//
+// Note: this method only adds specific set of supported HTTP methods as handler and is not true
+// "catch-any-arbitrary-method" way of matching requests.
 func (e *Echo) Any(path string, handler HandlerFunc, middleware ...MiddlewareFunc) []*Route {
 	routes := make([]*Route, len(methods))
 	for i, m := range methods {


### PR DESCRIPTION
Allow arbitrary HTTP method types to be added as routes. 

This does not affect routing "usual" use-case performance as these arbitrary HTTP method types and underlying map is accessed only when request is of that type. This code is taken from `v5`.

Relates to;
* https://github.com/labstack/echo/issues/1952
* https://github.com/labstack/echo/pull/2173
* https://github.com/labstack/echo/issues/1610
* https://github.com/labstack/echo/issues/1459


Example:
```go
import (
	"fmt"
	"github.com/labstack/echo/v4"
	"log"
	"net/http"
)

func main() {
	e := echo.New()

	e.Add("COPY", "/*", func(c echo.Context) error {
		return c.String(http.StatusOK, "OK COPY")
	})

	if err := e.Start(":8080"); err != http.ErrServerClosed {
		log.Print(fmt.Errorf("error when starting HTTP server: %w", err))
	}
}
```

Output:
```bash
x@x:~/code/$ curl -v -X COPY "http://localhost:8080/something"
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> COPY /something HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.81.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: text/plain; charset=UTF-8
< Date: Sat, 06 Aug 2022 20:34:24 GMT
< Content-Length: 7
< 
* Connection #0 to host localhost left intact
OK COPY
```