### PR TITLE
fix(Context.Bind): should unescape special char in path

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"reflect"
 	"strconv"
 	"strings"
@@ -35,7 +36,12 @@ func (b *DefaultBinder) BindPathParams(c Context, i interface{}) error {
 	values := c.ParamValues()
 	params := map[string][]string{}
 	for i, name := range names {
-		params[name] = []string{values[i]}
+		escaped, err := url.QueryUnescape(values[i])
+		if err != nil {
+			return err
+		}
+
+		params[name] = []string{escaped}
 	}
 	if err := b.bindData(i, params, "param"); err != nil {
 		return NewHTTPError(http.StatusBadRequest, err.Error()).SetInternal(err)

--- a/bind_test.go
+++ b/bind_test.go
@@ -468,6 +468,19 @@ func TestBindParam(t *testing.T) {
 		assert.Equal(t, "Jon Snow", u.Name)
 	}
 
+	// Bind param with escaped characters
+	{
+		c := e.NewContext(req, rec)
+		c.SetPath("/users/:name")
+		c.SetParamNames("name")
+		c.SetParamValues("John%2FSnow")
+
+		err := c.Bind(u)
+		if assert.NoError(t, err) {
+			assert.Equal(t, "John/Snow", u.Name)
+		}
+	}
+
 	// Second test for the absence of a param
 	c2 := e.NewContext(req, rec)
 	c2.SetPath("/users/:id")


### PR DESCRIPTION
Other famous frameworks, such as expressjs or rails, will unescape the path params. We should follow the industry convention too.

For example:

```go
package main
​
import (
	"fmt"
​
	"github.com/labstack/echo/v4"
)
​
type Req struct {
	A string `param:"a"`
	B string `query:"b"`
}
​
func main() {
	e := echo.New()
	e.GET("/:a", func(c echo.Context) error {
		req := Req{}
		c.Bind(&req)
		fmt.Println(req.A, req.B)
		return nil
	})
	e.Logger.Fatal(e.Start(":3000"))
}
```

If we send request `curl http://localhost:3000/%26\?b\=%26`, it will print `%26 &` not `& &`.

If we try expressjs, it won't have the problem:

```js
const express = require("express");
const app = express();

app.get("/:name", (req, res) => {
  res.send(req.params);
});

app.listen("3000");
```