### PR TITLE
`defer reader.Close()` in body_limit_test

### DIFF
--- a/middleware/body_limit_test.go
+++ b/middleware/body_limit_test.go
@@ -70,6 +70,7 @@ func TestBodyLimitReader(t *testing.T) {
 		reader:          io.NopCloser(bytes.NewReader(hw)),
 		context:         e.NewContext(req, rec),
 	}
+	defer reader.Close()
 
 	// read all should return ErrStatusRequestEntityTooLarge
 	_, err := io.ReadAll(reader)

--- a/middleware/body_limit_test.go
+++ b/middleware/body_limit_test.go
@@ -70,7 +70,7 @@ func TestBodyLimitReader(t *testing.T) {
 		reader:          io.NopCloser(bytes.NewReader(hw)),
 		context:         e.NewContext(req, rec),
 	}
-	defer reader.Close()
+	defer assert.NoError(t, reader.Close())
 
 	// read all should return ErrStatusRequestEntityTooLarge
 	_, err := io.ReadAll(reader)


### PR DESCRIPTION
`limitedReader.Close` function will be tested by this change.
As a result, the code coverage of `body_limit` increases.