### PR TITLE
Fix `echo.bindData`  not binding multiple values when map is used as destination

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -130,7 +130,11 @@ func bindData(destination interface{}, data map[string][]string, tag string) err
 	// Map
 	if typ.Kind() == reflect.Map {
 		for k, v := range data {
-			val.SetMapIndex(reflect.ValueOf(k), reflect.ValueOf(v[0]))
+			if len(v) == 1 {
+				val.SetMapIndex(reflect.ValueOf(k), reflect.ValueOf(v[0]))
+			} else {
+				val.SetMapIndex(reflect.ValueOf(k), reflect.ValueOf(v))
+			}
 		}
 		return nil
 	}

--- a/bind_test.go
+++ b/bind_test.go
@@ -535,13 +535,13 @@ func TestBindMultipartFormWithMapDestination(t *testing.T) {
 	{
 		assertMsg := "map with non-string value"
 		data := map[string]int{}
-		err := BindHeaders(c, &data)
+		err := c.Bind(&data)
 		assert.Error(t, err, assertMsg)
 	}
 	{
 		assertMsg := "map with string value"
 		data := map[string]string{}
-		err := BindHeaders(c, &data)
+		err := c.Bind(&data)
 		assert.NoError(t, err, assertMsg)
 		assert.Equal(t, "single_val1", data["single"], assertMsg)
 		assert.Equal(t, "multiple_val1", data["multiple"], assertMsg)
@@ -549,7 +549,7 @@ func TestBindMultipartFormWithMapDestination(t *testing.T) {
 	{
 		assertMsg := "map with slice value"
 		data := map[string][]string{}
-		err := BindHeaders(c, &data)
+		err := c.Bind(&data)
 		assert.NoError(t, err, assertMsg)
 		assert.Equal(t, []string{"single_val1"}, data["single"], assertMsg)
 		assert.Equal(t, []string{"multiple_val1", "multiple_val2"}, data["multiple"], assertMsg)
@@ -557,7 +557,7 @@ func TestBindMultipartFormWithMapDestination(t *testing.T) {
 	{
 		assertMsg := "map with interface{} value"
 		data := map[string]interface{}{}
-		err := BindHeaders(c, &data)
+		err := c.Bind(&data)
 		assert.NoError(t, err)
 		assert.Equal(t, "single_val1", data["single"], assertMsg)
 		assert.Equal(t, []string{"multiple_val1", "multiple_val2"}, data["multiple"], assertMsg)

--- a/bind_test.go
+++ b/bind_test.go
@@ -313,7 +313,6 @@ func TestBindHeaderWithMapDestination(t *testing.T) {
 	err := BindHeaders(c, &data)
 
 	assert.NoError(t, err)
-	assert.NoError(t, err)
 	assert.Equal(t, 2, len(data))
 	assert.Equal(t, "val1", data["Single"])
 	assert.Equal(t, []string{"val1", "val2"}, data["Multiple"])

--- a/bind_test.go
+++ b/bind_test.go
@@ -303,19 +303,42 @@ func TestBindHeaderParamBadType(t *testing.T) {
 func TestBindHeaderWithMapDestination(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	req.Header.Add("Single", "val1")
-	req.Header.Add("Multiple", "val1")
-	req.Header.Add("Multiple", "val2")
+	req.Header.Add("Single", "single_val1")
+	req.Header.Add("Multiple", "multiple_val1")
+	req.Header.Add("Multiple", "multiple_val2")
 	e := New()
 	c := e.NewContext(req, rec)
 
-	data := map[string]interface{}{}
-	err := BindHeaders(c, &data)
-
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(data))
-	assert.Equal(t, "val1", data["Single"])
-	assert.Equal(t, []string{"val1", "val2"}, data["Multiple"])
+	{
+		assertMsg := "map with non-string value"
+		data := map[string]int{}
+		err := BindHeaders(c, &data)
+		assert.Error(t, err, assertMsg)
+	}
+	{
+		assertMsg := "map with string value"
+		data := map[string]string{}
+		err := BindHeaders(c, &data)
+		assert.NoError(t, err, assertMsg)
+		assert.Equal(t, "single_val1", data["Single"], assertMsg)
+		assert.Equal(t, "multiple_val1", data["Multiple"], assertMsg)
+	}
+	{
+		assertMsg := "map with slice value"
+		data := map[string][]string{}
+		err := BindHeaders(c, &data)
+		assert.NoError(t, err, assertMsg)
+		assert.Equal(t, []string{"single_val1"}, data["Single"], assertMsg)
+		assert.Equal(t, []string{"multiple_val1", "multiple_val2"}, data["Multiple"], assertMsg)
+	}
+	{
+		assertMsg := "map with interface{} value"
+		data := map[string]interface{}{}
+		err := BindHeaders(c, &data)
+		assert.NoError(t, err)
+		assert.Equal(t, "single_val1", data["Single"], assertMsg)
+		assert.Equal(t, []string{"multiple_val1", "multiple_val2"}, data["Multiple"], assertMsg)
+	}
 }
 
 func TestBind_CombineQueryWithHeaderParam(t *testing.T) {
@@ -498,9 +521,9 @@ func TestBindMultipartForm(t *testing.T) {
 func TestBindMultipartFormWithMapDestination(t *testing.T) {
 	body := new(bytes.Buffer)
 	mw := multipart.NewWriter(body)
-	mw.WriteField("single", "val1")
-	mw.WriteField("multiple", "val1")
-	mw.WriteField("multiple", "val2")
+	mw.WriteField("single", "single_val1")
+	mw.WriteField("multiple", "multiple_val1")
+	mw.WriteField("multiple", "multiple_val2")
 	mw.Close()
 
 	rec := httptest.NewRecorder()
@@ -509,13 +532,36 @@ func TestBindMultipartFormWithMapDestination(t *testing.T) {
 	e := New()
 	c := e.NewContext(req, rec)
 
-	data := map[string]interface{}{}
-	err := c.Bind(&data)
-
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(data))
-	assert.Equal(t, "val1", data["single"])
-	assert.Equal(t, []string{"val1", "val2"}, data["multiple"])
+	{
+		assertMsg := "map with non-string value"
+		data := map[string]int{}
+		err := BindHeaders(c, &data)
+		assert.Error(t, err, assertMsg)
+	}
+	{
+		assertMsg := "map with string value"
+		data := map[string]string{}
+		err := BindHeaders(c, &data)
+		assert.NoError(t, err, assertMsg)
+		assert.Equal(t, "single_val1", data["single"], assertMsg)
+		assert.Equal(t, "multiple_val1", data["multiple"], assertMsg)
+	}
+	{
+		assertMsg := "map with slice value"
+		data := map[string][]string{}
+		err := BindHeaders(c, &data)
+		assert.NoError(t, err, assertMsg)
+		assert.Equal(t, []string{"single_val1"}, data["single"], assertMsg)
+		assert.Equal(t, []string{"multiple_val1", "multiple_val2"}, data["multiple"], assertMsg)
+	}
+	{
+		assertMsg := "map with interface{} value"
+		data := map[string]interface{}{}
+		err := BindHeaders(c, &data)
+		assert.NoError(t, err)
+		assert.Equal(t, "single_val1", data["single"], assertMsg)
+		assert.Equal(t, []string{"multiple_val1", "multiple_val2"}, data["multiple"], assertMsg)
+	}
 }
 
 func TestBindUnsupportedMediaType(t *testing.T) {

--- a/bind_test.go
+++ b/bind_test.go
@@ -505,6 +505,22 @@ func TestBindbindData(t *testing.T) {
 	a.Equal("", ts.cantSet)
 }
 
+func TestBind_bindDataWithMap(t *testing.T) {
+	a := assert.New(t)
+
+	data := map[string]interface{}{}
+
+	values := url.Values{
+		"single":   []string{"val1"},
+		"multiple": []string{"val1", "val2"},
+	}
+
+	err := bindData(&data, values, "form")
+	a.NoError(err)
+	a.Equal(data["single"], "val1")
+	a.Equal(data["multiple"], []string{"val1", "val2"})
+}
+
 func TestBindParam(t *testing.T) {
 	e := New()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)


### PR DESCRIPTION
When calling `echo.Bind()`, `echo.BindBody()`, `echo.BindHeaders()`, etc. with `*map[string]any` as destination, currently multiple values of a single entry are being swallowed and only the first value is binded.

Multiple values could be a result from repeatable/array `multipart/form-data` fields or header with multiple values.

This issue seems to be available in both v4 and v5_alpha.

I've submitted the PR against v5_alpha since it could be a breaking change for v4 in case someone is relying on the current single value bind behavior.