### PR TITLE
fix func(Context) error to HandlerFunc

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -626,7 +626,7 @@ func (e *Echo) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Acquire context
 	c := e.pool.Get().(*context)
 	c.Reset(r, w)
-	var h func(Context) error
+	var h HandlerFunc
 
 	if e.premiddleware == nil {
 		e.findRouter(r.Host).Find(r.Method, GetPath(r), c)


### PR DESCRIPTION
HandlerFunc has already been defined as func(Context) error in echo.go.
I think using HandlerFunc is more smarter than func(Context) error!