### PR TITLE
Add handling for empty content type in request header

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -90,6 +90,8 @@ func (b *DefaultBinder) BindBody(c Context, i interface{}) (err error) {
 		if err = b.bindData(i, params, "form"); err != nil {
 			return NewHTTPError(http.StatusBadRequest, err.Error()).SetInternal(err)
 		}
+	case ctype == "":
+		return ErrEmptyContentType
 	default:
 		return ErrUnsupportedMediaType
 	}
@@ -114,7 +116,7 @@ func (b *DefaultBinder) Bind(i interface{}, c Context) (err error) {
 	// Only bind query parameters for GET/DELETE/HEAD to avoid unexpected behavior with destination struct binding from body.
 	// For example a request URL `&id=1&lang=en` with body `{"id":100,"lang":"de"}` would lead to precedence issues.
 	// The HTTP method check restores pre-v4.1.11 behavior to avoid these problems (see issue #1670)
-  method := c.Request().Method
+	method := c.Request().Method
 	if method == http.MethodGet || method == http.MethodDelete || method == http.MethodHead {
 		if err = b.BindQueryParams(c, i); err != nil {
 			return err

--- a/echo.go
+++ b/echo.go
@@ -338,6 +338,7 @@ var (
 	ErrCookieNotFound         = errors.New("cookie not found")
 	ErrInvalidCertOrKeyType   = errors.New("invalid cert or key type, must be string or []byte")
 	ErrInvalidListenerNetwork = errors.New("invalid listener network")
+	ErrEmptyContentType       = errors.New("empty content type")
 )
 
 // Error handlers


### PR DESCRIPTION
Updated the code to handle the scenario when the content type in the request header is an empty string. Added a custom error to handle this scenario. No changes were made to other parts of the code.
