### PR TITLE
Support retries of failed proxy requests

### DIFF
--- a/middleware/proxy.go
+++ b/middleware/proxy.go
@@ -228,7 +228,12 @@ func (b *randomBalancer) Next(c echo.Context) *ProxyTarget {
 	return b.targets[b.random.Intn(len(b.targets))]
 }
 
-// Next returns an upstream target using round-robin technique.
+// Next returns an upstream target using round-robin technique. In the case
+// where a previously failed request is being retried, the round-robin
+// balancer will attempt to use the next target relative to the original
+// request. If the list of targets held by the balancer is modified while a
+// failed request is being retried, it is possible that the balancer will
+// return the original failed target.
 //
 // Note: `nil` is returned in case upstream target list is empty.
 func (b *roundRobinBalancer) Next(c echo.Context) *ProxyTarget {

--- a/middleware/proxy.go
+++ b/middleware/proxy.go
@@ -29,27 +29,29 @@ type (
 		// Required.
 		Balancer ProxyBalancer
 
-		// RetryCount defines the number of times a proxied request to an unavailable
-		// ProxyTarget should be retried using the next available ProxyTarget. Defaults
-		// to 0, meaning requests are never retried.
+		// RetryCount defines the number of times a failed proxied request should be retried
+		// using the next available ProxyTarget. Defaults to 0, meaning requests are never retried.
 		RetryCount int
 
-		// RetryFilter defines a function used to determine if a failed request to an
-		// unavailable ProxyTarget should be retried. The RetryFilter will only be called
-		// when the number of previous retries is less than RetryCount. If the function
-		// returns true, the request will be retried. When not specified, all requests that
-		// fail with http.StatusBadGateway error will be retried. A custom RetryFilter can
-		// be provided to only retry specific requests. Note that RetryFilter is only
-		// called when the request to the target fails, or an internal error in the Proxy
-		// middleware has occurred. Successful requests that return a non-200 response code
-		// cannot be retried.
+		// RetryFilter defines a function used to determine if a failed request to a
+		// ProxyTarget should be retried. The RetryFilter will only be called when the number
+		// of previous retries is less than RetryCount. If the function returns true, the
+		// request will be retried. The provided error indicates the reason for the request
+		// failure. When the ProxyTarget is unavailable, the error will be an instance of
+		// echo.HTTPError with a Code of http.StatusBadGateway. In all other cases, the error
+		// will indicate an internal error in the Proxy middleware. When a RetryFilter is not
+		// specified, all requests that fail with http.StatusBadGateway will be retried. A custom
+		// RetryFilter can be provided to only retry specific requests. Note that RetryFilter is
+		// only called when the request to the target fails, or an internal error in the Proxy
+		// middleware has occurred. Successful requests that return a non-200 response code cannot
+		// be retried.
 		RetryFilter func(c echo.Context, e error) bool
 
 		// ErrorHandler defines a function which can be used to return custom errors from
 		// the Proxy middleware. ErrorHandler is only invoked when there has been
 		// either an internal error in the Proxy middleware or the ProxyTarget is
 		// unavailable. Due to the way requests are proxied, ErrorHandler is not invoked
-		// when a Proxy target returns a non-200 response. In these cases, the response
+		// when a ProxyTarget returns a non-200 response. In these cases, the response
 		// is already written so errors cannot be modified. ErrorHandler is only
 		// invoked after all retry attempts have been exhausted.
 		ErrorHandler func(c echo.Context, err error) error

--- a/middleware/proxy.go
+++ b/middleware/proxy.go
@@ -326,7 +326,12 @@ func ProxyWithConfig(config ProxyConfig) echo.MiddlewareFunc {
 				} else {
 					tgt = config.Balancer.Next(c)
 				}
+
+				//Clear any previous errors from context here so
+				//that balancers have the option to check for errors
+				//using previous target
 				c.Set(config.ContextKey, tgt)
+				c.Set("_error", nil)
 
 				// Proxy
 				switch {
@@ -348,11 +353,6 @@ func ProxyWithConfig(config ProxyConfig) echo.MiddlewareFunc {
 				}
 
 				retries--
-
-				//Try request again. Clear the previous error and target
-				//server from context.
-				c.Set("_error", nil)
-				c.Set(config.ContextKey, nil)
 			}
 		}
 	}

