### PR TITLE
context.Render doesn't return an error

### DIFF
--- a/context.go
+++ b/context.go
@@ -452,7 +452,7 @@ func (c *context) Render(code int, name string, data interface{}) (err error) {
 	}
 	buf := new(bytes.Buffer)
 	if err = c.echo.Renderer.Render(buf, name, data, c); err != nil {
-		return
+		return err
 	}
 	return c.HTMLBlob(code, buf.Bytes())
 }


### PR DESCRIPTION
context.Render doesn't return an error if there's an issue calling the c.echo.RendererRender; added the error to the `return` statement.