### PR TITLE
delete unused context in body_limit.go

### DIFF
--- a/middleware/body_limit.go
+++ b/middleware/body_limit.go
@@ -23,9 +23,8 @@ type (
 
 	limitedReader struct {
 		BodyLimitConfig
-		reader  io.ReadCloser
-		read    int64
-		context echo.Context
+		reader io.ReadCloser
+		read   int64
 	}
 )
 
@@ -80,7 +79,7 @@ func BodyLimitWithConfig(config BodyLimitConfig) echo.MiddlewareFunc {
 
 			// Based on content read
 			r := pool.Get().(*limitedReader)
-			r.Reset(req.Body, c)
+			r.Reset(req.Body)
 			defer pool.Put(r)
 			req.Body = r
 
@@ -102,9 +101,8 @@ func (r *limitedReader) Close() error {
 	return r.reader.Close()
 }
 
-func (r *limitedReader) Reset(reader io.ReadCloser, context echo.Context) {
+func (r *limitedReader) Reset(reader io.ReadCloser) {
 	r.reader = reader
-	r.context = context
 	r.read = 0
 }
 

--- a/middleware/body_limit_test.go
+++ b/middleware/body_limit_test.go
@@ -56,9 +56,6 @@ func TestBodyLimit(t *testing.T) {
 
 func TestBodyLimitReader(t *testing.T) {
 	hw := []byte("Hello, World!")
-	e := echo.New()
-	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(hw))
-	rec := httptest.NewRecorder()
 
 	config := BodyLimitConfig{
 		Skipper: DefaultSkipper,
@@ -68,7 +65,6 @@ func TestBodyLimitReader(t *testing.T) {
 	reader := &limitedReader{
 		BodyLimitConfig: config,
 		reader:          io.NopCloser(bytes.NewReader(hw)),
-		context:         e.NewContext(req, rec),
 	}
 
 	// read all should return ErrStatusRequestEntityTooLarge
@@ -78,7 +74,7 @@ func TestBodyLimitReader(t *testing.T) {
 
 	// reset reader and read two bytes must succeed
 	bt := make([]byte, 2)
-	reader.Reset(io.NopCloser(bytes.NewReader(hw)), e.NewContext(req, rec))
+	reader.Reset(io.NopCloser(bytes.NewReader(hw)))
 	n, err := reader.Read(bt)
 	assert.Equal(t, 2, n)
 	assert.Equal(t, nil, err)


### PR DESCRIPTION
according to this [issue](https://github.com/labstack/echo/issues/2469), I remove unused context in limitedReader struct