### PR TITLE
fix: setCookie avoid security breach

### DIFF
--- a/context.go
+++ b/context.go
@@ -412,6 +412,8 @@ func (c *context) Cookie(name string) (*http.Cookie, error) {
 }
 
 func (c *context) SetCookie(cookie *http.Cookie) {
+	cookie.HttpOnly = true
+	cookie.Secure = true
 	http.SetCookie(c.Response(), cookie)
 }
 


### PR DESCRIPTION
Threat SetCookie method to always use security cookies.

Similar to https://security.snyk.io/vuln/SNYK-GOLANG-GITHUBCOMOPENSHIFTORIGINPKGCMDSERVERORIGINAUTHGO-2944969

[A cookie with the Secure attribute is only sent to the server with an encrypted request over the HTTPS protocol](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#restrict_access_to_cookies).
[A cookie with the HttpOnly attribute is inaccessible to the JavaScript Document.cookie API](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#restrict_access_to_cookies).