### PR TITLE
Security: c.Attachment and c.Inline should escape filename in `Content-Disposition` header

### DIFF
--- a/context.go
+++ b/context.go
@@ -584,8 +584,10 @@ func (c *context) Inline(file, name string) error {
 	return c.contentDisposition(file, name, "inline")
 }
 
+var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
+
 func (c *context) contentDisposition(file, name, dispositionType string) error {
-	c.response.Header().Set(HeaderContentDisposition, fmt.Sprintf("%s; filename=%q", dispositionType, name))
+	c.response.Header().Set(HeaderContentDisposition, fmt.Sprintf(`%s; filename="%s"`, dispositionType, quoteEscaper.Replace(name)))
 	return c.File(file)
 }
 


### PR DESCRIPTION
This fixes #2531

c.Attachment and c.Inline should escape filename in `Content-Disposition` header to avoid 'Reflect File Download' vulnerability.

This is same as Go std does escaping https://github.com/golang/go/blob/9d836d41d0d9df3acabf7f9607d3b09188a9bfc6/src/mime/multipart/writer.go#L132

