### PR TITLE
binder: allow binding to a nil map

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -145,6 +145,9 @@ func (b *DefaultBinder) bindData(destination interface{}, data map[string][]stri
 		if !(isElemSliceOfStrings || isElemString || isElemInterface) {
 			return nil
 		}
+		if val.IsNil() {
+			val.Set(reflect.MakeMap(typ))
+		}
 		for k, v := range data {
 			if isElemString {
 				val.SetMapIndex(reflect.ValueOf(k), reflect.ValueOf(v[0]))

--- a/bind_test.go
+++ b/bind_test.go
@@ -447,8 +447,32 @@ func TestDefaultBinder_bindDataToMap(t *testing.T) {
 		)
 	})
 
+	t.Run("ok, bind to map[string]string with nil map", func(t *testing.T) {
+		var dest map[string]string
+		assert.NoError(t, new(DefaultBinder).bindData(&dest, exampleData, "param"))
+		assert.Equal(t,
+			map[string]string{
+				"multiple": "1",
+				"single":   "3",
+			},
+			dest,
+		)
+	})
+
 	t.Run("ok, bind to map[string][]string", func(t *testing.T) {
 		dest := map[string][]string{}
+		assert.NoError(t, new(DefaultBinder).bindData(&dest, exampleData, "param"))
+		assert.Equal(t,
+			map[string][]string{
+				"multiple": {"1", "2"},
+				"single":   {"3"},
+			},
+			dest,
+		)
+	})
+
+	t.Run("ok, bind to map[string][]string with nil map", func(t *testing.T) {
+		var dest map[string][]string
 		assert.NoError(t, new(DefaultBinder).bindData(&dest, exampleData, "param"))
 		assert.Equal(t,
 			map[string][]string{
@@ -471,10 +495,28 @@ func TestDefaultBinder_bindDataToMap(t *testing.T) {
 		)
 	})
 
+	t.Run("ok, bind to map[string]interface with nil map", func(t *testing.T) {
+		var dest map[string]interface{}
+		assert.NoError(t, new(DefaultBinder).bindData(&dest, exampleData, "param"))
+		assert.Equal(t,
+			map[string]interface{}{
+				"multiple": []string{"1", "2"},
+				"single":   []string{"3"},
+			},
+			dest,
+		)
+	})
+
 	t.Run("ok, bind to map[string]int skips", func(t *testing.T) {
 		dest := map[string]int{}
 		assert.NoError(t, new(DefaultBinder).bindData(&dest, exampleData, "param"))
 		assert.Equal(t, map[string]int{}, dest)
+	})
+
+	t.Run("ok, bind to map[string]int skips with nil map", func(t *testing.T) {
+		var dest map[string]int
+		assert.NoError(t, new(DefaultBinder).bindData(&dest, exampleData, "param"))
+		assert.Equal(t, map[string]int(nil), dest)
 	})
 
 	t.Run("ok, bind to map[string][]int skips", func(t *testing.T) {
@@ -483,6 +525,11 @@ func TestDefaultBinder_bindDataToMap(t *testing.T) {
 		assert.Equal(t, map[string][]int{}, dest)
 	})
 
+	t.Run("ok, bind to map[string][]int skips with nil map", func(t *testing.T) {
+		var dest map[string][]int
+		assert.NoError(t, new(DefaultBinder).bindData(&dest, exampleData, "param"))
+		assert.Equal(t, map[string][]int(nil), dest)
+	})
 }
 
 func TestBindbindData(t *testing.T) {


### PR DESCRIPTION
Given the following code:

```
var params map[string]interface{} // <- this is nil
c.Bind(&params)
```

Currently, if the context does not define any path or query params, this might work when parsing a JSON body.
If there are path parameters involved, this will panic with:
```
echo: http: panic serving 127.0.0.1:41198: assignment to entry in nil map
goroutine 6 [running]:
net/http.(*conn).serve.func1()
	/usr/lib/golang/src/net/http/server.go:1868 +0x13d
panic({0x845340?, 0x8deaf0?})
	/usr/lib/golang/src/runtime/panic.go:920 +0x290
reflect.mapassign_faststr0(0x842580, 0x100c0000f8b18?, {0x8dc8c0?, 0x0?}, 0x842580?)
	/usr/lib/golang/src/runtime/map.go:1376 +0x25
reflect.mapassign_faststr(0x842580, 0x0, {0x8dc8c0, 0x1}, 0xc000017520)
	/usr/lib/golang/src/reflect/value.go:3837 +0x65
reflect.Value.SetMapIndex({0x842580, 0xc00006a088, 0x195}, {0x8327e0, 0xc000017510, 0x98}, {0x83d3a0, 0xc000017520, 0x94})
	/usr/lib/golang/src/reflect/value.go:2402 +0x2e5
github.com/labstack/echo/v4.(*DefaultBinder).bindData(0xad1780, {0x82ed80, 0xc00006a088}, 0xc0000f91b8, {0x89016d, 0x5})
	/home/georg/go/pkg/mod/github.com/labstack/echo/v4@v4.11.5-0.20231220133251-60fc2fb1b76f/bind.go:152 +0x150d
github.com/labstack/echo/v4.(*DefaultBinder).BindPathParams(0xad1780, {0x8e42b8, 0xc0000aaa00}, {0x82ed80, 0xc00006a088})
	/home/georg/go/pkg/mod/github.com/labstack/echo/v4@v4.11.5-0.20231220133251-60fc2fb1b76f/bind.go:40 +0x33d
github.com/labstack/echo/v4.(*DefaultBinder).Bind(0xad1780, {0x82ed80, 0xc00006a088}, {0x8e42b8, 0xc0000aaa00})
	/home/georg/go/pkg/mod/github.com/labstack/echo/v4@v4.11.5-0.20231220133251-60fc2fb1b76f/bind.go:111 +0x6d
github.com/labstack/echo/v4.(*context).Bind(0xc0000aaa00, {0x82ed80, 0xc00006a088})
	/home/georg/go/pkg/mod/github.com/labstack/echo/v4@v4.11.5-0.20231220133251-60fc2fb1b76f/context.go:439 +0x5d
```

With this patch applied, there are no panics anymore.
