### PR TITLE
handle a http.NoBody io.reader

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -58,7 +58,7 @@ func (b *DefaultBinder) BindQueryParams(c Context, i interface{}) error {
 // See MIMEMultipartForm: https://golang.org/pkg/net/http/#Request.ParseMultipartForm
 func (b *DefaultBinder) BindBody(c Context, i interface{}) (err error) {
 	req := c.Request()
-	if req.ContentLength == 0 {
+	if req.ContentLength <= 0 {
 		return
 	}
 

--- a/bind_test.go
+++ b/bind_test.go
@@ -239,6 +239,19 @@ func TestBindQueryParams(t *testing.T) {
 	}
 }
 
+func TestBindQueryParamsHttpNobody(t *testing.T) {
+	e := New()
+	req := httptest.NewRequest(http.MethodGet, "/?id=1&name=Jon+Snow", http.NoBody)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	u := new(user)
+	err := c.Bind(u)
+	if assert.NoError(t, err) {
+		assert.Equal(t, 1, u.ID)
+		assert.Equal(t, "Jon Snow", u.Name)
+	}
+}
+
 func TestBindQueryParamsCaseInsensitive(t *testing.T) {
 	e := New()
 	req := httptest.NewRequest(http.MethodGet, "/?ID=1&NAME=Jon+Snow", nil)


### PR DESCRIPTION
using a http.NoBody yields a content length of -1

as per the documentation of request.ContentLength
```go
	// ContentLength records the length of the associated content.
	// The value -1 indicates that the length is unknown.
	// Values >= 0 indicate that the given number of bytes may
	// be read from Body.
	//
	// For client requests, a value of 0 with a non-nil Body is
	// also treated as unknown.
```