### PR TITLE
fix(sec): `randomString` bias

### DIFF
--- a/middleware/util.go
+++ b/middleware/util.go
@@ -57,6 +57,7 @@ func matchSubdomain(domain, pattern string) bool {
 	return false
 }
 
+// https://tip.golang.org/doc/go1.19#:~:text=Read%20no%20longer%20buffers%20random%20data%20obtained%20from%20the%20operating%20system%20between%20calls
 var randomReaderPool = sync.Pool{New: func() any {
 	return bufio.NewReader(rand.Reader)
 }}

--- a/middleware/util.go
+++ b/middleware/util.go
@@ -61,7 +61,7 @@ const randomStringMaxByte = 255 - (256 % randomStringCharsetLen)
 
 func randomString(length uint8) string {
 	b := make([]byte, length)
-	r := make([]byte, length+(length/3))
+	r := make([]byte, length+(length/4)) // perf: avoid read from rand.Reader many times
 	var i uint8 = 0
 
 	for {
@@ -74,7 +74,7 @@ func randomString(length uint8) string {
 		}
 		for _, rb := range r {
 			if rb > randomStringMaxByte {
-				// Skip this number to avoid modulo bias.
+				// Skip this number to avoid bias.
 				continue
 			}
 			b[i] = randomStringCharset[rb%randomStringCharsetLen]

--- a/middleware/util.go
+++ b/middleware/util.go
@@ -58,7 +58,7 @@ func matchSubdomain(domain, pattern string) bool {
 }
 
 // https://tip.golang.org/doc/go1.19#:~:text=Read%20no%20longer%20buffers%20random%20data%20obtained%20from%20the%20operating%20system%20between%20calls
-var randomReaderPool = sync.Pool{New: func() any {
+var randomReaderPool = sync.Pool{New: func() interface{} {
 	return bufio.NewReader(rand.Reader)
 }}
 
@@ -75,12 +75,9 @@ func randomString(length uint8) string {
 	var i uint8 = 0
 
 	for {
-		n, err := io.ReadFull(reader, r)
+		_, err := io.ReadFull(reader, r)
 		if err != nil {
 			panic("unexpected error happened when reading from bufio.NewReader(crypto/rand.Reader)")
-		}
-		if n != len(r) {
-			panic("partial reads occurred when reading from bufio.NewReader(crypto/rand.Reader)")
 		}
 		for _, rb := range r {
 			if rb > randomStringMaxByte {

--- a/middleware/util.go
+++ b/middleware/util.go
@@ -77,8 +77,7 @@ func randomString(length uint8) string {
 				// Skip this number to avoid modulo bias.
 				continue
 			}
-			c := randomStringCharset[rb%randomStringCharsetLen]
-			b[i] = c
+			b[i] = randomStringCharset[rb%randomStringCharsetLen]
 			i++
 			if i == length {
 				return string(b)

--- a/middleware/util_test.go
+++ b/middleware/util_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_matchScheme(t *testing.T) {
@@ -115,5 +116,33 @@ func TestRandomString(t *testing.T) {
 			uid := randomString(tc.whenLength)
 			assert.Len(t, uid, int(tc.whenLength))
 		})
+	}
+}
+
+func TestRandomStringBias(t *testing.T) {
+	t.Parallel()
+	const slen = 33
+	const loop = 100000
+
+	counts := make(map[rune]int)
+	var count int64
+
+	for i := 0; i < loop; i++ {
+		s := randomString(slen)
+		require.Equal(t, slen, len(s))
+		for _, b := range s {
+			counts[b]++
+			count++
+		}
+	}
+
+	require.Equal(t, randomStringCharsetLen, len(counts))
+
+	avg := float64(count) / float64(len(counts))
+	for k, n := range counts {
+		diff := float64(n) / avg
+		if diff < 0.95 || diff > 1.05 {
+			t.Errorf("Bias on '%c': expected average %f, got %d", k, avg, n)
+		}
 	}
 }


### PR DESCRIPTION
security issue added by #2490

`len("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")==52`, and `256 = 52 * 4 + 48`, so the possibility of each characters generated by `randomString` is not equal.

A-Za-v: 5/256
wxyz: 4/256

also perfermance improve, in newer (>=1.19) go version, `rand.Reader` is not buffered any more, so it's suggested to wrap `rand.Reader` with bufio if the data read from reader is small.

https://tip.golang.org/doc/go1.19#:~:text=Read%20no%20longer%20buffers%20random%20data%20obtained%20from%20the%20operating%20system%20between%20calls