### PR TITLE
Fix UnescapePathParamValues not applying when route ends with static node

### DIFF
--- a/router.go
+++ b/router.go
@@ -1064,7 +1064,7 @@ func (r *DefaultRouter) Route(c RoutableContext) HandlerFunc {
 		}
 	}
 
-	if r.unescapePathParamValues && currentNode.kind != staticKind {
+	if r.unescapePathParamValues {
 		// See issue #1531, #1258 - there are cases when path parameter need to be unescaped
 		for i, p := range *pathParams {
 			tmpVal, err := url.PathUnescape(p.Value)

--- a/router_test.go
+++ b/router_test.go
@@ -2993,6 +2993,15 @@ func TestDefaultRouter_UnescapePathParamValues(t *testing.T) {
 			},
 		},
 		{
+			name:                         "ok, ending with static node, unescape = true",
+			givenUnescapePathParamValues: true,
+			whenURL:                      "/fourth/%20%2Fwith%20space/static",
+			expectPath:                   "/fourth/:id/static",
+			expectPathParams: PathParams{
+				{Name: "id", Value: " /with space"},
+			},
+		},
+		{
 			name:                         "ok, unescape = false",
 			givenUnescapePathParamValues: false,
 			whenURL:                      "/first/value%20with%20space",
@@ -3018,6 +3027,8 @@ func TestDefaultRouter_UnescapePathParamValues(t *testing.T) {
 			_, err = router.Add(Route{Method: http.MethodGet, Path: "/second/:id/:fileName", Handler: handlerFunc})
 			assert.NoError(t, err)
 			_, err = router.Add(Route{Method: http.MethodGet, Path: "/third/*", Handler: handlerFunc})
+			assert.NoError(t, err)
+			_, err = router.Add(Route{Method: http.MethodGet, Path: "/fourth/:id/static", Handler: handlerFunc})
 			assert.NoError(t, err)
 
 			target, _ := url.Parse(tc.whenURL)


### PR DESCRIPTION
This PR should fix https://github.com/labstack/echo/issues/2447.

It removes the static node check optimization as it is preventing `UnescapePathParamValues` option to apply.