### PR TITLE
Warn users with debug enabled that middleware errors are not handled

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -379,6 +379,9 @@ func (e *Echo) Routers() map[string]*Router {
 func (e *Echo) DefaultHTTPErrorHandler(err error, c Context) {
 
 	if c.Response().Committed {
+		if e.Debug {
+			e.Logger.Debug("Response is already committed, returning immediately")
+		}
 		return
 	}
 


### PR DESCRIPTION
Warn users with debug enabled that middleware errors are not handled

Users may not expect errors thrown in the middleware on the response path flow to be ignored if the response has been committed by a handler