### PR TITLE
Routes and onhandlers

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -64,7 +64,7 @@ type (
 	//
 	// Goroutine safety: Do not mutate Echo instance fields after server has started. Accessing these
 	// fields from handlers/middlewares and changing field values at the same time leads to data-races.
-	// Same rule applies to adding new routes after server has been started - Adding a route is not Goroutine safe action.
+	// Adding new routes after the server has been started is also not safe!
 	Echo struct {
 		filesystem
 		common
@@ -73,8 +73,8 @@ type (
 		startupMutex sync.RWMutex
 		colorer      *color.Color
 
-		// premiddleware are middlewares that are run before routing is done. In case pre-middleware returns an error router
-		// will not be called at all and execution ends up in global error handler.
+		// premiddleware are middlewares that are run before routing is done. In case a pre-middleware returns
+		// an error the router is not executed and the request will end up in the global error handler.
 		premiddleware []MiddlewareFunc
 		middleware    []MiddlewareFunc
 		maxParam      *int

--- a/echo_test.go
+++ b/echo_test.go
@@ -1461,6 +1461,44 @@ func TestEchoListenerNetworkInvalid(t *testing.T) {
 	assert.Equal(t, ErrInvalidListenerNetwork, e.Start(":1323"))
 }
 
+func TestEcho_OnAddRouteHandler(t *testing.T) {
+	type rr struct {
+		host       string
+		route      Route
+		handler    HandlerFunc
+		middleware []MiddlewareFunc
+	}
+	dummyHandler := func(Context) error { return nil }
+	e := New()
+
+	added := make([]rr, 0)
+	e.OnAddRouteHandler = func(host string, route Route, handler HandlerFunc, middleware []MiddlewareFunc) {
+		added = append(added, rr{
+			host:       host,
+			route:      route,
+			handler:    handler,
+			middleware: middleware,
+		})
+	}
+
+	e.GET("/static", NotFoundHandler)
+	e.Host("domain.site").GET("/static/*", dummyHandler, func(next HandlerFunc) HandlerFunc {
+		return func(c Context) error {
+			return next(c)
+		}
+	})
+
+	assert.Len(t, added, 2)
+
+	assert.Equal(t, "", added[0].host)
+	assert.Equal(t, Route{Method: http.MethodGet, Path: "/static", Name: "github.com/labstack/echo/v4.glob..func1"}, added[0].route)
+	assert.Len(t, added[0].middleware, 0)
+
+	assert.Equal(t, "domain.site", added[1].host)
+	assert.Equal(t, Route{Method: http.MethodGet, Path: "/static/*", Name: "github.com/labstack/echo/v4.TestEcho_OnAddRouteHandler.func1"}, added[1].route)
+	assert.Len(t, added[1].middleware, 1)
+}
+
 func TestEchoReverse(t *testing.T) {
 	e := New()
 	dummyHandler := func(Context) error { return nil }

--- a/echo_test.go
+++ b/echo_test.go
@@ -531,9 +531,9 @@ func TestEchoRoutes(t *testing.T) {
 	}
 }
 
-func TestEchoRoutesHandleHostsProperly(t *testing.T) {
+func TestEchoRoutesHandleAdditionalHosts(t *testing.T) {
 	e := New()
-	h := e.Host("route.com")
+	domain2Router := e.Host("domain2.router.com")
 	routes := []*Route{
 		{http.MethodGet, "/users/:user/events", ""},
 		{http.MethodGet, "/users/:user/events/public", ""},
@@ -541,23 +541,60 @@ func TestEchoRoutesHandleHostsProperly(t *testing.T) {
 		{http.MethodPost, "/repos/:owner/:repo/git/tags", ""},
 	}
 	for _, r := range routes {
-		h.Add(r.Method, r.Path, func(c Context) error {
+		domain2Router.Add(r.Method, r.Path, func(c Context) error {
 			return c.String(http.StatusOK, "OK")
 		})
 	}
+	e.Add(http.MethodGet, "/api", func(c Context) error {
+		return c.String(http.StatusOK, "OK")
+	})
 
-	if assert.Equal(t, len(routes), len(e.Routes())) {
-		for _, r := range e.Routes() {
-			found := false
-			for _, rr := range routes {
-				if r.Method == rr.Method && r.Path == rr.Path {
-					found = true
-					break
-				}
+	domain2Routes := e.Routers()["domain2.router.com"].Routes()
+
+	assert.Len(t, domain2Routes, len(routes))
+	for _, r := range domain2Routes {
+		found := false
+		for _, rr := range routes {
+			if r.Method == rr.Method && r.Path == rr.Path {
+				found = true
+				break
 			}
-			if !found {
-				t.Errorf("Route %s %s not found", r.Method, r.Path)
+		}
+		if !found {
+			t.Errorf("Route %s %s not found", r.Method, r.Path)
+		}
+	}
+}
+
+func TestEchoRoutesHandleDefaultHost(t *testing.T) {
+	e := New()
+	routes := []*Route{
+		{http.MethodGet, "/users/:user/events", ""},
+		{http.MethodGet, "/users/:user/events/public", ""},
+		{http.MethodPost, "/repos/:owner/:repo/git/refs", ""},
+		{http.MethodPost, "/repos/:owner/:repo/git/tags", ""},
+	}
+	for _, r := range routes {
+		e.Add(r.Method, r.Path, func(c Context) error {
+			return c.String(http.StatusOK, "OK")
+		})
+	}
+	e.Host("subdomain.mysite.site").Add(http.MethodGet, "/api", func(c Context) error {
+		return c.String(http.StatusOK, "OK")
+	})
+
+	defaultRouterRoutes := e.Routes()
+	assert.Len(t, defaultRouterRoutes, len(routes))
+	for _, r := range defaultRouterRoutes {
+		found := false
+		for _, rr := range routes {
+			if r.Method == rr.Method && r.Path == rr.Path {
+				found = true
+				break
 			}
+		}
+		if !found {
+			t.Errorf("Route %s %s not found", r.Method, r.Path)
 		}
 	}
 }
@@ -1451,14 +1488,27 @@ func TestEchoReverseHandleHostProperly(t *testing.T) {
 	dummyHandler := func(Context) error { return nil }
 
 	e := New()
-	h := e.Host("the_host")
-	h.GET("/static", dummyHandler).Name = "/static"
-	h.GET("/static/*", dummyHandler).Name = "/static/*"
 
-	assert.Equal(t, "/static", e.Reverse("/static"))
-	assert.Equal(t, "/static", e.Reverse("/static", "missing param"))
-	assert.Equal(t, "/static/*", e.Reverse("/static/*"))
-	assert.Equal(t, "/static/foo.txt", e.Reverse("/static/*", "foo.txt"))
+	// routes added to the default router are different form different hosts
+	e.GET("/static", dummyHandler).Name = "default-host /static"
+	e.GET("/static/*", dummyHandler).Name = "xxx"
+
+	// different host
+	h := e.Host("the_host")
+	h.GET("/static", dummyHandler).Name = "host2 /static"
+	h.GET("/static/v2/*", dummyHandler).Name = "xxx"
+
+	assert.Equal(t, "/static", e.Reverse("default-host /static"))
+	// when actual route does not have params and we provide some to Reverse we should get that route url back
+	assert.Equal(t, "/static", e.Reverse("default-host /static", "missing param"))
+
+	host2Router := e.Routers()["the_host"]
+	assert.Equal(t, "/static", host2Router.Reverse("host2 /static"))
+	assert.Equal(t, "/static", host2Router.Reverse("host2 /static", "missing param"))
+
+	assert.Equal(t, "/static/v2/*", host2Router.Reverse("xxx"))
+	assert.Equal(t, "/static/v2/foo.txt", host2Router.Reverse("xxx", "foo.txt"))
+
 }
 
 func TestEcho_ListenerAddr(t *testing.T) {

--- a/router_test.go
+++ b/router_test.go
@@ -914,19 +914,22 @@ func TestRouterParamWithSlash(t *testing.T) {
 // Searching route for "/a/c/f" should match "/a/*/f"
 // When route `4) /a/*/f` is not added then request for "/a/c/f" should match "/:e/c/f"
 //
-//                             +----------+
-//                       +-----+ "/" root +--------------------+--------------------------+
-//                       |     +----------+                    |                          |
-//                       |                                     |                          |
-//               +-------v-------+                         +---v---------+        +-------v---+
-//               | "a/" (static) +---------------+         | ":" (param) |        | "*" (any) |
-//               +-+----------+--+               |         +-----------+-+        +-----------+
-//                 |          |                  |                     |
+//	              +----------+
+//	        +-----+ "/" root +--------------------+--------------------------+
+//	        |     +----------+                    |                          |
+//	        |                                     |                          |
+//	+-------v-------+                         +---v---------+        +-------v---+
+//	| "a/" (static) +---------------+         | ":" (param) |        | "*" (any) |
+//	+-+----------+--+               |         +-----------+-+        +-----------+
+//	  |          |                  |                     |
+//
 // +---------------v+  +-- ---v------+    +------v----+          +-----v-----------+
 // | "c/d" (static) |  | ":" (param) |    | "*" (any) |          | "/c/f" (static) |
 // +---------+------+  +--------+----+    +----------++          +-----------------+
-//           |                  |                    |
-//           |                  |                    |
+//
+//	|                  |                    |
+//	|                  |                    |
+//
 // +---------v----+      +------v--------+    +------v--------+
 // | "f" (static) |      | "/c" (static) |    | "/f" (static) |
 // +--------------+      +---------------+    +---------------+
@@ -998,22 +1001,22 @@ func TestRouteMultiLevelBacktracking(t *testing.T) {
 //
 // Request for "/a/c/f" should match "/:e/c/f"
 //
-//                            +-0,7--------+
-//                            | "/" (root) |----------------------------------+
-//                            +------------+                                  |
-//                                 |      |                                   |
-//                                 |      |                                   |
-//             +-1,6-----------+   |      |          +-8-----------+   +------v----+
-//             | "a/" (static) +<--+      +--------->+ ":" (param) |   | "*" (any) |
-//             +---------------+                     +-------------+   +-----------+
-//                |          |                             |
-//     +-2--------v-----+   +v-3,5--------+       +-9------v--------+
-//     | "c/d" (static) |   | ":" (param) |       | "/c/f" (static) |
-//     +----------------+   +-------------+       +-----------------+
-//                           |
-//                      +-4--v----------+
-//                      | "/c" (static) |
-//                      +---------------+
+//	                       +-0,7--------+
+//	                       | "/" (root) |----------------------------------+
+//	                       +------------+                                  |
+//	                            |      |                                   |
+//	                            |      |                                   |
+//	        +-1,6-----------+   |      |          +-8-----------+   +------v----+
+//	        | "a/" (static) +<--+      +--------->+ ":" (param) |   | "*" (any) |
+//	        +---------------+                     +-------------+   +-----------+
+//	           |          |                             |
+//	+-2--------v-----+   +v-3,5--------+       +-9------v--------+
+//	| "c/d" (static) |   | ":" (param) |       | "/c/f" (static) |
+//	+----------------+   +-------------+       +-----------------+
+//	                      |
+//	                 +-4--v----------+
+//	                 | "/c" (static) |
+//	                 +---------------+
 func TestRouteMultiLevelBacktracking2(t *testing.T) {
 	e := New()
 	r := e.router
@@ -2693,6 +2696,87 @@ func TestRouterHandleMethodOptions(t *testing.T) {
 			assert.Equal(t, tc.expectAllowHeader, c.Response().Header().Get(HeaderAllow))
 		})
 	}
+}
+
+func TestRouter_Routes(t *testing.T) {
+	type rr struct {
+		method string
+		path   string
+		name   string
+	}
+	var testCases = []struct {
+		name        string
+		givenRoutes []rr
+		expect      []rr
+	}{
+		{
+			name: "ok, multiple",
+			givenRoutes: []rr{
+				{method: http.MethodGet, path: "/static", name: "/static"},
+				{method: http.MethodGet, path: "/static/*", name: "/static/*"},
+			},
+			expect: []rr{
+				{method: http.MethodGet, path: "/static", name: "/static"},
+				{method: http.MethodGet, path: "/static/*", name: "/static/*"},
+			},
+		},
+		{
+			name:        "ok, no routes",
+			givenRoutes: []rr{},
+			expect:      []rr{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dummyHandler := func(Context) error { return nil }
+
+			e := New()
+			route := e.router
+
+			for _, tmp := range tc.givenRoutes {
+				route.add(tmp.method, tmp.path, tmp.name, dummyHandler)
+			}
+
+			// Add does not add route. because of backwards compatibility we can not change this method signature
+			route.Add("LOCK", "/users", handlerFunc)
+
+			result := route.Routes()
+			assert.Len(t, result, len(tc.expect))
+			for _, r := range result {
+				for _, tmp := range tc.expect {
+					if tmp.name == r.Name {
+						assert.Equal(t, tmp.method, r.Method)
+						assert.Equal(t, tmp.path, r.Path)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestRouter_Reverse(t *testing.T) {
+	e := New()
+	r := e.router
+	dummyHandler := func(Context) error { return nil }
+
+	r.add(http.MethodGet, "/static", "/static", dummyHandler)
+	r.add(http.MethodGet, "/static/*", "/static/*", dummyHandler)
+	r.add(http.MethodGet, "/params/:foo", "/params/:foo", dummyHandler)
+	r.add(http.MethodGet, "/params/:foo/bar/:qux", "/params/:foo/bar/:qux", dummyHandler)
+	r.add(http.MethodGet, "/params/:foo/bar/:qux/*", "/params/:foo/bar/:qux/*", dummyHandler)
+
+	assert.Equal(t, "/static", r.Reverse("/static"))
+	assert.Equal(t, "/static", r.Reverse("/static", "missing param"))
+	assert.Equal(t, "/static/*", r.Reverse("/static/*"))
+	assert.Equal(t, "/static/foo.txt", r.Reverse("/static/*", "foo.txt"))
+
+	assert.Equal(t, "/params/:foo", r.Reverse("/params/:foo"))
+	assert.Equal(t, "/params/one", r.Reverse("/params/:foo", "one"))
+	assert.Equal(t, "/params/:foo/bar/:qux", r.Reverse("/params/:foo/bar/:qux"))
+	assert.Equal(t, "/params/one/bar/:qux", r.Reverse("/params/:foo/bar/:qux", "one"))
+	assert.Equal(t, "/params/one/bar/two", r.Reverse("/params/:foo/bar/:qux", "one", "two"))
+	assert.Equal(t, "/params/one/bar/two/three", r.Reverse("/params/:foo/bar/:qux/*", "one", "two", "three"))
 }
 
 func TestRouterAllowHeaderForAnyOtherMethodType(t *testing.T) {


### PR DESCRIPTION
* Fix situation when Echo instance is used to serve multiple hosts. In this case all registered routes are seen from `e.Routes()` map but problem arises when multiple hosts have routes with same method+path - in this case latest added will only be in `e.Routes()` output. 

  * `e.Routes()` will only report routes added to default router (hosts = "")
  * Routes for specific hosts are accessed by `e.Routers()["domain2.router.com"].Routes()`
  * Router has now new method `Reverse(name string, params ...interface{}) string`. Echos own `Reverse()` will call default router `Reverse` now.

* Added handler to echo instance to help keeping track what routes are registered in a centralized way. There is new  handler field:
```go
e := echo.New()
e.OnAddRouteHandler = func(host string, route Route, handler HandlerFunc, middleware []MiddlewareFunc) {
  // for example: add this route info to your own registry 
}
```

