### PR TITLE
Aliased slices should be consistent with builtin slices

### DIFF
--- a/bind_test.go
+++ b/bind_test.go
@@ -350,6 +350,18 @@ func TestBindUnmarshalParam(t *testing.T) {
 	}
 }
 
+func TestBindUnmarshalParamInvalidInt(t *testing.T) {
+	e := New()
+	req := httptest.NewRequest(http.MethodGet, "/?ia=1,two,3", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	result := struct {
+		IA IntArray `query:"ia"`
+	}{}
+	err := c.Bind(&result)
+	assert.Error(t, err)
+}
+
 func TestBindUnmarshalText(t *testing.T) {
 	e := New()
 	req := httptest.NewRequest(http.MethodGet, "/?ts=2016-12-06T19:09:05Z&sa=one,two,three&ta=2016-12-06T19:09:05Z&ta=2016-12-06T19:09:05Z&ST=baz", nil)


### PR DESCRIPTION
In working with an API at work we had the use case on query params to accept the following syntaxes:

- `?foo=1&foo=2&foo=3`
- `?foo=1,2,3`

Initially we were using only the former syntax, but then a new library was developed that sent the latter syntax.  When we switched from defining our field as `[]int` to a custom type `Ints` that implemented `UnmarshalParam` we found that when there were multiple values for the same key, the `UnmarshalParam` would only receive the first value and others would be lost.

This change brings
consistency between the builtin slices and the aliased slices for query parameters.