### PR TITLE
binder: make binding to Map work better with string destinations

### DIFF
--- a/bind_test.go
+++ b/bind_test.go
@@ -429,6 +429,62 @@ func TestBindUnsupportedMediaType(t *testing.T) {
 	testBindError(t, strings.NewReader(invalidContent), MIMEApplicationJSON, &json.SyntaxError{})
 }
 
+func TestDefaultBinder_bindDataToMap(t *testing.T) {
+	exampleData := map[string][]string{
+		"multiple": {"1", "2"},
+		"single":   {"3"},
+	}
+
+	t.Run("ok, bind to map[string]string", func(t *testing.T) {
+		dest := map[string]string{}
+		assert.NoError(t, new(DefaultBinder).bindData(&dest, exampleData, "param"))
+		assert.Equal(t,
+			map[string]string{
+				"multiple": "1",
+				"single":   "3",
+			},
+			dest,
+		)
+	})
+
+	t.Run("ok, bind to map[string][]string", func(t *testing.T) {
+		dest := map[string][]string{}
+		assert.NoError(t, new(DefaultBinder).bindData(&dest, exampleData, "param"))
+		assert.Equal(t,
+			map[string][]string{
+				"multiple": {"1", "2"},
+				"single":   {"3"},
+			},
+			dest,
+		)
+	})
+
+	t.Run("ok, bind to map[string]interface", func(t *testing.T) {
+		dest := map[string]interface{}{}
+		assert.NoError(t, new(DefaultBinder).bindData(&dest, exampleData, "param"))
+		assert.Equal(t,
+			map[string]interface{}{
+				"multiple": []string{"1", "2"},
+				"single":   []string{"3"},
+			},
+			dest,
+		)
+	})
+
+	t.Run("ok, bind to map[string]int skips", func(t *testing.T) {
+		dest := map[string]int{}
+		assert.NoError(t, new(DefaultBinder).bindData(&dest, exampleData, "param"))
+		assert.Equal(t, map[string]int{}, dest)
+	})
+
+	t.Run("ok, bind to map[string][]int skips", func(t *testing.T) {
+		dest := map[string][]int{}
+		assert.NoError(t, new(DefaultBinder).bindData(&dest, exampleData, "param"))
+		assert.Equal(t, map[string][]int{}, dest)
+	})
+
+}
+
 func TestBindbindData(t *testing.T) {
 	ts := new(bindTestStruct)
 	b := new(DefaultBinder)


### PR DESCRIPTION
Relates to #2552 and #988

Difference from previous implementations is that in case we are binding to unsupported Map we ended in with panic. Now we skip binding (params/query/header) and try other sources (ala body)
```go
package main

import (
	"github.com/labstack/echo/v4"
	"github.com/labstack/echo/v4/middleware"
	"net/http"
)

func main() {
	e := echo.New()
	e.Use(middleware.Logger())
	e.Use(middleware.Recover())

	// test: `curl -XPOST --header "Content-Type: application/json" -d '{"module1": "2", "module2": "3"}' http://127.0.0.1:8080/test/string/1`
	// output old: {"id":"1","module1":"2","module2":"3"}
	// output new: {"id":"1","module1":"2","module2":"3"}
	e.POST("/test/string/:id", func(c echo.Context) error {
		p := map[string]string{}
		if err := c.Bind(&p); err != nil {
			return err
		}
		return c.JSON(http.StatusOK, p)
	})

	// test: `curl -XPOST --header "Content-Type: application/json" -d '{"module1": 2, "module2": 3}' http://127.0.0.1:8080/test/int/1`
	// output old: {"message":"Internal Server Error"}
	// output new: {"module1":"2","module2":"3"}
	e.POST("/test/int/:id", func(c echo.Context) error {
		p := map[string]int{}
		if err := c.Bind(&p); err != nil {
			return err
		}
		return c.JSON(http.StatusOK, p)
	})

	e.Start("127.0.0.1:8080")
}

```