### PR TITLE
Bump dependancies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/labstack/gommon v0.4.0
-	github.com/stretchr/testify v1.8.1
+	github.com/stretchr/testify v1.8.4
 	github.com/valyala/fasttemplate v1.2.2
 	golang.org/x/crypto v0.14.0
 	golang.org/x/net v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpE
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=


### PR DESCRIPTION
Bump:
* ~~golang.org/x/net v0.12.0 -> v0.15.0 (diff https://github.com/golang/net/compare/v0.12.0...v0.15.0)~~ (obsolete since #2527)
* ~~golang.org/x/crypto v0.11.0 -> v0.13.0 (diff https://github.com/golang/net/compare/v0.11.0...v0.13.0)~~ (obsolete since #2527)
* github.com/stretchr/testify v1.8.1 -> v1.8.4 (diff https://github.com/stretchr/testify/compare/v1.8.1...v1.8.4)

The main motivation is `golang.org/x/net` which got cleaned up recently in [v0.15.0](https://github.com/golang/net/releases/tag/v0.15.0) via https://github.com/golang/net/commit/4a2d37ed365334ff00b166660d7c497fcfeaef1b removing the reference to ancient [`ubuntu:trusty`, which has currently 559 known vulnerabilities, 4 of which are critical](https://hub.docker.com/layers/library/ubuntu/trusty/images/sha256-881afbae521c910f764f7187dbfbca3cc10c26f8bafa458c76dda009a901c29d?context=explore), triggering various false positive alerts...