### PR TITLE
Fix group.RouteNotFound not working when group has attached middlewares

### DIFF
--- a/group.go
+++ b/group.go
@@ -23,10 +23,12 @@ func (g *Group) Use(middleware ...MiddlewareFunc) {
 	if len(g.middleware) == 0 {
 		return
 	}
-	// Allow all requests to reach the group as they might get dropped if router
-	// doesn't find a match, making none of the group middleware process.
-	g.Any("", NotFoundHandler)
-	g.Any("/*", NotFoundHandler)
+	// group level middlewares are different from Echo `Pre` and `Use` middlewares (those are global). Group level middlewares
+	// are only executed if they are added to the Router with route.
+	// So we register catch all route (404 is a safe way to emulate route match) for this group and now during routing the
+	// Router would find route to match our request path and therefore guarantee the middleware(s) will get executed.
+	g.RouteNotFound("", NotFoundHandler)
+	g.RouteNotFound("/*", NotFoundHandler)
 }
 
 // CONNECT implements `Echo#CONNECT()` for sub-routes within the Group.


### PR DESCRIPTION
Fix group.RouteNotFound not working when group has attached middlewares.

Problems is/was that `g.Use` registers special catch all routes with `g.Any` and those routes have priority over route registered by `g.NotFoundHandler`. 
Solution is to register these special routes also with `NotFoundHandler` so if you register custom one - it will override special catch all.

Fixes #2401
For history sake: somewhat relates to #1981 , #2256 , #1728