### PR TITLE
Changelog for 4.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v4.9.0 - 2022-09-04
+
+**Security**
+
+* Fix open redirect vulnerability in handlers serving static directories (e.Static, e.StaticFs, echo.StaticDirectoryHandler) [#2260](https://github.com/labstack/echo/pull/2260)
+
+**Enhancements**
+
+* Allow configuring ErrorHandler in CSRF middleware [#2257](https://github.com/labstack/echo/pull/2257)
+* Replace HTTP method constants in tests with stdlib constants [#2247](https://github.com/labstack/echo/pull/2247)
+
+
 ## v4.8.0 - 2022-08-10
 
 **Most notable things**

--- a/echo.go
+++ b/echo.go
@@ -248,7 +248,7 @@ const (
 
 const (
 	// Version of Echo
-	Version = "4.8.0"
+	Version = "4.9.0"
 	website = "https://echo.labstack.com"
 	// http://patorjk.com/software/taag/#p=display&f=Small%20Slant&t=Echo
 	banner = `


### PR DESCRIPTION
Changelog for 4.9.0

going to 4.9.0 because we had csrf middleware errorhandler #2257 already commited to main. otherwise would have used 4.8.1