### PR TITLE
bind.go: add BindHeaders() to Bind()

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -114,13 +114,16 @@ func (b *DefaultBinder) Bind(i interface{}, c Context) (err error) {
 	// Only bind query parameters for GET/DELETE/HEAD to avoid unexpected behavior with destination struct binding from body.
 	// For example a request URL `&id=1&lang=en` with body `{"id":100,"lang":"de"}` would lead to precedence issues.
 	// The HTTP method check restores pre-v4.1.11 behavior to avoid these problems (see issue #1670)
-  method := c.Request().Method
+	method := c.Request().Method
 	if method == http.MethodGet || method == http.MethodDelete || method == http.MethodHead {
 		if err = b.BindQueryParams(c, i); err != nil {
 			return err
 		}
 	}
-	return b.BindBody(c, i)
+	if err := b.BindBody(c, i); err != nil {
+		return err
+	}
+	return b.BindHeaders(c, i)
 }
 
 // bindData will bind data ONLY fields in destination struct that have EXPLICIT tag

--- a/bind_test.go
+++ b/bind_test.go
@@ -269,6 +269,21 @@ func TestBindQueryParamsCaseSensitivePrioritized(t *testing.T) {
 	}
 }
 
+func TestBindHeader(t *testing.T) {
+	e := New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Name", "Jon Doe")
+	req.Header.Set("Id", "2")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	u := new(user)
+	err := c.Bind(u)
+	if assert.NoError(t, err) {
+		assert.Equal(t, 2, u.ID)
+		assert.Equal(t, "Jon Doe", u.Name)
+	}
+}
+
 func TestBindHeaderParam(t *testing.T) {
 	e := New()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)


### PR DESCRIPTION
Headers are supported in Bind() and we can find the following in the
documentation[1]:

	Echo provides the following methods to bind data from different
	sources to Go Structs using the Context#Bind(i interface{}) method:
	- URL Path parameter
	- URL Query parameter
	- Request body
	- Header

1. https://echo.labstack.com/guide/binding/#bind-using-struct-tags
