### PR TITLE
fix gzip not sending response code for no content responses (404, 301/302 redirects etc)

### DIFF
--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -89,8 +89,6 @@ func TestGzip(t *testing.T) {
 }
 
 func TestGzipWithMinLength(t *testing.T) {
-	assert := assert.New(t)
-
 	e := echo.New()
 	// Minimal response length
 	e.Use(GzipWithConfig(GzipConfig{MinLength: 10}))
@@ -103,19 +101,17 @@ func TestGzipWithMinLength(t *testing.T) {
 	req.Header.Set(echo.HeaderAcceptEncoding, gzipScheme)
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
-	assert.Equal(gzipScheme, rec.Header().Get(echo.HeaderContentEncoding))
+	assert.Equal(t, gzipScheme, rec.Header().Get(echo.HeaderContentEncoding))
 	r, err := gzip.NewReader(rec.Body)
-	if assert.NoError(err) {
+	if assert.NoError(t, err) {
 		buf := new(bytes.Buffer)
 		defer r.Close()
 		buf.ReadFrom(r)
-		assert.Equal("foobarfoobar", buf.String())
+		assert.Equal(t, "foobarfoobar", buf.String())
 	}
 }
 
 func TestGzipWithMinLengthTooShort(t *testing.T) {
-	assert := assert.New(t)
-
 	e := echo.New()
 	// Minimal response length
 	e.Use(GzipWithConfig(GzipConfig{MinLength: 10}))
@@ -127,13 +123,29 @@ func TestGzipWithMinLengthTooShort(t *testing.T) {
 	req.Header.Set(echo.HeaderAcceptEncoding, gzipScheme)
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
-	assert.Equal("", rec.Header().Get(echo.HeaderContentEncoding))
-	assert.Contains(rec.Body.String(), "test")
+	assert.Equal(t, "", rec.Header().Get(echo.HeaderContentEncoding))
+	assert.Contains(t, rec.Body.String(), "test")
+}
+
+func TestGzipWithResponseWithoutBody(t *testing.T) {
+	e := echo.New()
+
+	e.Use(Gzip())
+	e.GET("/", func(c echo.Context) error {
+		return c.Redirect(http.StatusMovedPermanently, "http://localhost")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(echo.HeaderAcceptEncoding, gzipScheme)
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusMovedPermanently, rec.Code)
+	assert.Equal(t, "", rec.Header().Get(echo.HeaderContentEncoding))
 }
 
 func TestGzipWithMinLengthChunked(t *testing.T) {
-	assert := assert.New(t)
-
 	e := echo.New()
 
 	// Gzip chunked
@@ -155,36 +167,36 @@ func TestGzipWithMinLengthChunked(t *testing.T) {
 		c.Response().Flush()
 
 		// Read the first part of the data
-		assert.True(rec.Flushed)
-		assert.Equal(gzipScheme, rec.Header().Get(echo.HeaderContentEncoding))
+		assert.True(t, rec.Flushed)
+		assert.Equal(t, gzipScheme, rec.Header().Get(echo.HeaderContentEncoding))
 
 		var err error
 		r, err = gzip.NewReader(rec.Body)
-		assert.NoError(err)
+		assert.NoError(t, err)
 
 		_, err = io.ReadFull(r, chunkBuf)
-		assert.NoError(err)
-		assert.Equal("test\n", string(chunkBuf))
+		assert.NoError(t, err)
+		assert.Equal(t, "test\n", string(chunkBuf))
 
 		// Write and flush the second part of the data
 		c.Response().Write([]byte("test\n"))
 		c.Response().Flush()
 
 		_, err = io.ReadFull(r, chunkBuf)
-		assert.NoError(err)
-		assert.Equal("test\n", string(chunkBuf))
+		assert.NoError(t, err)
+		assert.Equal(t, "test\n", string(chunkBuf))
 
 		// Write the final part of the data and return
 		c.Response().Write([]byte("test"))
 		return nil
 	})(c)
 
-	assert.NotNil(r)
+	assert.NotNil(t, r)
 
 	buf := new(bytes.Buffer)
 
 	buf.ReadFrom(r)
-	assert.Equal("test", buf.String())
+	assert.Equal(t, "test", buf.String())
 
 	r.Close()
 }


### PR DESCRIPTION
This is fix for #2480

Response code is not written from buffered writer to the actual writer when  handler sent no-content response - ala 404 or redirect

```go
func main() {
	e := echo.New()

	e.Use(middleware.Gzip())

	e.GET("/404", func(ctx echo.Context) error {
		return ctx.NoContent(http.StatusNotFound)
	})

	e.GET("/redirect", func(ctx echo.Context) error {
		return ctx.Redirect(http.StatusTemporaryRedirect, "/login")
	})

	if err := e.Start(":8080"); err != nil && !errors.Is(err, http.ErrServerClosed) {
		log.Fatal(err)
	}
}
```

Example output after fix:
```bash
x@x:~/$ curl -v --compressed "http://localhost:8080/404"
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /404 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.88.1
> Accept: */*
> Accept-Encoding: deflate, gzip, br, zstd
> 
< HTTP/1.1 404 Not Found
< Vary: Accept-Encoding
< Date: Sun, 16 Jul 2023 17:20:11 GMT
< Content-Length: 0
< 
* Connection #0 to host localhost left intact

x@x:~/$ curl -v --compressed "http://localhost:8080/redirect"
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /redirect HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.88.1
> Accept: */*
> Accept-Encoding: deflate, gzip, br, zstd
> 
< HTTP/1.1 307 Temporary Redirect
< Location: /login
< Vary: Accept-Encoding
< Date: Sun, 16 Jul 2023 17:20:16 GMT
< Content-Length: 0
< 
* Connection #0 to host localhost left intact
```