### PR TITLE
Expose middleware.CreateExtractors function so we can use it from echo-contrib repository

### DIFF
--- a/middleware/csrf.go
+++ b/middleware/csrf.go
@@ -119,7 +119,7 @@ func CSRFWithConfig(config CSRFConfig) echo.MiddlewareFunc {
 		config.CookieSecure = true
 	}
 
-	extractors, err := createExtractors(config.TokenLookup, "")
+	extractors, err := CreateExtractors(config.TokenLookup)
 	if err != nil {
 		panic(err)
 	}

--- a/middleware/extractor.go
+++ b/middleware/extractor.go
@@ -24,6 +24,26 @@ var errFormExtractorValueMissing = errors.New("missing value in the form")
 // ValuesExtractor defines a function for extracting values (keys/tokens) from the given context.
 type ValuesExtractor func(c echo.Context) ([]string, error)
 
+// CreateExtractors creates ValuesExtractors from given lookups.
+// Lookups is a string in the form of "<source>:<name>" or "<source>:<name>,<source>:<name>" that is used
+// to extract key from the request.
+// Possible values:
+//   - "header:<name>" or "header:<name>:<cut-prefix>"
+//     `<cut-prefix>` is argument value to cut/trim prefix of the extracted value. This is useful if header
+//     value has static prefix like `Authorization: <auth-scheme> <authorisation-parameters>` where part that we
+//     want to cut is `<auth-scheme> ` note the space at the end.
+//     In case of basic authentication `Authorization: Basic <credentials>` prefix we want to remove is `Basic `.
+//   - "query:<name>"
+//   - "param:<name>"
+//   - "form:<name>"
+//   - "cookie:<name>"
+//
+// Multiple sources example:
+// - "header:Authorization,header:X-Api-Key"
+func CreateExtractors(lookups string) ([]ValuesExtractor, error) {
+	return createExtractors(lookups, "")
+}
+
 func createExtractors(lookups string, authScheme string) ([]ValuesExtractor, error) {
 	if lookups == "" {
 		return nil, nil

--- a/middleware/extractor_test.go
+++ b/middleware/extractor_test.go
@@ -110,7 +110,7 @@ func TestCreateExtractors(t *testing.T) {
 				setPathParams(c, tc.givenPathParams)
 			}
 
-			extractors, err := createExtractors(tc.whenLoopups, "")
+			extractors, err := CreateExtractors(tc.whenLoopups)
 			if tc.expectCreateError != "" {
 				assert.EqualError(t, err, tc.expectCreateError)
 				return


### PR DESCRIPTION
Expose middleware.CreateExtractors function so we can use it from echo-contrib repository. JWT middleware will move there.