### PR TITLE
Compress with empty content

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -80,7 +80,7 @@ func GzipWithConfig(config GzipConfig) echo.MiddlewareFunc {
 				w.Reset(rw)
 				grw := &gzipResponseWriter{Writer: w, ResponseWriter: rw}
 				defer func() {
-					if !grw.wroteBody {
+					if !grw.wroteBody || res.Size == 0 {
 						if res.Header().Get(echo.HeaderContentEncoding) == gzipScheme {
 							res.Header().Del(echo.HeaderContentEncoding)
 						}

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -114,7 +114,7 @@ func TestGzipEmpty(t *testing.T) {
 		return c.String(http.StatusOK, "")
 	})
 	if assert.NoError(t, h(c)) {
-		assert.Equal(t, gzipScheme, rec.Header().Get(echo.HeaderContentEncoding))
+		assert.Empty(t, rec.Header().Get(echo.HeaderContentEncoding))
 		assert.Equal(t, "text/plain; charset=UTF-8", rec.Header().Get(echo.HeaderContentType))
 		r, err := gzip.NewReader(rec.Body)
 		if assert.NoError(t, err) {


### PR DESCRIPTION
This is a follow-up for PR #2044.

In [RFC9110](https://www.rfc-editor.org/rfc/rfc9110#name-content-type) is stated:
> A sender that generates a message containing content SHOULD generate a Content-Type header field in that message unless the intended media type of the enclosed representation is unknown to the sender. If a Content-Type header field is not present, the recipient MAY either assume a media type of "application/octet-stream" ([[RFC2046](https://www.rfc-editor.org/rfc/rfc9110#RFC2046)], [Section 4.5.1](https://www.rfc-editor.org/rfc/rfc2046#section-4.5.1)) or examine the data to determine its type.

So this PR adds a check for the response size to ensure no `Content-Type` header is set if no payload is set.