### PR TITLE
Proper colon support in reverse

### DIFF
--- a/echo_test.go
+++ b/echo_test.go
@@ -1525,6 +1525,7 @@ func TestEchoReverse(t *testing.T) {
 	e.GET("/params/:foo", dummyHandler).Name = "/params/:foo"
 	e.GET("/params/:foo/bar/:qux", dummyHandler).Name = "/params/:foo/bar/:qux"
 	e.GET("/params/:foo/bar/:qux/*", dummyHandler).Name = "/params/:foo/bar/:qux/*"
+	e.GET("/params\\::customVerb", dummyHandler).Name = "/params:customVerb"
 
 	assert.Equal(t, "/static", e.Reverse("/static"))
 	assert.Equal(t, "/static", e.Reverse("/static", "missing param"))
@@ -1537,6 +1538,8 @@ func TestEchoReverse(t *testing.T) {
 	assert.Equal(t, "/params/one/bar/:qux", e.Reverse("/params/:foo/bar/:qux", "one"))
 	assert.Equal(t, "/params/one/bar/two", e.Reverse("/params/:foo/bar/:qux", "one", "two"))
 	assert.Equal(t, "/params/one/bar/two/three", e.Reverse("/params/:foo/bar/:qux/*", "one", "two", "three"))
+
+	assert.Equal(t, "/params:PATCH", e.Reverse("/params:customVerb", "PATCH"))
 }
 
 func TestEchoReverseHandleHostProperly(t *testing.T) {

--- a/router.go
+++ b/router.go
@@ -162,7 +162,7 @@ func (r *Router) Reverse(name string, params ...interface{}) string {
 				if route.Path[i] == '\\' {
 					continue
 				}
-				if ((route.Path[i] == ':' && route.Path[i-1] != '\\') || route.Path[i] == '*') && n < ln {
+				if ((route.Path[i] == ':' && (i == 0 || route.Path[i-1] != '\\')) || route.Path[i] == '*') && n < ln {
 					for ; i < l && route.Path[i] != '/'; i++ {
 					}
 					uri.WriteString(fmt.Sprintf("%v", params[n]))

--- a/router.go
+++ b/router.go
@@ -159,7 +159,10 @@ func (r *Router) Reverse(name string, params ...interface{}) string {
 	for _, route := range r.routes {
 		if route.Name == name {
 			for i, l := 0, len(route.Path); i < l; i++ {
-				if (route.Path[i] == ':' || route.Path[i] == '*') && n < ln {
+				if route.Path[i] == '\\' {
+					continue
+				}
+				if ((route.Path[i] == ':' && route.Path[i-1] != '\\') || route.Path[i] == '*') && n < ln {
 					for ; i < l && route.Path[i] != '/'; i++ {
 					}
 					uri.WriteString(fmt.Sprintf("%v", params[n]))

--- a/router.go
+++ b/router.go
@@ -159,10 +159,12 @@ func (r *Router) Reverse(name string, params ...interface{}) string {
 	for _, route := range r.routes {
 		if route.Name == name {
 			for i, l := 0, len(route.Path); i < l; i++ {
-				if route.Path[i] == '\\' {
-					continue
+				hasBackslash := route.Path[i] == '\\'
+				if hasBackslash && i+1 < l && route.Path[i+1] == ':' {
+					i++ // backslash before colon escapes that colon. in that case skip backslash
 				}
-				if ((route.Path[i] == ':' && (i == 0 || route.Path[i-1] != '\\')) || route.Path[i] == '*') && n < ln {
+				if n < ln && (route.Path[i] == '*' || (!hasBackslash && route.Path[i] == ':')) {
+					// in case of `*` wildcard or `:` (unescaped colon) param we replace everything till next slash or end of path
 					for ; i < l && route.Path[i] != '/'; i++ {
 					}
 					uri.WriteString(fmt.Sprintf("%v", params[n]))


### PR DESCRIPTION
A small follow-up for https://github.com/labstack/echo/pull/1988 - add support of `\\:` into Reverse method of the router