### PR TITLE
Fix rate limiter docs

### DIFF
--- a/middleware/rate_limiter.go
+++ b/middleware/rate_limiter.go
@@ -155,7 +155,7 @@ type (
 	RateLimiterMemoryStore struct {
 		visitors map[string]*Visitor
 		mutex    sync.Mutex
-		rate     rate.Limit //for more info check out Limiter docs - https://pkg.go.dev/golang.org/x/time/rate#Limit.
+		rate     rate.Limit // for more info check out Limiter docs - https://pkg.go.dev/golang.org/x/time/rate#Limit.
 
 		burst       int
 		expiresIn   time.Duration
@@ -178,7 +178,6 @@ Burst and ExpiresIn will be set to default values.
 Example (with 20 requests/sec):
 
 	limiterStore := middleware.NewRateLimiterMemoryStore(20)
-
 */
 func NewRateLimiterMemoryStore(rate rate.Limit) (store *RateLimiterMemoryStore) {
 	return NewRateLimiterMemoryStoreWithConfig(RateLimiterMemoryStoreConfig{
@@ -225,7 +224,7 @@ func NewRateLimiterMemoryStoreWithConfig(config RateLimiterMemoryStoreConfig) (s
 // RateLimiterMemoryStoreConfig represents configuration for RateLimiterMemoryStore
 type RateLimiterMemoryStoreConfig struct {
 	Rate      rate.Limit    // Rate of requests allowed to pass as req/s. For more info check out Limiter docs - https://pkg.go.dev/golang.org/x/time/rate#Limit.
-	Burst     int           // Burst additionally allows a number of requests to pass when rate limit is reached
+	Burst     int           // Burst is maximum number of requests to pass at the same moment. It additionally allows a number of requests to pass when rate limit is reached.
 	ExpiresIn time.Duration // ExpiresIn is the duration after that a rate limiter is cleaned up
 }
 

--- a/middleware/rate_limiter.go
+++ b/middleware/rate_limiter.go
@@ -170,10 +170,12 @@ type (
 
 /*
 NewRateLimiterMemoryStore returns an instance of RateLimiterMemoryStore with
-the provided rate (as req/s). The provided rate less than 1 will be treated as zero.
+the provided rate (as req/s).
 for more info check out Limiter docs - https://pkg.go.dev/golang.org/x/time/rate#Limit.
 
 Burst and ExpiresIn will be set to default values.
+
+Note that if the provided rate is a float number and Burst is zero, Burst will be treated as the rounded down value of the rate.
 
 Example (with 20 requests/sec):
 
@@ -187,7 +189,7 @@ func NewRateLimiterMemoryStore(rate rate.Limit) (store *RateLimiterMemoryStore) 
 
 /*
 NewRateLimiterMemoryStoreWithConfig returns an instance of RateLimiterMemoryStore
-with the provided configuration. Rate must be provided. Burst will be set to the value of
+with the provided configuration. Rate must be provided. Burst will be set to the rounded down value of
 the configured rate if not provided or set to 0.
 
 The build-in memory store is usually capable for modest loads. For higher loads other


### PR DESCRIPTION
Closes #1853 

## What I did
* fix docs and comment in `rate_limiter.go`
## Why
* It is difficult to understand the behavior of `middleware.NewRateLimiterMemoryStore` when the argument is  a float number.

## Need to do
* also Improve [this doc](https://github.com/labstack/echox/blob/master/website/content/middleware/rate-limiter.md)