--- a/middleware/proxy.go
+++ b/middleware/proxy.go
@@ -239,6 +239,7 @@ func (b *roundRobinBalancer) Next(c echo.Context) *ProxyTarget {
 	} else if len(b.targets) == 1 {
 		return b.targets[0]
 	}
+
 	// reset the index if out of bounds
 	if b.i >= len(b.targets) {
 		b.i = 0

--- a/middleware/proxy.go
+++ b/middleware/proxy.go
@@ -251,13 +251,13 @@ func (b *roundRobinBalancer) Next(c echo.Context) *ProxyTarget {
 		if i >= len(b.targets) {
 			i = 0
 		}
-		// This is a first time request, use the global index
 	} else {
-		i = b.i
-		b.i++
+		// This is a first time request, use the global index
 		if b.i >= len(b.targets) {
 			b.i = 0
 		}
+		i = b.i
+		b.i++
 	}
 
 	c.Set(lastIdxKey, i)

--- a/middleware/proxy.go
+++ b/middleware/proxy.go
@@ -29,15 +29,16 @@ type (
 		// Required.
 		Balancer ProxyBalancer
 
-		// RetryCount defines the number of times a proxied request to an unavailable ProxyTarget
-		// should be retried using the next available ProxyTarget. Defaults to 0, meaning requests
-		// are never retried.
+		// RetryCount defines the number of times a proxied request to an unavailable
+		// ProxyTarget should be retried using the next available ProxyTarget. Defaults
+		// to 0, meaning requests are never retried.
 		RetryCount int
 
-		// RetryHandler defines a function used to determine if a failed request to an unavailable ProxyTarget
-		// should be retried. The RetryHandler will only be called when the number of previous retries is less
-		// than RetryCount. If the function returns true, the request will be retried. When not specified,
-		// DefaultProxyRetryHandler will be used, which will always retry requests. A user defined ProxyRetryHandler
+		// RetryHandler defines a function used to determine if a failed request to an
+		// unavailable ProxyTarget should be retried. The RetryHandler will only be called
+		// when the number of previous retries is less than RetryCount. If the function returns
+		// true, the request will be retried. When not specified, DefaultProxyRetryHandler
+		// will be used, which will always retry requests. A user defined ProxyRetryHandler
 		// can be provided to only retry specific requests, for example only retry GET requests.
 		RetryHandler ProxyRetryHandler
 
@@ -83,13 +84,15 @@ type (
 		Next(echo.Context) *ProxyTarget
 	}
 
-	// TargetProvider defines an interface that gives the opportunity for balancer to return custom errors when selecting target.
+	// TargetProvider defines an interface that gives the opportunity for balancer
+	// to return custom errors when selecting target.
 	TargetProvider interface {
 		NextTarget(echo.Context) (*ProxyTarget, error)
 	}
 
-	// ProxyRetryHandler defines a function that determines if a failed request to an unavailable ProxyTarget should
-	// be retried using the next available ProxyTarget. When the function returns true, the request will be retried.
+	// ProxyRetryHandler defines a function that determines if a failed request to
+	// an unavailable ProxyTarget should be retried using the next available ProxyTarget.
+	// When the function returns true, the request will be retried.
 	ProxyRetryHandler func(c echo.Context) bool
 
 	commonBalancer struct {
@@ -159,7 +162,7 @@ func proxyRaw(t *ProxyTarget, c echo.Context) http.Handler {
 }
 
 // DefaultProxyRetryHandler is a ProxyRetryHandler that always retries requests
-func DefaultProxyRetryHandler(_ echo.Context) bool {
+func DefaultProxyRetryHandler(c echo.Context) bool {
 	return true
 }
 
@@ -322,7 +325,6 @@ func ProxyWithConfig(config ProxyConfig) echo.MiddlewareFunc {
 					proxyHTTP(tgt, c, config).ServeHTTP(res, req)
 				}
 
-				//If there was no error, return
 				e, hasError := c.Get("_error").(error)
 				if !hasError {
 					return nil
@@ -335,14 +337,13 @@ func ProxyWithConfig(config ProxyConfig) echo.MiddlewareFunc {
 					}
 				}
 
-				//If we are not retrying this request, return the error
 				if !retry {
 					return e
 				}
 
 				retries--
 
-				//Otherwise, try again. Clear the previous error and target
+				//Try request again. Clear the previous error and target
 				//server from context.
 				c.Set("_error", nil)
 				c.Set(config.ContextKey, nil)

--- a/middleware/proxy.go
+++ b/middleware/proxy.go
@@ -329,11 +329,14 @@ func ProxyWithConfig(config ProxyConfig) echo.MiddlewareFunc {
 					tgt = config.Balancer.Next(c)
 				}
 
-				//Clear any previous errors from context here so
-				//that balancers have the option to check for errors
-				//using previous target
 				c.Set(config.ContextKey, tgt)
-				c.Set("_error", nil)
+
+				//If retrying a failed request, clear any previous errors from
+				//context here so that balancers have the option to check for
+				//errors that occurred using previous target
+				if retries < config.RetryCount {
+					c.Set("_error", nil)
+				}
 
 				// Proxy
 				switch {

--- a/middleware/proxy_test.go
+++ b/middleware/proxy_test.go
@@ -593,9 +593,7 @@ func TestProxyErrorHandler(t *testing.T) {
 	}
 
 	transformedError := errors.New("a new error")
-	//Not called when no error
-	//Called when error and returned error passed to central
-	//
+
 	testCases := []struct {
 		name             string
 		target           *ProxyTarget

--- a/middleware/proxy_test.go
+++ b/middleware/proxy_test.go
@@ -494,7 +494,7 @@ func TestProxyRetries(t *testing.T) {
 			http.StatusBadGateway,
 		},
 		{
-			"retry count 2 returns error when retries left by handler returns false",
+			"retry count 2 returns error when retries left but handler returns false",
 			3,
 			[]ProxyRetryHandler{
 				doRetryHandler,

--- a/middleware/proxy_test.go
+++ b/middleware/proxy_test.go
@@ -436,104 +436,100 @@ func TestProxyRetries(t *testing.T) {
 		expectedResponse int
 	}{
 		{
-			"retry count 0 does not attempt retry on fail",
-			0,
-			nil,
-			[]*ProxyTarget{
+			name: "retry count 0 does not attempt retry on fail",
+			targets: []*ProxyTarget{
 				badTarget,
 				goodTarget,
 			},
-			http.StatusBadGateway,
+			expectedResponse: http.StatusBadGateway,
 		},
 		{
-			"retry count 1 does not attempt retry on success",
-			1,
-			nil,
-			[]*ProxyTarget{
+			name:       "retry count 1 does not attempt retry on success",
+			retryCount: 1,
+			targets: []*ProxyTarget{
 				goodTarget,
 			},
-			http.StatusOK,
+			expectedResponse: http.StatusOK,
 		},
 		{
-			"retry count 1 does retry on handler return true",
-			1,
-			[]ProxyRetryFilter{
+			name:       "retry count 1 does retry on handler return true",
+			retryCount: 1,
+			retryFilters: []ProxyRetryFilter{
 				alwaysRetryFilter,
 			},
-			[]*ProxyTarget{
+			targets: []*ProxyTarget{
 				badTarget,
 				goodTarget,
 			},
-			http.StatusOK,
+			expectedResponse: http.StatusOK,
 		},
 		{
-			"retry count 1 does not retry on handler return false",
-			1,
-			[]ProxyRetryFilter{
+			name:       "retry count 1 does not retry on handler return false",
+			retryCount: 1,
+			retryFilters: []ProxyRetryFilter{
 				neverRetryFilter,
 			},
-			[]*ProxyTarget{
+			targets: []*ProxyTarget{
 				badTarget,
 				goodTarget,
 			},
-			http.StatusBadGateway,
+			expectedResponse: http.StatusBadGateway,
 		},
 		{
-			"retry count 2 returns error when no more retries left",
-			2,
-			[]ProxyRetryFilter{
+			name:       "retry count 2 returns error when no more retries left",
+			retryCount: 2,
+			retryFilters: []ProxyRetryFilter{
 				alwaysRetryFilter,
 				alwaysRetryFilter,
 			},
-			[]*ProxyTarget{
+			targets: []*ProxyTarget{
 				badTarget,
 				badTarget,
 				badTarget,
 				goodTarget, //Should never be reached as only 2 retries
 			},
-			http.StatusBadGateway,
+			expectedResponse: http.StatusBadGateway,
 		},
 		{
-			"retry count 2 returns error when retries left but handler returns false",
-			3,
-			[]ProxyRetryFilter{
+			name:       "retry count 2 returns error when retries left but handler returns false",
+			retryCount: 3,
+			retryFilters: []ProxyRetryFilter{
 				alwaysRetryFilter,
 				alwaysRetryFilter,
 				neverRetryFilter,
 			},
-			[]*ProxyTarget{
+			targets: []*ProxyTarget{
 				badTarget,
 				badTarget,
 				badTarget,
 				goodTarget, //Should never be reached as retry handler returns false on 2nd check
 			},
-			http.StatusBadGateway,
+			expectedResponse: http.StatusBadGateway,
 		},
 		{
-			"retry count 3 succeeds",
-			3,
-			[]ProxyRetryFilter{
+			name:       "retry count 3 succeeds",
+			retryCount: 3,
+			retryFilters: []ProxyRetryFilter{
 				alwaysRetryFilter,
 				alwaysRetryFilter,
 				alwaysRetryFilter,
 			},
-			[]*ProxyTarget{
+			targets: []*ProxyTarget{
 				badTarget,
 				badTarget,
 				badTarget,
 				goodTarget,
 			},
-			http.StatusOK,
+			expectedResponse: http.StatusOK,
 		},
 		{
-			"40x responses are not retried",
-			1,
-			nil,
-			[]*ProxyTarget{
+			name:       "40x responses are not retried",
+			retryCount: 1,
+			targets: []*ProxyTarget{
 				goodTargetWith40X,
 				goodTarget,
 			},
-			http.StatusBadRequest,
+			expectedResponse: http.StatusBadRequest,
 		},
 	}
 

--- a/middleware/proxy_test.go
+++ b/middleware/proxy_test.go
@@ -402,8 +402,8 @@ func TestProxyRetries(t *testing.T) {
 				w.WriteHeader(res)
 			}),
 		)
-		targetUrl, _ := url.Parse(server.URL)
-		return targetUrl, server
+		targetURL, _ := url.Parse(server.URL)
+		return targetURL, server
 	}
 
 	targetURL, server := newServer(http.StatusOK)
@@ -579,17 +579,17 @@ func TestProxyErrorHandler(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	goodUrl, _ := url.Parse(server.URL)
+	goodURL, _ := url.Parse(server.URL)
 	defer server.Close()
 	goodTarget := &ProxyTarget{
 		Name: "Good",
-		URL:  goodUrl,
+		URL:  goodURL,
 	}
 
-	badUrl, _ := url.Parse("http://127.0.0.1:27121")
+	badURL, _ := url.Parse("http://127.0.0.1:27121")
 	badTarget := &ProxyTarget{
 		Name: "Bad",
-		URL:  badUrl,
+		URL:  badURL,
 	}
 
 	transformedError := errors.New("a new error")

--- a/middleware/proxy_test.go
+++ b/middleware/proxy_test.go
@@ -425,13 +425,13 @@ func TestProxyRetries(t *testing.T) {
 		URL:  targetUrl,
 	}
 
-	var alwaysRetryFilter ProxyRetryFilter = func(c echo.Context) bool { return true }
-	var neverRetryFilter ProxyRetryFilter = func(c echo.Context) bool { return false }
+	alwaysRetryFilter := func(c echo.Context) bool { return true }
+	neverRetryFilter := func(c echo.Context) bool { return false }
 
 	testCases := []struct {
 		name             string
 		retryCount       int
-		retryFilters     []ProxyRetryFilter
+		retryFilters     []func(c echo.Context) bool
 		targets          []*ProxyTarget
 		expectedResponse int
 	}{
@@ -454,7 +454,7 @@ func TestProxyRetries(t *testing.T) {
 		{
 			name:       "retry count 1 does retry on handler return true",
 			retryCount: 1,
-			retryFilters: []ProxyRetryFilter{
+			retryFilters: []func(c echo.Context) bool{
 				alwaysRetryFilter,
 			},
 			targets: []*ProxyTarget{
@@ -466,7 +466,7 @@ func TestProxyRetries(t *testing.T) {
 		{
 			name:       "retry count 1 does not retry on handler return false",
 			retryCount: 1,
-			retryFilters: []ProxyRetryFilter{
+			retryFilters: []func(c echo.Context) bool{
 				neverRetryFilter,
 			},
 			targets: []*ProxyTarget{
@@ -478,7 +478,7 @@ func TestProxyRetries(t *testing.T) {
 		{
 			name:       "retry count 2 returns error when no more retries left",
 			retryCount: 2,
-			retryFilters: []ProxyRetryFilter{
+			retryFilters: []func(c echo.Context) bool{
 				alwaysRetryFilter,
 				alwaysRetryFilter,
 			},
@@ -493,7 +493,7 @@ func TestProxyRetries(t *testing.T) {
 		{
 			name:       "retry count 2 returns error when retries left but handler returns false",
 			retryCount: 3,
-			retryFilters: []ProxyRetryFilter{
+			retryFilters: []func(c echo.Context) bool{
 				alwaysRetryFilter,
 				alwaysRetryFilter,
 				neverRetryFilter,
@@ -509,7 +509,7 @@ func TestProxyRetries(t *testing.T) {
 		{
 			name:       "retry count 3 succeeds",
 			retryCount: 3,
-			retryFilters: []ProxyRetryFilter{
+			retryFilters: []func(c echo.Context) bool{
 				alwaysRetryFilter,
 				alwaysRetryFilter,
 				alwaysRetryFilter,

--- a/middleware/proxy_test.go
+++ b/middleware/proxy_test.go
@@ -621,7 +621,7 @@ func TestProxyRetryWithBackendTimeout(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/", nil)
 			rec := httptest.NewRecorder()
 			e.ServeHTTP(rec, req)
-			assert.Contains(t, []int{200, 502}, rec.Code)
+			assert.Equal(t, 200, rec.Code)
 		}()
 	}
 

--- a/middleware/proxy_test.go
+++ b/middleware/proxy_test.go
@@ -406,24 +406,24 @@ func TestProxyRetries(t *testing.T) {
 		return targetUrl, server
 	}
 
-	targetUrl, server := newServer(http.StatusOK)
+	targetURL, server := newServer(http.StatusOK)
 	defer server.Close()
 	goodTarget := &ProxyTarget{
 		Name: "Good",
-		URL:  targetUrl,
+		URL:  targetURL,
 	}
 
-	targetUrl, server = newServer(http.StatusBadRequest)
+	targetURL, server = newServer(http.StatusBadRequest)
 	defer server.Close()
 	goodTargetWith40X := &ProxyTarget{
 		Name: "Good with 40X",
-		URL:  targetUrl,
+		URL:  targetURL,
 	}
 
-	targetUrl, _ = url.Parse("http://127.0.0.1:27121")
+	targetURL, _ = url.Parse("http://127.0.0.1:27121")
 	badTarget := &ProxyTarget{
 		Name: "Bad",
-		URL:  targetUrl,
+		URL:  targetURL,
 	}
 
 	alwaysRetryFilter := func(c echo.Context, e error) bool { return true }


### PR DESCRIPTION
Implements #2372 

Support for retrying proxy requests that fail due to an unavailable backend instance. 