### PR TITLE
CI: Use Go 1.22

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,7 +14,7 @@ permissions:
 
 env:
   # run static analysis only with the latest Go version
-  LATEST_GO_VERSION: "1.21"
+  LATEST_GO_VERSION: "1.22"
 
 jobs:
   check:

--- a/.github/workflows/echo.yml
+++ b/.github/workflows/echo.yml
@@ -14,7 +14,7 @@ permissions:
 
 env:
   # run coverage and benchmarks only with the latest Go version
-  LATEST_GO_VERSION: "1.21"
+  LATEST_GO_VERSION: "1.22"
 
 jobs:
   test:
@@ -25,7 +25,7 @@ jobs:
         # Echo tests with last four major releases (unless there are pressing vulnerabilities)
         # As we depend on `golang.org/x/` libraries which only support last 2 Go releases we could have situations when
         # we derive from last four major releases promise.
-        go: ["1.18", "1.19", "1.20", "1.21"]
+        go: ["1.19", "1.20", "1.21", "1.22"]
     name: ${{ matrix.os }} @ Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/echo_test.go
+++ b/echo_test.go
@@ -1572,7 +1572,7 @@ func TestEcho_OnAddRouteHandler(t *testing.T) {
 		})
 	}
 
-	e.GET("/static", NotFoundHandler)
+	e.GET("/static", dummyHandler)
 	e.Host("domain.site").GET("/static/*", dummyHandler, func(next HandlerFunc) HandlerFunc {
 		return func(c Context) error {
 			return next(c)
@@ -1582,7 +1582,7 @@ func TestEcho_OnAddRouteHandler(t *testing.T) {
 	assert.Len(t, added, 2)
 
 	assert.Equal(t, "", added[0].host)
-	assert.Equal(t, Route{Method: http.MethodGet, Path: "/static", Name: "github.com/labstack/echo/v4.glob..func1"}, added[0].route)
+	assert.Equal(t, Route{Method: http.MethodGet, Path: "/static", Name: "github.com/labstack/echo/v4.TestEcho_OnAddRouteHandler.func1"}, added[0].route)
 	assert.Len(t, added[0].middleware, 0)
 
 	assert.Equal(t, "domain.site", added[1].host)


### PR DESCRIPTION
Go 1.22 is released. See https://go.dev/doc/go1.22


note to self:  seems that in Go 1.22 reflection package gives different names for package level function variables. Previously these resulted as `github.com/labstack/echo/v4.glob..func1` but in 1.22  you get `github.com/labstack/echo/v4.init.func1`. I have changed problematic test to pass in newer/older versions.