### PR TITLE
Deprecated ErrStatusRequestEntityTooLarge

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -304,7 +304,8 @@ var (
 	ErrGone                          = NewHTTPError(http.StatusGone)                          // HTTP 410 Gone
 	ErrLengthRequired                = NewHTTPError(http.StatusLengthRequired)                // HTTP 411 Length Required
 	ErrPreconditionFailed            = NewHTTPError(http.StatusPreconditionFailed)            // HTTP 412 Precondition Failed
-	ErrStatusRequestEntityTooLarge   = NewHTTPError(http.StatusRequestEntityTooLarge)         // HTTP 413 Payload Too Large
+	ErrStatusRequestEntityTooLarge   = NewHTTPError(http.StatusRequestEntityTooLarge)         // Deprecated: Use ErrRequestEntityTooLarge instead
+	ErrRequestEntityTooLarge         = NewHTTPError(http.StatusRequestEntityTooLarge)         // HTTP 413 Payload Too Large
 	ErrRequestURITooLong             = NewHTTPError(http.StatusRequestURITooLong)             // HTTP 414 URI Too Long
 	ErrUnsupportedMediaType          = NewHTTPError(http.StatusUnsupportedMediaType)          // HTTP 415 Unsupported Media Type
 	ErrRequestedRangeNotSatisfiable  = NewHTTPError(http.StatusRequestedRangeNotSatisfiable)  // HTTP 416 Range Not Satisfiable

--- a/middleware/body_limit.go
+++ b/middleware/body_limit.go
@@ -75,7 +75,7 @@ func BodyLimitWithConfig(config BodyLimitConfig) echo.MiddlewareFunc {
 
 			// Based on content length
 			if req.ContentLength > config.limit {
-				return echo.ErrStatusRequestEntityTooLarge
+				return echo.ErrRequestEntityTooLarge
 			}
 
 			// Based on content read
@@ -93,7 +93,7 @@ func (r *limitedReader) Read(b []byte) (n int, err error) {
 	n, err = r.reader.Read(b)
 	r.read += int64(n)
 	if r.read > r.limit {
-		return n, echo.ErrStatusRequestEntityTooLarge
+		return n, echo.ErrRequestEntityTooLarge
 	}
 	return
 }

--- a/middleware/body_limit_test.go
+++ b/middleware/body_limit_test.go
@@ -71,7 +71,7 @@ func TestBodyLimitReader(t *testing.T) {
 		context:         e.NewContext(req, rec),
 	}
 
-	// read all should return ErrStatusRequestEntityTooLarge
+	// read all should return ErrRequestEntityTooLarge
 	_, err := io.ReadAll(reader)
 	he := err.(*echo.HTTPError)
 	assert.Equal(t, http.StatusRequestEntityTooLarge, he.Code)


### PR DESCRIPTION
- Deprecated ErrStatusRequestEntityTooLarge and Add ErrStatusRequestEntityTooLarge