### PR TITLE
documentation: changed description for `Bind()` method

### DIFF
--- a/context.go
+++ b/context.go
@@ -100,8 +100,8 @@ type (
 		// Set saves data in the context.
 		Set(key string, val interface{})
 
-		// Bind binds the request body into provided type `i`. The default binder
-		// does it based on Content-Type header.
+		// Bind binds path params, query params and the request body into provided type `i`. The default binder
+		// binds body based on Content-Type header.
 		Bind(i interface{}) error
 
 		// Validate validates provided `i`. It is usually called after `Context#Bind()`.


### PR DESCRIPTION
changed description for the `Bind()` method of `Context interface`. Because `Bind()` binds not only the request body but also the path and query params