### PR TITLE
Logging level middleware

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -39,6 +39,7 @@ type (
 		// - referer
 		// - user_agent
 		// - status
+		// - level
 		// - error
 		// - latency (In nanoseconds)
 		// - latency_human (Human readable)
@@ -180,6 +181,11 @@ func LoggerWithConfig(config LoggerConfig) echo.MiddlewareFunc {
 						s = config.colorer.Cyan(n)
 					}
 					return buf.WriteString(s)
+				case "level":
+					if err != nil {
+						return buf.WriteString("error")
+					}
+					return buf.WriteString("info")
 				case "error":
 					if err != nil {
 						// Error may contain invalid JSON e.g. `"`

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -16,6 +16,9 @@ type (
 
 	// BeforeFunc defines a function which is executed just before the middleware.
 	BeforeFunc func(c echo.Context)
+
+	// LoggingLevelSetterFunc allow set login level based on context and error.
+	LoggingLevelSetterFunc func(c echo.Context, err error) string
 )
 
 func captureTokens(pattern *regexp.Regexp, input string) *strings.Replacer {
@@ -86,4 +89,12 @@ func rewriteURL(rewriteRegex map[*regexp.Regexp]string, req *http.Request) error
 // DefaultSkipper returns false which processes the middleware.
 func DefaultSkipper(echo.Context) bool {
 	return false
+}
+
+// DefaultLoggingLevelSetter returns "error" when error is not nil and returns info when error is nil.
+func DefaultLoggingLevelSetter(_ echo.Context, err error) string {
+	if err != nil {
+		return "error"
+	}
+	return "info"
 }

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -1,11 +1,13 @@
 package middleware
 
 import (
-	"github.com/stretchr/testify/assert"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRewriteURL(t *testing.T) {
@@ -89,4 +91,14 @@ func TestRewriteURL(t *testing.T) {
 			assert.Equal(t, tc.expectQuery, req.URL.RawQuery)
 		})
 	}
+}
+
+func TestDefaultLoggingLevelSetter_withError(t *testing.T) {
+	level := DefaultLoggingLevelSetter(nil, errors.New("error"))
+	assert.Equal(t, "error", level)
+}
+
+func TestDefaultLoggingLevelSetter_withoutError(t *testing.T) {
+	level := DefaultLoggingLevelSetter(nil, nil)
+	assert.Equal(t, "info", level)
 }


### PR DESCRIPTION
I added ``level`` field to logging template and allow customize with ``LevelSetter`` function for different use cases. For example, you can set  ``level`` to ``info`` by just  checking ``err == nil`` and/or you can set ``error`` when request responded with ``500``
 and/or ``error`` is not nil.

Adding ``level`` field to logs allows better filtering and observability in your log stack.