### PR TITLE
[issue-2557] Add :from-:to range route formats

### DIFF
--- a/router.go
+++ b/router.go
@@ -210,7 +210,11 @@ func (r *Router) Add(method, path string, h HandlerFunc) {
 	}
 
 	for i, lcpIndex := 0, len(path); i < lcpIndex; i++ {
-		if path[i] == ':' {
+		if path[i] == ':' || path[i] == '{' {
+			bracketsOpen := false
+			if path[i] == '{' {
+				bracketsOpen = true
+			}
 			if i > 0 && path[i-1] == '\\' {
 				path = path[:i-1] + path[i:]
 				i--
@@ -220,11 +224,15 @@ func (r *Router) Add(method, path string, h HandlerFunc) {
 			j := i + 1
 
 			r.insert(method, path[:i], staticKind, routeMethod{})
-			for ; i < lcpIndex && (path[i] != '/' && path[i] != '-'); i++ {
+			for ; i < lcpIndex && (path[i] != '/' && !(path[j-1] == '{' && path[i] == '}')); i++ {
 			}
 
 			pnames = append(pnames, path[j:i])
-			path = path[:j] + path[i:]
+			if bracketsOpen {
+				path = path[:j-1] + ":" + path[i+1:]
+			} else {
+				path = path[:j] + path[i:]
+			}
 			i, lcpIndex = j, len(path)
 
 			if i == lcpIndex {
@@ -660,7 +668,7 @@ func (r *Router) Find(method, path string, c Context) {
 				// act similarly to any node - consider all remaining search as match
 				i = l
 			} else {
-				for ; i < l && search[i] != '/' && search[i] != '-'; i++ {
+				for ; i < l && search[i] != '/' && !(search[i] == '-' || search[i] == '.'); i++ {
 				}
 			}
 
@@ -714,7 +722,6 @@ func (r *Router) Find(method, path string, c Context) {
 	if currentNode == nil && previousBestMatchNode == nil {
 		return // nothing matched at all
 	}
-
 	// matchedHandler could be method+path handler that we matched or notFoundHandler from node with matching path
 	// user provided not found (404) handler has priority over generic method not found (405) handler or global 404 handler
 	var rPath string

--- a/router.go
+++ b/router.go
@@ -165,7 +165,7 @@ func (r *Router) Reverse(name string, params ...interface{}) string {
 				}
 				if n < ln && (route.Path[i] == '*' || (!hasBackslash && route.Path[i] == ':')) {
 					// in case of `*` wildcard or `:` (unescaped colon) param we replace everything till next slash or end of path
-					for ; i < l && route.Path[i] != '/'; i++ {
+					for ; i < l && route.Path[i] != '/' && route.Path[i] != '-'; i++ {
 					}
 					uri.WriteString(fmt.Sprintf("%v", params[n]))
 					n++
@@ -220,7 +220,7 @@ func (r *Router) Add(method, path string, h HandlerFunc) {
 			j := i + 1
 
 			r.insert(method, path[:i], staticKind, routeMethod{})
-			for ; i < lcpIndex && path[i] != '/'; i++ {
+			for ; i < lcpIndex && (path[i] != '/' && path[i] != '-'); i++ {
 			}
 
 			pnames = append(pnames, path[j:i])
@@ -660,7 +660,7 @@ func (r *Router) Find(method, path string, c Context) {
 				// act similarly to any node - consider all remaining search as match
 				i = l
 			} else {
-				for ; i < l && search[i] != '/'; i++ {
+				for ; i < l && search[i] != '/' && search[i] != '-'; i++ {
 				}
 			}
 

--- a/router.go
+++ b/router.go
@@ -668,8 +668,14 @@ func (r *Router) Find(method, path string, c Context) {
 				// act similarly to any node - consider all remaining search as match
 				i = l
 			} else {
-				for ; i < l && search[i] != '/' && !(search[i] == '-' || search[i] == '.'); i++ {
+				for ; i < l && search[i] != '/'; i++ {
+					for _, static := range currentNode.staticChildren {
+						if search[i] == static.label {
+							goto Done
+						}
+					}
 				}
+			Done:
 			}
 
 			paramValues[paramIndex] = search[:i]

--- a/router_test.go
+++ b/router_test.go
@@ -733,7 +733,7 @@ func TestRouterRangeParam(t *testing.T) {
 	r := e.router
 
 	r.Add(http.MethodGet, "/flights/{from}.{to}", handlerFunc)
-	r.Add(http.MethodGet, "/flights/{from}-{to}", handlerFunc)
+	r.Add(http.MethodGet, "/flights/{from}to{to}", handlerFunc)
 
 	var testCases = []struct {
 		name        string
@@ -748,9 +748,9 @@ func TestRouterRangeParam(t *testing.T) {
 			expectParam: map[string]string{"from": "LAX", "to": "DEN"},
 		},
 		{
-			name:        "route /flights/LAX-DEN to /flights/{from}-{to}",
-			whenURL:     "/flights/LAX-DEN",
-			expectRoute: "/flights/{from}-{to}",
+			name:        "route /flights/LAXtoDEN to /flights/{from}to{to}",
+			whenURL:     "/flights/LAXtoDEN",
+			expectRoute: "/flights/{from}to{to}",
 			expectParam: map[string]string{"from": "LAX", "to": "DEN"},
 		},
 	}

--- a/router_test.go
+++ b/router_test.go
@@ -728,6 +728,42 @@ func TestRouterParam(t *testing.T) {
 	}
 }
 
+func TestRouterRangeParam(t *testing.T) {
+	e := New()
+	r := e.router
+
+	r.Add(http.MethodGet, "/flights/:from-:to", handlerFunc)
+
+	var testCases = []struct {
+		name        string
+		whenURL     string
+		expectRoute interface{}
+		expectParam map[string]string
+	}{
+		{
+			name:        "route /flights/LAX-DEN to /flights/:from-:to",
+			whenURL:     "/flights/LAX-DEN",
+			expectRoute: "/flights/:from-:to",
+			expectParam: map[string]string{"from": "LAX", "to": "DEN"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			c := e.NewContext(nil, nil).(*context)
+			r.Find(http.MethodGet, tc.whenURL, c)
+
+			c.handler(c)
+			assert.Equal(t, tc.expectRoute, c.Get("path"))
+			for param, expectedValue := range tc.expectParam {
+				assert.Equal(t, expectedValue, c.Param(param))
+			}
+			checkUnusedParamValues(t, c, tc.expectParam)
+		})
+	}
+}
+
 func TestRouter_addAndMatchAllSupportedMethods(t *testing.T) {
 	var testCases = []struct {
 		name            string

--- a/router_test.go
+++ b/router_test.go
@@ -732,7 +732,8 @@ func TestRouterRangeParam(t *testing.T) {
 	e := New()
 	r := e.router
 
-	r.Add(http.MethodGet, "/flights/:from-:to", handlerFunc)
+	r.Add(http.MethodGet, "/flights/{from}.{to}", handlerFunc)
+	r.Add(http.MethodGet, "/flights/{from}-{to}", handlerFunc)
 
 	var testCases = []struct {
 		name        string
@@ -741,9 +742,15 @@ func TestRouterRangeParam(t *testing.T) {
 		expectParam map[string]string
 	}{
 		{
-			name:        "route /flights/LAX-DEN to /flights/:from-:to",
+			name:        "route /flights/LAX.DEN to /flights/{from}.{to}",
+			whenURL:     "/flights/LAX.DEN",
+			expectRoute: "/flights/{from}.{to}",
+			expectParam: map[string]string{"from": "LAX", "to": "DEN"},
+		},
+		{
+			name:        "route /flights/LAX-DEN to /flights/{from}-{to}",
 			whenURL:     "/flights/LAX-DEN",
-			expectRoute: "/flights/:from-:to",
+			expectRoute: "/flights/{from}-{to}",
 			expectParam: map[string]string{"from": "LAX", "to": "DEN"},
 		},
 	}


### PR DESCRIPTION
Implements this feature (https://github.com/labstack/echo/issues/2557)

Adds :from-:to route.

example /flights/:from-:to

![image](https://github.com/labstack/echo/assets/42649107/99a3325a-acd1-4092-b5e0-863f85f69124)
![image](https://github.com/labstack/echo/assets/42649107/39aa6917-1884-4ae2-9131-62ac23682a5c)
