### PR TITLE
Added a optional config variable to disable centralized error handler in recovery

### DIFF
--- a/middleware/recover.go
+++ b/middleware/recover.go
@@ -38,6 +38,10 @@ type (
 		// LogErrorFunc defines a function for custom logging in the middleware.
 		// If it's set you don't need to provide LogLevel for config.
 		LogErrorFunc LogErrorFunc
+
+		// DisableErrorHandler disables the centralized HTTPErrorHandler.
+		// Optional. Default value false.
+		DisableErrorHandler bool `yaml:"disable_error_handler"`
 	}
 )
 
@@ -50,6 +54,7 @@ var (
 		DisablePrintStack: false,
 		LogLevel:          0,
 		LogErrorFunc:      nil,
+		DisableErrorHandler: false,
 	}
 )
 
@@ -113,7 +118,10 @@ func RecoverWithConfig(config RecoverConfig) echo.MiddlewareFunc {
 							c.Logger().Print(msg)
 						}
 					}
-					c.Error(err)
+
+					if(!config.DisableErrorHandler) {
+						c.Error(err)
+					}
 				}
 			}()
 			return next(c)

--- a/middleware/recover_test.go
+++ b/middleware/recover_test.go
@@ -163,3 +163,32 @@ func TestRecoverWithConfig_LogErrorFunc(t *testing.T) {
 		assert.Contains(t, output, `"level":"ERROR"`)
 	})
 }
+
+func TestRecoverWithDisabled_ErrorHandler(t *testing.T) {
+	e := echo.New()
+	buf := new(bytes.Buffer)
+	e.Logger.SetOutput(buf)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	config := DefaultRecoverConfig
+	config.DisableErrorHandler = false
+	h := RecoverWithConfig(config)(echo.HandlerFunc(func(c echo.Context) error {
+		panic(http.ErrAbortHandler)
+	}))
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expecting nil, got `%v`", r)
+		}
+	}()
+	h(c)
+
+	h = Recover()(echo.HandlerFunc(func(c echo.Context) error {
+		panic(http.ErrAbortHandler)
+	}))
+	h(c)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Contains(t, buf.String(), "PANIC RECOVER")
+}


### PR DESCRIPTION
Added a optional config variable to disable centralized error handler in recovery. 
The default value is false.