### PR TITLE
Change type definition blocks to single declarations. This helps copy…

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -14,23 +14,21 @@ import (
 	"strings"
 )
 
-type (
-	// Binder is the interface that wraps the Bind method.
-	Binder interface {
-		Bind(i interface{}, c Context) error
-	}
+// Binder is the interface that wraps the Bind method.
+type Binder interface {
+	Bind(i interface{}, c Context) error
+}
 
-	// DefaultBinder is the default implementation of the Binder interface.
-	DefaultBinder struct{}
+// DefaultBinder is the default implementation of the Binder interface.
+type DefaultBinder struct{}
 
-	// BindUnmarshaler is the interface used to wrap the UnmarshalParam method.
-	// Types that don't implement this, but do implement encoding.TextUnmarshaler
-	// will use that interface instead.
-	BindUnmarshaler interface {
-		// UnmarshalParam decodes and assigns a value from an form or query param.
-		UnmarshalParam(param string) error
-	}
-)
+// BindUnmarshaler is the interface used to wrap the UnmarshalParam method.
+// Types that don't implement this, but do implement encoding.TextUnmarshaler
+// will use that interface instead.
+type BindUnmarshaler interface {
+	// UnmarshalParam decodes and assigns a value from an form or query param.
+	UnmarshalParam(param string) error
+}
 
 // BindPathParams binds path params to bindable object
 func (b *DefaultBinder) BindPathParams(c Context, i interface{}) error {

--- a/bind_test.go
+++ b/bind_test.go
@@ -22,91 +22,91 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type (
-	bindTestStruct struct {
-		I           int
-		PtrI        *int
-		I8          int8
-		PtrI8       *int8
-		I16         int16
-		PtrI16      *int16
-		I32         int32
-		PtrI32      *int32
-		I64         int64
-		PtrI64      *int64
-		UI          uint
-		PtrUI       *uint
-		UI8         uint8
-		PtrUI8      *uint8
-		UI16        uint16
-		PtrUI16     *uint16
-		UI32        uint32
-		PtrUI32     *uint32
-		UI64        uint64
-		PtrUI64     *uint64
-		B           bool
-		PtrB        *bool
-		F32         float32
-		PtrF32      *float32
-		F64         float64
-		PtrF64      *float64
-		S           string
-		PtrS        *string
-		cantSet     string
-		DoesntExist string
-		GoT         time.Time
-		GoTptr      *time.Time
-		T           Timestamp
-		Tptr        *Timestamp
-		SA          StringArray
-	}
-	bindTestStructWithTags struct {
-		I           int      `json:"I" form:"I"`
-		PtrI        *int     `json:"PtrI" form:"PtrI"`
-		I8          int8     `json:"I8" form:"I8"`
-		PtrI8       *int8    `json:"PtrI8" form:"PtrI8"`
-		I16         int16    `json:"I16" form:"I16"`
-		PtrI16      *int16   `json:"PtrI16" form:"PtrI16"`
-		I32         int32    `json:"I32" form:"I32"`
-		PtrI32      *int32   `json:"PtrI32" form:"PtrI32"`
-		I64         int64    `json:"I64" form:"I64"`
-		PtrI64      *int64   `json:"PtrI64" form:"PtrI64"`
-		UI          uint     `json:"UI" form:"UI"`
-		PtrUI       *uint    `json:"PtrUI" form:"PtrUI"`
-		UI8         uint8    `json:"UI8" form:"UI8"`
-		PtrUI8      *uint8   `json:"PtrUI8" form:"PtrUI8"`
-		UI16        uint16   `json:"UI16" form:"UI16"`
-		PtrUI16     *uint16  `json:"PtrUI16" form:"PtrUI16"`
-		UI32        uint32   `json:"UI32" form:"UI32"`
-		PtrUI32     *uint32  `json:"PtrUI32" form:"PtrUI32"`
-		UI64        uint64   `json:"UI64" form:"UI64"`
-		PtrUI64     *uint64  `json:"PtrUI64" form:"PtrUI64"`
-		B           bool     `json:"B" form:"B"`
-		PtrB        *bool    `json:"PtrB" form:"PtrB"`
-		F32         float32  `json:"F32" form:"F32"`
-		PtrF32      *float32 `json:"PtrF32" form:"PtrF32"`
-		F64         float64  `json:"F64" form:"F64"`
-		PtrF64      *float64 `json:"PtrF64" form:"PtrF64"`
-		S           string   `json:"S" form:"S"`
-		PtrS        *string  `json:"PtrS" form:"PtrS"`
-		cantSet     string
-		DoesntExist string      `json:"DoesntExist" form:"DoesntExist"`
-		GoT         time.Time   `json:"GoT" form:"GoT"`
-		GoTptr      *time.Time  `json:"GoTptr" form:"GoTptr"`
-		T           Timestamp   `json:"T" form:"T"`
-		Tptr        *Timestamp  `json:"Tptr" form:"Tptr"`
-		SA          StringArray `json:"SA" form:"SA"`
-	}
-	Timestamp   time.Time
-	TA          []Timestamp
-	StringArray []string
-	Struct      struct {
-		Foo string
-	}
-	Bar struct {
-		Baz int `json:"baz" query:"baz"`
-	}
-)
+type bindTestStruct struct {
+	I           int
+	PtrI        *int
+	I8          int8
+	PtrI8       *int8
+	I16         int16
+	PtrI16      *int16
+	I32         int32
+	PtrI32      *int32
+	I64         int64
+	PtrI64      *int64
+	UI          uint
+	PtrUI       *uint
+	UI8         uint8
+	PtrUI8      *uint8
+	UI16        uint16
+	PtrUI16     *uint16
+	UI32        uint32
+	PtrUI32     *uint32
+	UI64        uint64
+	PtrUI64     *uint64
+	B           bool
+	PtrB        *bool
+	F32         float32
+	PtrF32      *float32
+	F64         float64
+	PtrF64      *float64
+	S           string
+	PtrS        *string
+	cantSet     string
+	DoesntExist string
+	GoT         time.Time
+	GoTptr      *time.Time
+	T           Timestamp
+	Tptr        *Timestamp
+	SA          StringArray
+}
+
+type bindTestStructWithTags struct {
+	I           int      `json:"I" form:"I"`
+	PtrI        *int     `json:"PtrI" form:"PtrI"`
+	I8          int8     `json:"I8" form:"I8"`
+	PtrI8       *int8    `json:"PtrI8" form:"PtrI8"`
+	I16         int16    `json:"I16" form:"I16"`
+	PtrI16      *int16   `json:"PtrI16" form:"PtrI16"`
+	I32         int32    `json:"I32" form:"I32"`
+	PtrI32      *int32   `json:"PtrI32" form:"PtrI32"`
+	I64         int64    `json:"I64" form:"I64"`
+	PtrI64      *int64   `json:"PtrI64" form:"PtrI64"`
+	UI          uint     `json:"UI" form:"UI"`
+	PtrUI       *uint    `json:"PtrUI" form:"PtrUI"`
+	UI8         uint8    `json:"UI8" form:"UI8"`
+	PtrUI8      *uint8   `json:"PtrUI8" form:"PtrUI8"`
+	UI16        uint16   `json:"UI16" form:"UI16"`
+	PtrUI16     *uint16  `json:"PtrUI16" form:"PtrUI16"`
+	UI32        uint32   `json:"UI32" form:"UI32"`
+	PtrUI32     *uint32  `json:"PtrUI32" form:"PtrUI32"`
+	UI64        uint64   `json:"UI64" form:"UI64"`
+	PtrUI64     *uint64  `json:"PtrUI64" form:"PtrUI64"`
+	B           bool     `json:"B" form:"B"`
+	PtrB        *bool    `json:"PtrB" form:"PtrB"`
+	F32         float32  `json:"F32" form:"F32"`
+	PtrF32      *float32 `json:"PtrF32" form:"PtrF32"`
+	F64         float64  `json:"F64" form:"F64"`
+	PtrF64      *float64 `json:"PtrF64" form:"PtrF64"`
+	S           string   `json:"S" form:"S"`
+	PtrS        *string  `json:"PtrS" form:"PtrS"`
+	cantSet     string
+	DoesntExist string      `json:"DoesntExist" form:"DoesntExist"`
+	GoT         time.Time   `json:"GoT" form:"GoT"`
+	GoTptr      *time.Time  `json:"GoTptr" form:"GoTptr"`
+	T           Timestamp   `json:"T" form:"T"`
+	Tptr        *Timestamp  `json:"Tptr" form:"Tptr"`
+	SA          StringArray `json:"SA" form:"SA"`
+}
+
+type Timestamp time.Time
+type TA []Timestamp
+type StringArray []string
+type Struct struct {
+	Foo string
+}
+type Bar struct {
+	Baz int `json:"baz" query:"baz"`
+}
 
 func (t *Timestamp) UnmarshalParam(src string) error {
 	ts, err := time.Parse(time.RFC3339, src)

--- a/context.go
+++ b/context.go
@@ -16,204 +16,202 @@ import (
 	"sync"
 )
 
-type (
-	// Context represents the context of the current HTTP request. It holds request and
-	// response objects, path, path parameters, data and registered handler.
-	Context interface {
-		// Request returns `*http.Request`.
-		Request() *http.Request
+// Context represents the context of the current HTTP request. It holds request and
+// response objects, path, path parameters, data and registered handler.
+type Context interface {
+	// Request returns `*http.Request`.
+	Request() *http.Request
 
-		// SetRequest sets `*http.Request`.
-		SetRequest(r *http.Request)
+	// SetRequest sets `*http.Request`.
+	SetRequest(r *http.Request)
 
-		// SetResponse sets `*Response`.
-		SetResponse(r *Response)
+	// SetResponse sets `*Response`.
+	SetResponse(r *Response)
 
-		// Response returns `*Response`.
-		Response() *Response
+	// Response returns `*Response`.
+	Response() *Response
 
-		// IsTLS returns true if HTTP connection is TLS otherwise false.
-		IsTLS() bool
+	// IsTLS returns true if HTTP connection is TLS otherwise false.
+	IsTLS() bool
 
-		// IsWebSocket returns true if HTTP connection is WebSocket otherwise false.
-		IsWebSocket() bool
+	// IsWebSocket returns true if HTTP connection is WebSocket otherwise false.
+	IsWebSocket() bool
 
-		// Scheme returns the HTTP protocol scheme, `http` or `https`.
-		Scheme() string
+	// Scheme returns the HTTP protocol scheme, `http` or `https`.
+	Scheme() string
 
-		// RealIP returns the client's network address based on `X-Forwarded-For`
-		// or `X-Real-IP` request header.
-		// The behavior can be configured using `Echo#IPExtractor`.
-		RealIP() string
+	// RealIP returns the client's network address based on `X-Forwarded-For`
+	// or `X-Real-IP` request header.
+	// The behavior can be configured using `Echo#IPExtractor`.
+	RealIP() string
 
-		// Path returns the registered path for the handler.
-		Path() string
+	// Path returns the registered path for the handler.
+	Path() string
 
-		// SetPath sets the registered path for the handler.
-		SetPath(p string)
+	// SetPath sets the registered path for the handler.
+	SetPath(p string)
 
-		// Param returns path parameter by name.
-		Param(name string) string
+	// Param returns path parameter by name.
+	Param(name string) string
 
-		// ParamNames returns path parameter names.
-		ParamNames() []string
+	// ParamNames returns path parameter names.
+	ParamNames() []string
 
-		// SetParamNames sets path parameter names.
-		SetParamNames(names ...string)
+	// SetParamNames sets path parameter names.
+	SetParamNames(names ...string)
 
-		// ParamValues returns path parameter values.
-		ParamValues() []string
+	// ParamValues returns path parameter values.
+	ParamValues() []string
 
-		// SetParamValues sets path parameter values.
-		SetParamValues(values ...string)
+	// SetParamValues sets path parameter values.
+	SetParamValues(values ...string)
 
-		// QueryParam returns the query param for the provided name.
-		QueryParam(name string) string
+	// QueryParam returns the query param for the provided name.
+	QueryParam(name string) string
 
-		// QueryParams returns the query parameters as `url.Values`.
-		QueryParams() url.Values
+	// QueryParams returns the query parameters as `url.Values`.
+	QueryParams() url.Values
 
-		// QueryString returns the URL query string.
-		QueryString() string
+	// QueryString returns the URL query string.
+	QueryString() string
 
-		// FormValue returns the form field value for the provided name.
-		FormValue(name string) string
+	// FormValue returns the form field value for the provided name.
+	FormValue(name string) string
 
-		// FormParams returns the form parameters as `url.Values`.
-		FormParams() (url.Values, error)
+	// FormParams returns the form parameters as `url.Values`.
+	FormParams() (url.Values, error)
 
-		// FormFile returns the multipart form file for the provided name.
-		FormFile(name string) (*multipart.FileHeader, error)
+	// FormFile returns the multipart form file for the provided name.
+	FormFile(name string) (*multipart.FileHeader, error)
 
-		// MultipartForm returns the multipart form.
-		MultipartForm() (*multipart.Form, error)
+	// MultipartForm returns the multipart form.
+	MultipartForm() (*multipart.Form, error)
 
-		// Cookie returns the named cookie provided in the request.
-		Cookie(name string) (*http.Cookie, error)
+	// Cookie returns the named cookie provided in the request.
+	Cookie(name string) (*http.Cookie, error)
 
-		// SetCookie adds a `Set-Cookie` header in HTTP response.
-		SetCookie(cookie *http.Cookie)
+	// SetCookie adds a `Set-Cookie` header in HTTP response.
+	SetCookie(cookie *http.Cookie)
 
-		// Cookies returns the HTTP cookies sent with the request.
-		Cookies() []*http.Cookie
+	// Cookies returns the HTTP cookies sent with the request.
+	Cookies() []*http.Cookie
 
-		// Get retrieves data from the context.
-		Get(key string) interface{}
+	// Get retrieves data from the context.
+	Get(key string) interface{}
 
-		// Set saves data in the context.
-		Set(key string, val interface{})
+	// Set saves data in the context.
+	Set(key string, val interface{})
 
-		// Bind binds path params, query params and the request body into provided type `i`. The default binder
-		// binds body based on Content-Type header.
-		Bind(i interface{}) error
+	// Bind binds path params, query params and the request body into provided type `i`. The default binder
+	// binds body based on Content-Type header.
+	Bind(i interface{}) error
 
-		// Validate validates provided `i`. It is usually called after `Context#Bind()`.
-		// Validator must be registered using `Echo#Validator`.
-		Validate(i interface{}) error
+	// Validate validates provided `i`. It is usually called after `Context#Bind()`.
+	// Validator must be registered using `Echo#Validator`.
+	Validate(i interface{}) error
 
-		// Render renders a template with data and sends a text/html response with status
-		// code. Renderer must be registered using `Echo.Renderer`.
-		Render(code int, name string, data interface{}) error
+	// Render renders a template with data and sends a text/html response with status
+	// code. Renderer must be registered using `Echo.Renderer`.
+	Render(code int, name string, data interface{}) error
 
-		// HTML sends an HTTP response with status code.
-		HTML(code int, html string) error
+	// HTML sends an HTTP response with status code.
+	HTML(code int, html string) error
 
-		// HTMLBlob sends an HTTP blob response with status code.
-		HTMLBlob(code int, b []byte) error
+	// HTMLBlob sends an HTTP blob response with status code.
+	HTMLBlob(code int, b []byte) error
 
-		// String sends a string response with status code.
-		String(code int, s string) error
+	// String sends a string response with status code.
+	String(code int, s string) error
 
-		// JSON sends a JSON response with status code.
-		JSON(code int, i interface{}) error
+	// JSON sends a JSON response with status code.
+	JSON(code int, i interface{}) error
 
-		// JSONPretty sends a pretty-print JSON with status code.
-		JSONPretty(code int, i interface{}, indent string) error
+	// JSONPretty sends a pretty-print JSON with status code.
+	JSONPretty(code int, i interface{}, indent string) error
 
-		// JSONBlob sends a JSON blob response with status code.
-		JSONBlob(code int, b []byte) error
+	// JSONBlob sends a JSON blob response with status code.
+	JSONBlob(code int, b []byte) error
 
-		// JSONP sends a JSONP response with status code. It uses `callback` to construct
-		// the JSONP payload.
-		JSONP(code int, callback string, i interface{}) error
+	// JSONP sends a JSONP response with status code. It uses `callback` to construct
+	// the JSONP payload.
+	JSONP(code int, callback string, i interface{}) error
 
-		// JSONPBlob sends a JSONP blob response with status code. It uses `callback`
-		// to construct the JSONP payload.
-		JSONPBlob(code int, callback string, b []byte) error
+	// JSONPBlob sends a JSONP blob response with status code. It uses `callback`
+	// to construct the JSONP payload.
+	JSONPBlob(code int, callback string, b []byte) error
 
-		// XML sends an XML response with status code.
-		XML(code int, i interface{}) error
+	// XML sends an XML response with status code.
+	XML(code int, i interface{}) error
 
-		// XMLPretty sends a pretty-print XML with status code.
-		XMLPretty(code int, i interface{}, indent string) error
+	// XMLPretty sends a pretty-print XML with status code.
+	XMLPretty(code int, i interface{}, indent string) error
 
-		// XMLBlob sends an XML blob response with status code.
-		XMLBlob(code int, b []byte) error
+	// XMLBlob sends an XML blob response with status code.
+	XMLBlob(code int, b []byte) error
 
-		// Blob sends a blob response with status code and content type.
-		Blob(code int, contentType string, b []byte) error
+	// Blob sends a blob response with status code and content type.
+	Blob(code int, contentType string, b []byte) error
 
-		// Stream sends a streaming response with status code and content type.
-		Stream(code int, contentType string, r io.Reader) error
+	// Stream sends a streaming response with status code and content type.
+	Stream(code int, contentType string, r io.Reader) error
 
-		// File sends a response with the content of the file.
-		File(file string) error
+	// File sends a response with the content of the file.
+	File(file string) error
 
-		// Attachment sends a response as attachment, prompting client to save the
-		// file.
-		Attachment(file string, name string) error
+	// Attachment sends a response as attachment, prompting client to save the
+	// file.
+	Attachment(file string, name string) error
 
-		// Inline sends a response as inline, opening the file in the browser.
-		Inline(file string, name string) error
+	// Inline sends a response as inline, opening the file in the browser.
+	Inline(file string, name string) error
 
-		// NoContent sends a response with no body and a status code.
-		NoContent(code int) error
+	// NoContent sends a response with no body and a status code.
+	NoContent(code int) error
 
-		// Redirect redirects the request to a provided URL with status code.
-		Redirect(code int, url string) error
+	// Redirect redirects the request to a provided URL with status code.
+	Redirect(code int, url string) error
 
-		// Error invokes the registered global HTTP error handler. Generally used by middleware.
-		// A side-effect of calling global error handler is that now Response has been committed (sent to the client) and
-		// middlewares up in chain can not change Response status code or Response body anymore.
-		//
-		// Avoid using this method in handlers as no middleware will be able to effectively handle errors after that.
-		Error(err error)
+	// Error invokes the registered global HTTP error handler. Generally used by middleware.
+	// A side-effect of calling global error handler is that now Response has been committed (sent to the client) and
+	// middlewares up in chain can not change Response status code or Response body anymore.
+	//
+	// Avoid using this method in handlers as no middleware will be able to effectively handle errors after that.
+	Error(err error)
 
-		// Handler returns the matched handler by router.
-		Handler() HandlerFunc
+	// Handler returns the matched handler by router.
+	Handler() HandlerFunc
 
-		// SetHandler sets the matched handler by router.
-		SetHandler(h HandlerFunc)
+	// SetHandler sets the matched handler by router.
+	SetHandler(h HandlerFunc)
 
-		// Logger returns the `Logger` instance.
-		Logger() Logger
+	// Logger returns the `Logger` instance.
+	Logger() Logger
 
-		// SetLogger Set the logger
-		SetLogger(l Logger)
+	// SetLogger Set the logger
+	SetLogger(l Logger)
 
-		// Echo returns the `Echo` instance.
-		Echo() *Echo
+	// Echo returns the `Echo` instance.
+	Echo() *Echo
 
-		// Reset resets the context after request completes. It must be called along
-		// with `Echo#AcquireContext()` and `Echo#ReleaseContext()`.
-		// See `Echo#ServeHTTP()`
-		Reset(r *http.Request, w http.ResponseWriter)
-	}
+	// Reset resets the context after request completes. It must be called along
+	// with `Echo#AcquireContext()` and `Echo#ReleaseContext()`.
+	// See `Echo#ServeHTTP()`
+	Reset(r *http.Request, w http.ResponseWriter)
+}
 
-	context struct {
-		request  *http.Request
-		response *Response
-		path     string
-		pnames   []string
-		pvalues  []string
-		query    url.Values
-		handler  HandlerFunc
-		store    Map
-		echo     *Echo
-		logger   Logger
-		lock     sync.RWMutex
-	}
-)
+type context struct {
+	request  *http.Request
+	response *Response
+	path     string
+	pnames   []string
+	pvalues  []string
+	query    url.Values
+	handler  HandlerFunc
+	store    Map
+	echo     *Echo
+	logger   Logger
+	lock     sync.RWMutex
+}
 
 const (
 	// ContextKeyHeaderAllow is set by Router for getting value for `Allow` header in later stages of handler call chain.

--- a/context_test.go
+++ b/context_test.go
@@ -25,11 +25,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type (
-	Template struct {
-		templates *template.Template
-	}
-)
+type Template struct {
+	templates *template.Template
+}
 
 var testUser = user{1, "Jon Snow"}
 

--- a/echo.go
+++ b/echo.go
@@ -63,97 +63,95 @@ import (
 	"golang.org/x/net/http2/h2c"
 )
 
-type (
-	// Echo is the top-level framework instance.
-	//
-	// Goroutine safety: Do not mutate Echo instance fields after server has started. Accessing these
-	// fields from handlers/middlewares and changing field values at the same time leads to data-races.
-	// Adding new routes after the server has been started is also not safe!
-	Echo struct {
-		filesystem
-		common
-		// startupMutex is mutex to lock Echo instance access during server configuration and startup. Useful for to get
-		// listener address info (on which interface/port was listener bound) without having data races.
-		startupMutex sync.RWMutex
-		colorer      *color.Color
+// Echo is the top-level framework instance.
+//
+// Goroutine safety: Do not mutate Echo instance fields after server has started. Accessing these
+// fields from handlers/middlewares and changing field values at the same time leads to data-races.
+// Adding new routes after the server has been started is also not safe!
+type Echo struct {
+	filesystem
+	common
+	// startupMutex is mutex to lock Echo instance access during server configuration and startup. Useful for to get
+	// listener address info (on which interface/port was listener bound) without having data races.
+	startupMutex sync.RWMutex
+	colorer      *color.Color
 
-		// premiddleware are middlewares that are run before routing is done. In case a pre-middleware returns
-		// an error the router is not executed and the request will end up in the global error handler.
-		premiddleware []MiddlewareFunc
-		middleware    []MiddlewareFunc
-		maxParam      *int
-		router        *Router
-		routers       map[string]*Router
-		pool          sync.Pool
+	// premiddleware are middlewares that are run before routing is done. In case a pre-middleware returns
+	// an error the router is not executed and the request will end up in the global error handler.
+	premiddleware []MiddlewareFunc
+	middleware    []MiddlewareFunc
+	maxParam      *int
+	router        *Router
+	routers       map[string]*Router
+	pool          sync.Pool
 
-		StdLogger        *stdLog.Logger
-		Server           *http.Server
-		TLSServer        *http.Server
-		Listener         net.Listener
-		TLSListener      net.Listener
-		AutoTLSManager   autocert.Manager
-		DisableHTTP2     bool
-		Debug            bool
-		HideBanner       bool
-		HidePort         bool
-		HTTPErrorHandler HTTPErrorHandler
-		Binder           Binder
-		JSONSerializer   JSONSerializer
-		Validator        Validator
-		Renderer         Renderer
-		Logger           Logger
-		IPExtractor      IPExtractor
-		ListenerNetwork  string
+	StdLogger        *stdLog.Logger
+	Server           *http.Server
+	TLSServer        *http.Server
+	Listener         net.Listener
+	TLSListener      net.Listener
+	AutoTLSManager   autocert.Manager
+	DisableHTTP2     bool
+	Debug            bool
+	HideBanner       bool
+	HidePort         bool
+	HTTPErrorHandler HTTPErrorHandler
+	Binder           Binder
+	JSONSerializer   JSONSerializer
+	Validator        Validator
+	Renderer         Renderer
+	Logger           Logger
+	IPExtractor      IPExtractor
+	ListenerNetwork  string
 
-		// OnAddRouteHandler is called when Echo adds new route to specific host router.
-		OnAddRouteHandler func(host string, route Route, handler HandlerFunc, middleware []MiddlewareFunc)
-	}
+	// OnAddRouteHandler is called when Echo adds new route to specific host router.
+	OnAddRouteHandler func(host string, route Route, handler HandlerFunc, middleware []MiddlewareFunc)
+}
 
-	// Route contains a handler and information for matching against requests.
-	Route struct {
-		Method string `json:"method"`
-		Path   string `json:"path"`
-		Name   string `json:"name"`
-	}
+// Route contains a handler and information for matching against requests.
+type Route struct {
+	Method string `json:"method"`
+	Path   string `json:"path"`
+	Name   string `json:"name"`
+}
 
-	// HTTPError represents an error that occurred while handling a request.
-	HTTPError struct {
-		Code     int         `json:"-"`
-		Message  interface{} `json:"message"`
-		Internal error       `json:"-"` // Stores the error returned by an external dependency
-	}
+// HTTPError represents an error that occurred while handling a request.
+type HTTPError struct {
+	Code     int         `json:"-"`
+	Message  interface{} `json:"message"`
+	Internal error       `json:"-"` // Stores the error returned by an external dependency
+}
 
-	// MiddlewareFunc defines a function to process middleware.
-	MiddlewareFunc func(next HandlerFunc) HandlerFunc
+// MiddlewareFunc defines a function to process middleware.
+type MiddlewareFunc func(next HandlerFunc) HandlerFunc
 
-	// HandlerFunc defines a function to serve HTTP requests.
-	HandlerFunc func(c Context) error
+// HandlerFunc defines a function to serve HTTP requests.
+type HandlerFunc func(c Context) error
 
-	// HTTPErrorHandler is a centralized HTTP error handler.
-	HTTPErrorHandler func(err error, c Context)
+// HTTPErrorHandler is a centralized HTTP error handler.
+type HTTPErrorHandler func(err error, c Context)
 
-	// Validator is the interface that wraps the Validate function.
-	Validator interface {
-		Validate(i interface{}) error
-	}
+// Validator is the interface that wraps the Validate function.
+type Validator interface {
+	Validate(i interface{}) error
+}
 
-	// JSONSerializer is the interface that encodes and decodes JSON to and from interfaces.
-	JSONSerializer interface {
-		Serialize(c Context, i interface{}, indent string) error
-		Deserialize(c Context, i interface{}) error
-	}
+// JSONSerializer is the interface that encodes and decodes JSON to and from interfaces.
+type JSONSerializer interface {
+	Serialize(c Context, i interface{}, indent string) error
+	Deserialize(c Context, i interface{}) error
+}
 
-	// Renderer is the interface that wraps the Render function.
-	Renderer interface {
-		Render(io.Writer, string, interface{}, Context) error
-	}
+// Renderer is the interface that wraps the Render function.
+type Renderer interface {
+	Render(io.Writer, string, interface{}, Context) error
+}
 
-	// Map defines a generic map of type `map[string]interface{}`.
-	Map map[string]interface{}
+// Map defines a generic map of type `map[string]interface{}`.
+type Map map[string]interface{}
 
-	// Common struct for Echo & Group.
-	common struct{}
-)
+// Common struct for Echo & Group.
+type common struct{}
 
 // HTTP methods
 // NOTE: Deprecated, please use the stdlib constants directly instead.
@@ -282,21 +280,19 @@ ____________________________________O/_______
 `
 )
 
-var (
-	methods = [...]string{
-		http.MethodConnect,
-		http.MethodDelete,
-		http.MethodGet,
-		http.MethodHead,
-		http.MethodOptions,
-		http.MethodPatch,
-		http.MethodPost,
-		PROPFIND,
-		http.MethodPut,
-		http.MethodTrace,
-		REPORT,
-	}
-)
+var methods = [...]string{
+	http.MethodConnect,
+	http.MethodDelete,
+	http.MethodGet,
+	http.MethodHead,
+	http.MethodOptions,
+	http.MethodPatch,
+	http.MethodPost,
+	PROPFIND,
+	http.MethodPut,
+	http.MethodTrace,
+	REPORT,
+}
 
 // Errors
 var (
@@ -349,22 +345,23 @@ var (
 	ErrInvalidListenerNetwork = errors.New("invalid listener network")
 )
 
-// Error handlers
-var (
-	NotFoundHandler = func(c Context) error {
-		return ErrNotFound
-	}
+// NotFoundHandler is the handler that router uses in case there was no matching route found. Returns an error that results
+// HTTP 404 status code.
+var NotFoundHandler = func(c Context) error {
+	return ErrNotFound
+}
 
-	MethodNotAllowedHandler = func(c Context) error {
-		// See RFC 7231 section 7.4.1: An origin server MUST generate an Allow field in a 405 (Method Not Allowed)
-		// response and MAY do so in any other response. For disabled resources an empty Allow header may be returned
-		routerAllowMethods, ok := c.Get(ContextKeyHeaderAllow).(string)
-		if ok && routerAllowMethods != "" {
-			c.Response().Header().Set(HeaderAllow, routerAllowMethods)
-		}
-		return ErrMethodNotAllowed
+// MethodNotAllowedHandler is the handler thar router uses in case there was no matching route found but there was
+// another matching routes for that requested URL. Returns an error that results HTTP 405 Method Not Allowed status code.
+var MethodNotAllowedHandler = func(c Context) error {
+	// See RFC 7231 section 7.4.1: An origin server MUST generate an Allow field in a 405 (Method Not Allowed)
+	// response and MAY do so in any other response. For disabled resources an empty Allow header may be returned
+	routerAllowMethods, ok := c.Get(ContextKeyHeaderAllow).(string)
+	if ok && routerAllowMethods != "" {
+		c.Response().Header().Set(HeaderAllow, routerAllowMethods)
 	}
-)
+	return ErrMethodNotAllowed
+}
 
 // New creates an instance of Echo.
 func New() (e *Echo) {

--- a/echo_test.go
+++ b/echo_test.go
@@ -25,12 +25,10 @@ import (
 	"golang.org/x/net/http2"
 )
 
-type (
-	user struct {
-		ID   int    `json:"id" xml:"id" form:"id" query:"id" param:"id" header:"id"`
-		Name string `json:"name" xml:"name" form:"name" query:"name" param:"name" header:"name"`
-	}
-)
+type user struct {
+	ID   int    `json:"id" xml:"id" form:"id" query:"id" param:"id" header:"id"`
+	Name string `json:"name" xml:"name" form:"name" query:"name" param:"name" header:"name"`
+}
 
 const (
 	userJSON                    = `{"id":1,"name":"Jon Snow"}`

--- a/group.go
+++ b/group.go
@@ -7,18 +7,16 @@ import (
 	"net/http"
 )
 
-type (
-	// Group is a set of sub-routes for a specified route. It can be used for inner
-	// routes that share a common middleware or functionality that should be separate
-	// from the parent echo instance while still inheriting from it.
-	Group struct {
-		common
-		host       string
-		prefix     string
-		middleware []MiddlewareFunc
-		echo       *Echo
-	}
-)
+// Group is a set of sub-routes for a specified route. It can be used for inner
+// routes that share a common middleware or functionality that should be separate
+// from the parent echo instance while still inheriting from it.
+type Group struct {
+	common
+	host       string
+	prefix     string
+	middleware []MiddlewareFunc
+	echo       *Echo
+}
 
 // Use implements `Echo#Use()` for sub-routes within the Group.
 func (g *Group) Use(middleware ...MiddlewareFunc) {

--- a/log.go
+++ b/log.go
@@ -4,41 +4,38 @@
 package echo
 
 import (
-	"io"
-
 	"github.com/labstack/gommon/log"
+	"io"
 )
 
-type (
-	// Logger defines the logging interface.
-	Logger interface {
-		Output() io.Writer
-		SetOutput(w io.Writer)
-		Prefix() string
-		SetPrefix(p string)
-		Level() log.Lvl
-		SetLevel(v log.Lvl)
-		SetHeader(h string)
-		Print(i ...interface{})
-		Printf(format string, args ...interface{})
-		Printj(j log.JSON)
-		Debug(i ...interface{})
-		Debugf(format string, args ...interface{})
-		Debugj(j log.JSON)
-		Info(i ...interface{})
-		Infof(format string, args ...interface{})
-		Infoj(j log.JSON)
-		Warn(i ...interface{})
-		Warnf(format string, args ...interface{})
-		Warnj(j log.JSON)
-		Error(i ...interface{})
-		Errorf(format string, args ...interface{})
-		Errorj(j log.JSON)
-		Fatal(i ...interface{})
-		Fatalj(j log.JSON)
-		Fatalf(format string, args ...interface{})
-		Panic(i ...interface{})
-		Panicj(j log.JSON)
-		Panicf(format string, args ...interface{})
-	}
-)
+// Logger defines the logging interface.
+type Logger interface {
+	Output() io.Writer
+	SetOutput(w io.Writer)
+	Prefix() string
+	SetPrefix(p string)
+	Level() log.Lvl
+	SetLevel(v log.Lvl)
+	SetHeader(h string)
+	Print(i ...interface{})
+	Printf(format string, args ...interface{})
+	Printj(j log.JSON)
+	Debug(i ...interface{})
+	Debugf(format string, args ...interface{})
+	Debugj(j log.JSON)
+	Info(i ...interface{})
+	Infof(format string, args ...interface{})
+	Infoj(j log.JSON)
+	Warn(i ...interface{})
+	Warnf(format string, args ...interface{})
+	Warnj(j log.JSON)
+	Error(i ...interface{})
+	Errorf(format string, args ...interface{})
+	Errorj(j log.JSON)
+	Fatal(i ...interface{})
+	Fatalj(j log.JSON)
+	Fatalf(format string, args ...interface{})
+	Panic(i ...interface{})
+	Panicj(j log.JSON)
+	Panicf(format string, args ...interface{})
+}

--- a/middleware/basic_auth.go
+++ b/middleware/basic_auth.go
@@ -12,39 +12,35 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-type (
-	// BasicAuthConfig defines the config for BasicAuth middleware.
-	BasicAuthConfig struct {
-		// Skipper defines a function to skip middleware.
-		Skipper Skipper
+// BasicAuthConfig defines the config for BasicAuth middleware.
+type BasicAuthConfig struct {
+	// Skipper defines a function to skip middleware.
+	Skipper Skipper
 
-		// Validator is a function to validate BasicAuth credentials.
-		// Required.
-		Validator BasicAuthValidator
+	// Validator is a function to validate BasicAuth credentials.
+	// Required.
+	Validator BasicAuthValidator
 
-		// Realm is a string to define realm attribute of BasicAuth.
-		// Default value "Restricted".
-		Realm string
-	}
+	// Realm is a string to define realm attribute of BasicAuth.
+	// Default value "Restricted".
+	Realm string
+}
 
-	// BasicAuthValidator defines a function to validate BasicAuth credentials.
-	// The function should return a boolean indicating whether the credentials are valid,
-	// and an error if any error occurs during the validation process.
-	BasicAuthValidator func(string, string, echo.Context) (bool, error)
-)
+// BasicAuthValidator defines a function to validate BasicAuth credentials.
+// The function should return a boolean indicating whether the credentials are valid,
+// and an error if any error occurs during the validation process.
+type BasicAuthValidator func(string, string, echo.Context) (bool, error)
 
 const (
 	basic        = "basic"
 	defaultRealm = "Restricted"
 )
 
-var (
-	// DefaultBasicAuthConfig is the default BasicAuth middleware config.
-	DefaultBasicAuthConfig = BasicAuthConfig{
-		Skipper: DefaultSkipper,
-		Realm:   defaultRealm,
-	}
-)
+// DefaultBasicAuthConfig is the default BasicAuth middleware config.
+var DefaultBasicAuthConfig = BasicAuthConfig{
+	Skipper: DefaultSkipper,
+	Realm:   defaultRealm,
+}
 
 // BasicAuth returns an BasicAuth middleware.
 //

--- a/middleware/body_dump.go
+++ b/middleware/body_dump.go
@@ -14,32 +14,28 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-type (
-	// BodyDumpConfig defines the config for BodyDump middleware.
-	BodyDumpConfig struct {
-		// Skipper defines a function to skip middleware.
-		Skipper Skipper
+// BodyDumpConfig defines the config for BodyDump middleware.
+type BodyDumpConfig struct {
+	// Skipper defines a function to skip middleware.
+	Skipper Skipper
 
-		// Handler receives request and response payload.
-		// Required.
-		Handler BodyDumpHandler
-	}
+	// Handler receives request and response payload.
+	// Required.
+	Handler BodyDumpHandler
+}
 
-	// BodyDumpHandler receives the request and response payload.
-	BodyDumpHandler func(echo.Context, []byte, []byte)
+// BodyDumpHandler receives the request and response payload.
+type BodyDumpHandler func(echo.Context, []byte, []byte)
 
-	bodyDumpResponseWriter struct {
-		io.Writer
-		http.ResponseWriter
-	}
-)
+type bodyDumpResponseWriter struct {
+	io.Writer
+	http.ResponseWriter
+}
 
-var (
-	// DefaultBodyDumpConfig is the default BodyDump middleware config.
-	DefaultBodyDumpConfig = BodyDumpConfig{
-		Skipper: DefaultSkipper,
-	}
-)
+// DefaultBodyDumpConfig is the default BodyDump middleware config.
+var DefaultBodyDumpConfig = BodyDumpConfig{
+	Skipper: DefaultSkipper,
+}
 
 // BodyDump returns a BodyDump middleware.
 //

--- a/middleware/body_limit.go
+++ b/middleware/body_limit.go
@@ -12,31 +12,27 @@ import (
 	"github.com/labstack/gommon/bytes"
 )
 
-type (
-	// BodyLimitConfig defines the config for BodyLimit middleware.
-	BodyLimitConfig struct {
-		// Skipper defines a function to skip middleware.
-		Skipper Skipper
+// BodyLimitConfig defines the config for BodyLimit middleware.
+type BodyLimitConfig struct {
+	// Skipper defines a function to skip middleware.
+	Skipper Skipper
 
-		// Maximum allowed size for a request body, it can be specified
-		// as `4x` or `4xB`, where x is one of the multiple from K, M, G, T or P.
-		Limit string `yaml:"limit"`
-		limit int64
-	}
+	// Maximum allowed size for a request body, it can be specified
+	// as `4x` or `4xB`, where x is one of the multiple from K, M, G, T or P.
+	Limit string `yaml:"limit"`
+	limit int64
+}
 
-	limitedReader struct {
-		BodyLimitConfig
-		reader io.ReadCloser
-		read   int64
-	}
-)
+type limitedReader struct {
+	BodyLimitConfig
+	reader io.ReadCloser
+	read   int64
+}
 
-var (
-	// DefaultBodyLimitConfig is the default BodyLimit middleware config.
-	DefaultBodyLimitConfig = BodyLimitConfig{
-		Skipper: DefaultSkipper,
-	}
-)
+// DefaultBodyLimitConfig is the default BodyLimit middleware config.
+var DefaultBodyLimitConfig = BodyLimitConfig{
+	Skipper: DefaultSkipper,
+}
 
 // BodyLimit returns a BodyLimit middleware.
 //

--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -16,54 +16,50 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-type (
-	// GzipConfig defines the config for Gzip middleware.
-	GzipConfig struct {
-		// Skipper defines a function to skip middleware.
-		Skipper Skipper
+// GzipConfig defines the config for Gzip middleware.
+type GzipConfig struct {
+	// Skipper defines a function to skip middleware.
+	Skipper Skipper
 
-		// Gzip compression level.
-		// Optional. Default value -1.
-		Level int `yaml:"level"`
+	// Gzip compression level.
+	// Optional. Default value -1.
+	Level int `yaml:"level"`
 
-		// Length threshold before gzip compression is applied.
-		// Optional. Default value 0.
-		//
-		// Most of the time you will not need to change the default. Compressing
-		// a short response might increase the transmitted data because of the
-		// gzip format overhead. Compressing the response will also consume CPU
-		// and time on the server and the client (for decompressing). Depending on
-		// your use case such a threshold might be useful.
-		//
-		// See also:
-		// https://webmasters.stackexchange.com/questions/31750/what-is-recommended-minimum-object-size-for-gzip-performance-benefits
-		MinLength int
-	}
+	// Length threshold before gzip compression is applied.
+	// Optional. Default value 0.
+	//
+	// Most of the time you will not need to change the default. Compressing
+	// a short response might increase the transmitted data because of the
+	// gzip format overhead. Compressing the response will also consume CPU
+	// and time on the server and the client (for decompressing). Depending on
+	// your use case such a threshold might be useful.
+	//
+	// See also:
+	// https://webmasters.stackexchange.com/questions/31750/what-is-recommended-minimum-object-size-for-gzip-performance-benefits
+	MinLength int
+}
 
-	gzipResponseWriter struct {
-		io.Writer
-		http.ResponseWriter
-		wroteHeader       bool
-		wroteBody         bool
-		minLength         int
-		minLengthExceeded bool
-		buffer            *bytes.Buffer
-		code              int
-	}
-)
+type gzipResponseWriter struct {
+	io.Writer
+	http.ResponseWriter
+	wroteHeader       bool
+	wroteBody         bool
+	minLength         int
+	minLengthExceeded bool
+	buffer            *bytes.Buffer
+	code              int
+}
 
 const (
 	gzipScheme = "gzip"
 )
 
-var (
-	// DefaultGzipConfig is the default Gzip middleware config.
-	DefaultGzipConfig = GzipConfig{
-		Skipper:   DefaultSkipper,
-		Level:     -1,
-		MinLength: 0,
-	}
-)
+// DefaultGzipConfig is the default Gzip middleware config.
+var DefaultGzipConfig = GzipConfig{
+	Skipper:   DefaultSkipper,
+	Level:     -1,
+	MinLength: 0,
+}
 
 // Gzip returns a middleware which compresses HTTP response using gzip compression
 // scheme.

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -12,113 +12,109 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-type (
-	// CORSConfig defines the config for CORS middleware.
-	CORSConfig struct {
-		// Skipper defines a function to skip middleware.
-		Skipper Skipper
+// CORSConfig defines the config for CORS middleware.
+type CORSConfig struct {
+	// Skipper defines a function to skip middleware.
+	Skipper Skipper
 
-		// AllowOrigins determines the value of the Access-Control-Allow-Origin
-		// response header.  This header defines a list of origins that may access the
-		// resource.  The wildcard characters '*' and '?' are supported and are
-		// converted to regex fragments '.*' and '.' accordingly.
-		//
-		// Security: use extreme caution when handling the origin, and carefully
-		// validate any logic. Remember that attackers may register hostile domain names.
-		// See https://blog.portswigger.net/2016/10/exploiting-cors-misconfigurations-for.html
-		//
-		// Optional. Default value []string{"*"}.
-		//
-		// See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
-		AllowOrigins []string `yaml:"allow_origins"`
+	// AllowOrigins determines the value of the Access-Control-Allow-Origin
+	// response header.  This header defines a list of origins that may access the
+	// resource.  The wildcard characters '*' and '?' are supported and are
+	// converted to regex fragments '.*' and '.' accordingly.
+	//
+	// Security: use extreme caution when handling the origin, and carefully
+	// validate any logic. Remember that attackers may register hostile domain names.
+	// See https://blog.portswigger.net/2016/10/exploiting-cors-misconfigurations-for.html
+	//
+	// Optional. Default value []string{"*"}.
+	//
+	// See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
+	AllowOrigins []string `yaml:"allow_origins"`
 
-		// AllowOriginFunc is a custom function to validate the origin. It takes the
-		// origin as an argument and returns true if allowed or false otherwise. If
-		// an error is returned, it is returned by the handler. If this option is
-		// set, AllowOrigins is ignored.
-		//
-		// Security: use extreme caution when handling the origin, and carefully
-		// validate any logic. Remember that attackers may register hostile domain names.
-		// See https://blog.portswigger.net/2016/10/exploiting-cors-misconfigurations-for.html
-		//
-		// Optional.
-		AllowOriginFunc func(origin string) (bool, error) `yaml:"-"`
+	// AllowOriginFunc is a custom function to validate the origin. It takes the
+	// origin as an argument and returns true if allowed or false otherwise. If
+	// an error is returned, it is returned by the handler. If this option is
+	// set, AllowOrigins is ignored.
+	//
+	// Security: use extreme caution when handling the origin, and carefully
+	// validate any logic. Remember that attackers may register hostile domain names.
+	// See https://blog.portswigger.net/2016/10/exploiting-cors-misconfigurations-for.html
+	//
+	// Optional.
+	AllowOriginFunc func(origin string) (bool, error) `yaml:"-"`
 
-		// AllowMethods determines the value of the Access-Control-Allow-Methods
-		// response header.  This header specified the list of methods allowed when
-		// accessing the resource.  This is used in response to a preflight request.
-		//
-		// Optional. Default value DefaultCORSConfig.AllowMethods.
-		// If `allowMethods` is left empty, this middleware will fill for preflight
-		// request `Access-Control-Allow-Methods` header value
-		// from `Allow` header that echo.Router set into context.
-		//
-		// See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods
-		AllowMethods []string `yaml:"allow_methods"`
+	// AllowMethods determines the value of the Access-Control-Allow-Methods
+	// response header.  This header specified the list of methods allowed when
+	// accessing the resource.  This is used in response to a preflight request.
+	//
+	// Optional. Default value DefaultCORSConfig.AllowMethods.
+	// If `allowMethods` is left empty, this middleware will fill for preflight
+	// request `Access-Control-Allow-Methods` header value
+	// from `Allow` header that echo.Router set into context.
+	//
+	// See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods
+	AllowMethods []string `yaml:"allow_methods"`
 
-		// AllowHeaders determines the value of the Access-Control-Allow-Headers
-		// response header.  This header is used in response to a preflight request to
-		// indicate which HTTP headers can be used when making the actual request.
-		//
-		// Optional. Default value []string{}.
-		//
-		// See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
-		AllowHeaders []string `yaml:"allow_headers"`
+	// AllowHeaders determines the value of the Access-Control-Allow-Headers
+	// response header.  This header is used in response to a preflight request to
+	// indicate which HTTP headers can be used when making the actual request.
+	//
+	// Optional. Default value []string{}.
+	//
+	// See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
+	AllowHeaders []string `yaml:"allow_headers"`
 
-		// AllowCredentials determines the value of the
-		// Access-Control-Allow-Credentials response header.  This header indicates
-		// whether or not the response to the request can be exposed when the
-		// credentials mode (Request.credentials) is true. When used as part of a
-		// response to a preflight request, this indicates whether or not the actual
-		// request can be made using credentials.  See also
-		// [MDN: Access-Control-Allow-Credentials].
-		//
-		// Optional. Default value false, in which case the header is not set.
-		//
-		// Security: avoid using `AllowCredentials = true` with `AllowOrigins = *`.
-		// See "Exploiting CORS misconfigurations for Bitcoins and bounties",
-		// https://blog.portswigger.net/2016/10/exploiting-cors-misconfigurations-for.html
-		//
-		// See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials
-		AllowCredentials bool `yaml:"allow_credentials"`
+	// AllowCredentials determines the value of the
+	// Access-Control-Allow-Credentials response header.  This header indicates
+	// whether or not the response to the request can be exposed when the
+	// credentials mode (Request.credentials) is true. When used as part of a
+	// response to a preflight request, this indicates whether or not the actual
+	// request can be made using credentials.  See also
+	// [MDN: Access-Control-Allow-Credentials].
+	//
+	// Optional. Default value false, in which case the header is not set.
+	//
+	// Security: avoid using `AllowCredentials = true` with `AllowOrigins = *`.
+	// See "Exploiting CORS misconfigurations for Bitcoins and bounties",
+	// https://blog.portswigger.net/2016/10/exploiting-cors-misconfigurations-for.html
+	//
+	// See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials
+	AllowCredentials bool `yaml:"allow_credentials"`
 
-		// UnsafeWildcardOriginWithAllowCredentials UNSAFE/INSECURE: allows wildcard '*' origin to be used with AllowCredentials
-		// flag. In that case we consider any origin allowed and send it back to the client with `Access-Control-Allow-Origin` header.
-		//
-		// This is INSECURE and potentially leads to [cross-origin](https://portswigger.net/research/exploiting-cors-misconfigurations-for-bitcoins-and-bounties)
-		// attacks. See: https://github.com/labstack/echo/issues/2400 for discussion on the subject.
-		//
-		// Optional. Default value is false.
-		UnsafeWildcardOriginWithAllowCredentials bool `yaml:"unsafe_wildcard_origin_with_allow_credentials"`
+	// UnsafeWildcardOriginWithAllowCredentials UNSAFE/INSECURE: allows wildcard '*' origin to be used with AllowCredentials
+	// flag. In that case we consider any origin allowed and send it back to the client with `Access-Control-Allow-Origin` header.
+	//
+	// This is INSECURE and potentially leads to [cross-origin](https://portswigger.net/research/exploiting-cors-misconfigurations-for-bitcoins-and-bounties)
+	// attacks. See: https://github.com/labstack/echo/issues/2400 for discussion on the subject.
+	//
+	// Optional. Default value is false.
+	UnsafeWildcardOriginWithAllowCredentials bool `yaml:"unsafe_wildcard_origin_with_allow_credentials"`
 
-		// ExposeHeaders determines the value of Access-Control-Expose-Headers, which
-		// defines a list of headers that clients are allowed to access.
-		//
-		// Optional. Default value []string{}, in which case the header is not set.
-		//
-		// See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Header
-		ExposeHeaders []string `yaml:"expose_headers"`
+	// ExposeHeaders determines the value of Access-Control-Expose-Headers, which
+	// defines a list of headers that clients are allowed to access.
+	//
+	// Optional. Default value []string{}, in which case the header is not set.
+	//
+	// See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Header
+	ExposeHeaders []string `yaml:"expose_headers"`
 
-		// MaxAge determines the value of the Access-Control-Max-Age response header.
-		// This header indicates how long (in seconds) the results of a preflight
-		// request can be cached.
-		// The header is set only if MaxAge != 0, negative value sends "0" which instructs browsers not to cache that response.
-		//
-		// Optional. Default value 0 - meaning header is not sent.
-		//
-		// See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
-		MaxAge int `yaml:"max_age"`
-	}
-)
+	// MaxAge determines the value of the Access-Control-Max-Age response header.
+	// This header indicates how long (in seconds) the results of a preflight
+	// request can be cached.
+	// The header is set only if MaxAge != 0, negative value sends "0" which instructs browsers not to cache that response.
+	//
+	// Optional. Default value 0 - meaning header is not sent.
+	//
+	// See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
+	MaxAge int `yaml:"max_age"`
+}
 
-var (
-	// DefaultCORSConfig is the default CORS middleware config.
-	DefaultCORSConfig = CORSConfig{
-		Skipper:      DefaultSkipper,
-		AllowOrigins: []string{"*"},
-		AllowMethods: []string{http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPatch, http.MethodPost, http.MethodDelete},
-	}
-)
+// DefaultCORSConfig is the default CORS middleware config.
+var DefaultCORSConfig = CORSConfig{
+	Skipper:      DefaultSkipper,
+	AllowOrigins: []string{"*"},
+	AllowMethods: []string{http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPatch, http.MethodPost, http.MethodDelete},
+}
 
 // CORS returns a Cross-Origin Resource Sharing (CORS) middleware.
 // See also [MDN: Cross-Origin Resource Sharing (CORS)].

--- a/middleware/csrf.go
+++ b/middleware/csrf.go
@@ -11,82 +11,78 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-type (
-	// CSRFConfig defines the config for CSRF middleware.
-	CSRFConfig struct {
-		// Skipper defines a function to skip middleware.
-		Skipper Skipper
+// CSRFConfig defines the config for CSRF middleware.
+type CSRFConfig struct {
+	// Skipper defines a function to skip middleware.
+	Skipper Skipper
 
-		// TokenLength is the length of the generated token.
-		TokenLength uint8 `yaml:"token_length"`
-		// Optional. Default value 32.
+	// TokenLength is the length of the generated token.
+	TokenLength uint8 `yaml:"token_length"`
+	// Optional. Default value 32.
 
-		// TokenLookup is a string in the form of "<source>:<name>" or "<source>:<name>,<source>:<name>" that is used
-		// to extract token from the request.
-		// Optional. Default value "header:X-CSRF-Token".
-		// Possible values:
-		// - "header:<name>" or "header:<name>:<cut-prefix>"
-		// - "query:<name>"
-		// - "form:<name>"
-		// Multiple sources example:
-		// - "header:X-CSRF-Token,query:csrf"
-		TokenLookup string `yaml:"token_lookup"`
+	// TokenLookup is a string in the form of "<source>:<name>" or "<source>:<name>,<source>:<name>" that is used
+	// to extract token from the request.
+	// Optional. Default value "header:X-CSRF-Token".
+	// Possible values:
+	// - "header:<name>" or "header:<name>:<cut-prefix>"
+	// - "query:<name>"
+	// - "form:<name>"
+	// Multiple sources example:
+	// - "header:X-CSRF-Token,query:csrf"
+	TokenLookup string `yaml:"token_lookup"`
 
-		// Context key to store generated CSRF token into context.
-		// Optional. Default value "csrf".
-		ContextKey string `yaml:"context_key"`
+	// Context key to store generated CSRF token into context.
+	// Optional. Default value "csrf".
+	ContextKey string `yaml:"context_key"`
 
-		// Name of the CSRF cookie. This cookie will store CSRF token.
-		// Optional. Default value "csrf".
-		CookieName string `yaml:"cookie_name"`
+	// Name of the CSRF cookie. This cookie will store CSRF token.
+	// Optional. Default value "csrf".
+	CookieName string `yaml:"cookie_name"`
 
-		// Domain of the CSRF cookie.
-		// Optional. Default value none.
-		CookieDomain string `yaml:"cookie_domain"`
+	// Domain of the CSRF cookie.
+	// Optional. Default value none.
+	CookieDomain string `yaml:"cookie_domain"`
 
-		// Path of the CSRF cookie.
-		// Optional. Default value none.
-		CookiePath string `yaml:"cookie_path"`
+	// Path of the CSRF cookie.
+	// Optional. Default value none.
+	CookiePath string `yaml:"cookie_path"`
 
-		// Max age (in seconds) of the CSRF cookie.
-		// Optional. Default value 86400 (24hr).
-		CookieMaxAge int `yaml:"cookie_max_age"`
+	// Max age (in seconds) of the CSRF cookie.
+	// Optional. Default value 86400 (24hr).
+	CookieMaxAge int `yaml:"cookie_max_age"`
 
-		// Indicates if CSRF cookie is secure.
-		// Optional. Default value false.
-		CookieSecure bool `yaml:"cookie_secure"`
+	// Indicates if CSRF cookie is secure.
+	// Optional. Default value false.
+	CookieSecure bool `yaml:"cookie_secure"`
 
-		// Indicates if CSRF cookie is HTTP only.
-		// Optional. Default value false.
-		CookieHTTPOnly bool `yaml:"cookie_http_only"`
+	// Indicates if CSRF cookie is HTTP only.
+	// Optional. Default value false.
+	CookieHTTPOnly bool `yaml:"cookie_http_only"`
 
-		// Indicates SameSite mode of the CSRF cookie.
-		// Optional. Default value SameSiteDefaultMode.
-		CookieSameSite http.SameSite `yaml:"cookie_same_site"`
+	// Indicates SameSite mode of the CSRF cookie.
+	// Optional. Default value SameSiteDefaultMode.
+	CookieSameSite http.SameSite `yaml:"cookie_same_site"`
 
-		// ErrorHandler defines a function which is executed for returning custom errors.
-		ErrorHandler CSRFErrorHandler
-	}
+	// ErrorHandler defines a function which is executed for returning custom errors.
+	ErrorHandler CSRFErrorHandler
+}
 
-	// CSRFErrorHandler is a function which is executed for creating custom errors.
-	CSRFErrorHandler func(err error, c echo.Context) error
-)
+// CSRFErrorHandler is a function which is executed for creating custom errors.
+type CSRFErrorHandler func(err error, c echo.Context) error
 
 // ErrCSRFInvalid is returned when CSRF check fails
 var ErrCSRFInvalid = echo.NewHTTPError(http.StatusForbidden, "invalid csrf token")
 
-var (
-	// DefaultCSRFConfig is the default CSRF middleware config.
-	DefaultCSRFConfig = CSRFConfig{
-		Skipper:        DefaultSkipper,
-		TokenLength:    32,
-		TokenLookup:    "header:" + echo.HeaderXCSRFToken,
-		ContextKey:     "csrf",
-		CookieName:     "_csrf",
-		CookieMaxAge:   86400,
-		CookieSameSite: http.SameSiteDefaultMode,
-	}
-)
+// DefaultCSRFConfig is the default CSRF middleware config.
+var DefaultCSRFConfig = CSRFConfig{
+	Skipper:        DefaultSkipper,
+	TokenLength:    32,
+	TokenLookup:    "header:" + echo.HeaderXCSRFToken,
+	ContextKey:     "csrf",
+	CookieName:     "_csrf",
+	CookieMaxAge:   86400,
+	CookieSameSite: http.SameSiteDefaultMode,
+}
 
 // CSRF returns a Cross-Site Request Forgery (CSRF) middleware.
 // See: https://en.wikipedia.org/wiki/Cross-site_request_forgery

--- a/middleware/decompress.go
+++ b/middleware/decompress.go
@@ -12,16 +12,14 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-type (
-	// DecompressConfig defines the config for Decompress middleware.
-	DecompressConfig struct {
-		// Skipper defines a function to skip middleware.
-		Skipper Skipper
+// DecompressConfig defines the config for Decompress middleware.
+type DecompressConfig struct {
+	// Skipper defines a function to skip middleware.
+	Skipper Skipper
 
-		// GzipDecompressPool defines an interface to provide the sync.Pool used to create/store Gzip readers
-		GzipDecompressPool Decompressor
-	}
-)
+	// GzipDecompressPool defines an interface to provide the sync.Pool used to create/store Gzip readers
+	GzipDecompressPool Decompressor
+}
 
 // GZIPEncoding content-encoding header if set to "gzip", decompress body contents.
 const GZIPEncoding string = "gzip"
@@ -31,13 +29,11 @@ type Decompressor interface {
 	gzipDecompressPool() sync.Pool
 }
 
-var (
-	//DefaultDecompressConfig defines the config for decompress middleware
-	DefaultDecompressConfig = DecompressConfig{
-		Skipper:            DefaultSkipper,
-		GzipDecompressPool: &DefaultGzipDecompressPool{},
-	}
-)
+// DefaultDecompressConfig defines the config for decompress middleware
+var DefaultDecompressConfig = DecompressConfig{
+	Skipper:            DefaultSkipper,
+	GzipDecompressPool: &DefaultGzipDecompressPool{},
+}
 
 // DefaultGzipDecompressPool is the default implementation of Decompressor interface
 type DefaultGzipDecompressPool struct {

--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -15,139 +15,135 @@ import (
 	"reflect"
 )
 
-type (
-	// JWTConfig defines the config for JWT middleware.
-	JWTConfig struct {
-		// Skipper defines a function to skip middleware.
-		Skipper Skipper
+// JWTConfig defines the config for JWT middleware.
+type JWTConfig struct {
+	// Skipper defines a function to skip middleware.
+	Skipper Skipper
 
-		// BeforeFunc defines a function which is executed just before the middleware.
-		BeforeFunc BeforeFunc
+	// BeforeFunc defines a function which is executed just before the middleware.
+	BeforeFunc BeforeFunc
 
-		// SuccessHandler defines a function which is executed for a valid token before middleware chain continues with next
-		// middleware or handler.
-		SuccessHandler JWTSuccessHandler
+	// SuccessHandler defines a function which is executed for a valid token before middleware chain continues with next
+	// middleware or handler.
+	SuccessHandler JWTSuccessHandler
 
-		// ErrorHandler defines a function which is executed for an invalid token.
-		// It may be used to define a custom JWT error.
-		ErrorHandler JWTErrorHandler
+	// ErrorHandler defines a function which is executed for an invalid token.
+	// It may be used to define a custom JWT error.
+	ErrorHandler JWTErrorHandler
 
-		// ErrorHandlerWithContext is almost identical to ErrorHandler, but it's passed the current context.
-		ErrorHandlerWithContext JWTErrorHandlerWithContext
+	// ErrorHandlerWithContext is almost identical to ErrorHandler, but it's passed the current context.
+	ErrorHandlerWithContext JWTErrorHandlerWithContext
 
-		// ContinueOnIgnoredError allows the next middleware/handler to be called when ErrorHandlerWithContext decides to
-		// ignore the error (by returning `nil`).
-		// This is useful when parts of your site/api allow public access and some authorized routes provide extra functionality.
-		// In that case you can use ErrorHandlerWithContext to set a default public JWT token value in the request context
-		// and continue. Some logic down the remaining execution chain needs to check that (public) token value then.
-		ContinueOnIgnoredError bool
+	// ContinueOnIgnoredError allows the next middleware/handler to be called when ErrorHandlerWithContext decides to
+	// ignore the error (by returning `nil`).
+	// This is useful when parts of your site/api allow public access and some authorized routes provide extra functionality.
+	// In that case you can use ErrorHandlerWithContext to set a default public JWT token value in the request context
+	// and continue. Some logic down the remaining execution chain needs to check that (public) token value then.
+	ContinueOnIgnoredError bool
 
-		// Signing key to validate token.
-		// This is one of the three options to provide a token validation key.
-		// The order of precedence is a user-defined KeyFunc, SigningKeys and SigningKey.
-		// Required if neither user-defined KeyFunc nor SigningKeys is provided.
-		SigningKey interface{}
+	// Signing key to validate token.
+	// This is one of the three options to provide a token validation key.
+	// The order of precedence is a user-defined KeyFunc, SigningKeys and SigningKey.
+	// Required if neither user-defined KeyFunc nor SigningKeys is provided.
+	SigningKey interface{}
 
-		// Map of signing keys to validate token with kid field usage.
-		// This is one of the three options to provide a token validation key.
-		// The order of precedence is a user-defined KeyFunc, SigningKeys and SigningKey.
-		// Required if neither user-defined KeyFunc nor SigningKey is provided.
-		SigningKeys map[string]interface{}
+	// Map of signing keys to validate token with kid field usage.
+	// This is one of the three options to provide a token validation key.
+	// The order of precedence is a user-defined KeyFunc, SigningKeys and SigningKey.
+	// Required if neither user-defined KeyFunc nor SigningKey is provided.
+	SigningKeys map[string]interface{}
 
-		// Signing method used to check the token's signing algorithm.
-		// Optional. Default value HS256.
-		SigningMethod string
+	// Signing method used to check the token's signing algorithm.
+	// Optional. Default value HS256.
+	SigningMethod string
 
-		// Context key to store user information from the token into context.
-		// Optional. Default value "user".
-		ContextKey string
+	// Context key to store user information from the token into context.
+	// Optional. Default value "user".
+	ContextKey string
 
-		// Claims are extendable claims data defining token content. Used by default ParseTokenFunc implementation.
-		// Not used if custom ParseTokenFunc is set.
-		// Optional. Default value jwt.MapClaims
-		Claims jwt.Claims
+	// Claims are extendable claims data defining token content. Used by default ParseTokenFunc implementation.
+	// Not used if custom ParseTokenFunc is set.
+	// Optional. Default value jwt.MapClaims
+	Claims jwt.Claims
 
-		// TokenLookup is a string in the form of "<source>:<name>" or "<source>:<name>,<source>:<name>" that is used
-		// to extract token from the request.
-		// Optional. Default value "header:Authorization".
-		// Possible values:
-		// - "header:<name>" or "header:<name>:<cut-prefix>"
-		// 			`<cut-prefix>` is argument value to cut/trim prefix of the extracted value. This is useful if header
-		//			value has static prefix like `Authorization: <auth-scheme> <authorisation-parameters>` where part that we
-		//			want to cut is `<auth-scheme> ` note the space at the end.
-		//			In case of JWT tokens `Authorization: Bearer <token>` prefix we cut is `Bearer `.
-		// If prefix is left empty the whole value is returned.
-		// - "query:<name>"
-		// - "param:<name>"
-		// - "cookie:<name>"
-		// - "form:<name>"
-		// Multiple sources example:
-		// - "header:Authorization,cookie:myowncookie"
-		TokenLookup string
+	// TokenLookup is a string in the form of "<source>:<name>" or "<source>:<name>,<source>:<name>" that is used
+	// to extract token from the request.
+	// Optional. Default value "header:Authorization".
+	// Possible values:
+	// - "header:<name>" or "header:<name>:<cut-prefix>"
+	// 			`<cut-prefix>` is argument value to cut/trim prefix of the extracted value. This is useful if header
+	//			value has static prefix like `Authorization: <auth-scheme> <authorisation-parameters>` where part that we
+	//			want to cut is `<auth-scheme> ` note the space at the end.
+	//			In case of JWT tokens `Authorization: Bearer <token>` prefix we cut is `Bearer `.
+	// If prefix is left empty the whole value is returned.
+	// - "query:<name>"
+	// - "param:<name>"
+	// - "cookie:<name>"
+	// - "form:<name>"
+	// Multiple sources example:
+	// - "header:Authorization,cookie:myowncookie"
+	TokenLookup string
 
-		// TokenLookupFuncs defines a list of user-defined functions that extract JWT token from the given context.
-		// This is one of the two options to provide a token extractor.
-		// The order of precedence is user-defined TokenLookupFuncs, and TokenLookup.
-		// You can also provide both if you want.
-		TokenLookupFuncs []ValuesExtractor
+	// TokenLookupFuncs defines a list of user-defined functions that extract JWT token from the given context.
+	// This is one of the two options to provide a token extractor.
+	// The order of precedence is user-defined TokenLookupFuncs, and TokenLookup.
+	// You can also provide both if you want.
+	TokenLookupFuncs []ValuesExtractor
 
-		// AuthScheme to be used in the Authorization header.
-		// Optional. Default value "Bearer".
-		AuthScheme string
+	// AuthScheme to be used in the Authorization header.
+	// Optional. Default value "Bearer".
+	AuthScheme string
 
-		// KeyFunc defines a user-defined function that supplies the public key for a token validation.
-		// The function shall take care of verifying the signing algorithm and selecting the proper key.
-		// A user-defined KeyFunc can be useful if tokens are issued by an external party.
-		// Used by default ParseTokenFunc implementation.
-		//
-		// When a user-defined KeyFunc is provided, SigningKey, SigningKeys, and SigningMethod are ignored.
-		// This is one of the three options to provide a token validation key.
-		// The order of precedence is a user-defined KeyFunc, SigningKeys and SigningKey.
-		// Required if neither SigningKeys nor SigningKey is provided.
-		// Not used if custom ParseTokenFunc is set.
-		// Default to an internal implementation verifying the signing algorithm and selecting the proper key.
-		KeyFunc jwt.Keyfunc
+	// KeyFunc defines a user-defined function that supplies the public key for a token validation.
+	// The function shall take care of verifying the signing algorithm and selecting the proper key.
+	// A user-defined KeyFunc can be useful if tokens are issued by an external party.
+	// Used by default ParseTokenFunc implementation.
+	//
+	// When a user-defined KeyFunc is provided, SigningKey, SigningKeys, and SigningMethod are ignored.
+	// This is one of the three options to provide a token validation key.
+	// The order of precedence is a user-defined KeyFunc, SigningKeys and SigningKey.
+	// Required if neither SigningKeys nor SigningKey is provided.
+	// Not used if custom ParseTokenFunc is set.
+	// Default to an internal implementation verifying the signing algorithm and selecting the proper key.
+	KeyFunc jwt.Keyfunc
 
-		// ParseTokenFunc defines a user-defined function that parses token from given auth. Returns an error when token
-		// parsing fails or parsed token is invalid.
-		// Defaults to implementation using `github.com/golang-jwt/jwt` as JWT implementation library
-		ParseTokenFunc func(auth string, c echo.Context) (interface{}, error)
-	}
+	// ParseTokenFunc defines a user-defined function that parses token from given auth. Returns an error when token
+	// parsing fails or parsed token is invalid.
+	// Defaults to implementation using `github.com/golang-jwt/jwt` as JWT implementation library
+	ParseTokenFunc func(auth string, c echo.Context) (interface{}, error)
+}
 
-	// JWTSuccessHandler defines a function which is executed for a valid token.
-	JWTSuccessHandler func(c echo.Context)
+// JWTSuccessHandler defines a function which is executed for a valid token.
+type JWTSuccessHandler func(c echo.Context)
 
-	// JWTErrorHandler defines a function which is executed for an invalid token.
-	JWTErrorHandler func(err error) error
+// JWTErrorHandler defines a function which is executed for an invalid token.
+type JWTErrorHandler func(err error) error
 
-	// JWTErrorHandlerWithContext is almost identical to JWTErrorHandler, but it's passed the current context.
-	JWTErrorHandlerWithContext func(err error, c echo.Context) error
-)
+// JWTErrorHandlerWithContext is almost identical to JWTErrorHandler, but it's passed the current context.
+type JWTErrorHandlerWithContext func(err error, c echo.Context) error
 
 // Algorithms
 const (
 	AlgorithmHS256 = "HS256"
 )
 
-// Errors
-var (
-	ErrJWTMissing = echo.NewHTTPError(http.StatusBadRequest, "missing or malformed jwt")
-	ErrJWTInvalid = echo.NewHTTPError(http.StatusUnauthorized, "invalid or expired jwt")
-)
+// ErrJWTMissing is error that is returned when no JWToken was extracted from the request.
+var ErrJWTMissing = echo.NewHTTPError(http.StatusBadRequest, "missing or malformed jwt")
 
-var (
-	// DefaultJWTConfig is the default JWT auth middleware config.
-	DefaultJWTConfig = JWTConfig{
-		Skipper:          DefaultSkipper,
-		SigningMethod:    AlgorithmHS256,
-		ContextKey:       "user",
-		TokenLookup:      "header:" + echo.HeaderAuthorization,
-		TokenLookupFuncs: nil,
-		AuthScheme:       "Bearer",
-		Claims:           jwt.MapClaims{},
-		KeyFunc:          nil,
-	}
-)
+// ErrJWTInvalid is error that is returned when middleware could not parse JWT correctly.
+var ErrJWTInvalid = echo.NewHTTPError(http.StatusUnauthorized, "invalid or expired jwt")
+
+// DefaultJWTConfig is the default JWT auth middleware config.
+var DefaultJWTConfig = JWTConfig{
+	Skipper:          DefaultSkipper,
+	SigningMethod:    AlgorithmHS256,
+	ContextKey:       "user",
+	TokenLookup:      "header:" + echo.HeaderAuthorization,
+	TokenLookupFuncs: nil,
+	AuthScheme:       "Bearer",
+	Claims:           jwt.MapClaims{},
+	KeyFunc:          nil,
+}
 
 // JWT returns a JSON Web Token (JWT) auth middleware.
 //

--- a/middleware/key_auth.go
+++ b/middleware/key_auth.go
@@ -9,67 +9,63 @@ import (
 	"net/http"
 )
 
-type (
-	// KeyAuthConfig defines the config for KeyAuth middleware.
-	KeyAuthConfig struct {
-		// Skipper defines a function to skip middleware.
-		Skipper Skipper
+// KeyAuthConfig defines the config for KeyAuth middleware.
+type KeyAuthConfig struct {
+	// Skipper defines a function to skip middleware.
+	Skipper Skipper
 
-		// KeyLookup is a string in the form of "<source>:<name>" or "<source>:<name>,<source>:<name>" that is used
-		// to extract key from the request.
-		// Optional. Default value "header:Authorization".
-		// Possible values:
-		// - "header:<name>" or "header:<name>:<cut-prefix>"
-		// 			`<cut-prefix>` is argument value to cut/trim prefix of the extracted value. This is useful if header
-		//			value has static prefix like `Authorization: <auth-scheme> <authorisation-parameters>` where part that we
-		//			want to cut is `<auth-scheme> ` note the space at the end.
-		//			In case of basic authentication `Authorization: Basic <credentials>` prefix we want to remove is `Basic `.
-		// - "query:<name>"
-		// - "form:<name>"
-		// - "cookie:<name>"
-		// Multiple sources example:
-		// - "header:Authorization,header:X-Api-Key"
-		KeyLookup string
+	// KeyLookup is a string in the form of "<source>:<name>" or "<source>:<name>,<source>:<name>" that is used
+	// to extract key from the request.
+	// Optional. Default value "header:Authorization".
+	// Possible values:
+	// - "header:<name>" or "header:<name>:<cut-prefix>"
+	// 			`<cut-prefix>` is argument value to cut/trim prefix of the extracted value. This is useful if header
+	//			value has static prefix like `Authorization: <auth-scheme> <authorisation-parameters>` where part that we
+	//			want to cut is `<auth-scheme> ` note the space at the end.
+	//			In case of basic authentication `Authorization: Basic <credentials>` prefix we want to remove is `Basic `.
+	// - "query:<name>"
+	// - "form:<name>"
+	// - "cookie:<name>"
+	// Multiple sources example:
+	// - "header:Authorization,header:X-Api-Key"
+	KeyLookup string
 
-		// AuthScheme to be used in the Authorization header.
-		// Optional. Default value "Bearer".
-		AuthScheme string
+	// AuthScheme to be used in the Authorization header.
+	// Optional. Default value "Bearer".
+	AuthScheme string
 
-		// Validator is a function to validate key.
-		// Required.
-		Validator KeyAuthValidator
+	// Validator is a function to validate key.
+	// Required.
+	Validator KeyAuthValidator
 
-		// ErrorHandler defines a function which is executed for an invalid key.
-		// It may be used to define a custom error.
-		ErrorHandler KeyAuthErrorHandler
+	// ErrorHandler defines a function which is executed for an invalid key.
+	// It may be used to define a custom error.
+	ErrorHandler KeyAuthErrorHandler
 
-		// ContinueOnIgnoredError allows the next middleware/handler to be called when ErrorHandler decides to
-		// ignore the error (by returning `nil`).
-		// This is useful when parts of your site/api allow public access and some authorized routes provide extra functionality.
-		// In that case you can use ErrorHandler to set a default public key auth value in the request context
-		// and continue. Some logic down the remaining execution chain needs to check that (public) key auth value then.
-		ContinueOnIgnoredError bool
-	}
+	// ContinueOnIgnoredError allows the next middleware/handler to be called when ErrorHandler decides to
+	// ignore the error (by returning `nil`).
+	// This is useful when parts of your site/api allow public access and some authorized routes provide extra functionality.
+	// In that case you can use ErrorHandler to set a default public key auth value in the request context
+	// and continue. Some logic down the remaining execution chain needs to check that (public) key auth value then.
+	ContinueOnIgnoredError bool
+}
 
-	// KeyAuthValidator defines a function to validate KeyAuth credentials.
-	KeyAuthValidator func(auth string, c echo.Context) (bool, error)
+// KeyAuthValidator defines a function to validate KeyAuth credentials.
+type KeyAuthValidator func(auth string, c echo.Context) (bool, error)
 
-	// KeyAuthErrorHandler defines a function which is executed for an invalid key.
-	KeyAuthErrorHandler func(err error, c echo.Context) error
-)
-
-var (
-	// DefaultKeyAuthConfig is the default KeyAuth middleware config.
-	DefaultKeyAuthConfig = KeyAuthConfig{
-		Skipper:    DefaultSkipper,
-		KeyLookup:  "header:" + echo.HeaderAuthorization,
-		AuthScheme: "Bearer",
-	}
-)
+// KeyAuthErrorHandler defines a function which is executed for an invalid key.
+type KeyAuthErrorHandler func(err error, c echo.Context) error
 
 // ErrKeyAuthMissing is error type when KeyAuth middleware is unable to extract value from lookups
 type ErrKeyAuthMissing struct {
 	Err error
+}
+
+// DefaultKeyAuthConfig is the default KeyAuth middleware config.
+var DefaultKeyAuthConfig = KeyAuthConfig{
+	Skipper:    DefaultSkipper,
+	KeyLookup:  "header:" + echo.HeaderAuthorization,
+	AuthScheme: "Bearer",
 }
 
 // Error returns errors text

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -17,77 +17,73 @@ import (
 	"github.com/valyala/fasttemplate"
 )
 
-type (
-	// LoggerConfig defines the config for Logger middleware.
-	LoggerConfig struct {
-		// Skipper defines a function to skip middleware.
-		Skipper Skipper
+// LoggerConfig defines the config for Logger middleware.
+type LoggerConfig struct {
+	// Skipper defines a function to skip middleware.
+	Skipper Skipper
 
-		// Tags to construct the logger format.
-		//
-		// - time_unix
-		// - time_unix_milli
-		// - time_unix_micro
-		// - time_unix_nano
-		// - time_rfc3339
-		// - time_rfc3339_nano
-		// - time_custom
-		// - id (Request ID)
-		// - remote_ip
-		// - uri
-		// - host
-		// - method
-		// - path
-		// - route
-		// - protocol
-		// - referer
-		// - user_agent
-		// - status
-		// - error
-		// - latency (In nanoseconds)
-		// - latency_human (Human readable)
-		// - bytes_in (Bytes received)
-		// - bytes_out (Bytes sent)
-		// - header:<NAME>
-		// - query:<NAME>
-		// - form:<NAME>
-		// - custom (see CustomTagFunc field)
-		//
-		// Example "${remote_ip} ${status}"
-		//
-		// Optional. Default value DefaultLoggerConfig.Format.
-		Format string `yaml:"format"`
+	// Tags to construct the logger format.
+	//
+	// - time_unix
+	// - time_unix_milli
+	// - time_unix_micro
+	// - time_unix_nano
+	// - time_rfc3339
+	// - time_rfc3339_nano
+	// - time_custom
+	// - id (Request ID)
+	// - remote_ip
+	// - uri
+	// - host
+	// - method
+	// - path
+	// - route
+	// - protocol
+	// - referer
+	// - user_agent
+	// - status
+	// - error
+	// - latency (In nanoseconds)
+	// - latency_human (Human readable)
+	// - bytes_in (Bytes received)
+	// - bytes_out (Bytes sent)
+	// - header:<NAME>
+	// - query:<NAME>
+	// - form:<NAME>
+	// - custom (see CustomTagFunc field)
+	//
+	// Example "${remote_ip} ${status}"
+	//
+	// Optional. Default value DefaultLoggerConfig.Format.
+	Format string `yaml:"format"`
 
-		// Optional. Default value DefaultLoggerConfig.CustomTimeFormat.
-		CustomTimeFormat string `yaml:"custom_time_format"`
+	// Optional. Default value DefaultLoggerConfig.CustomTimeFormat.
+	CustomTimeFormat string `yaml:"custom_time_format"`
 
-		// CustomTagFunc is function called for `${custom}` tag to output user implemented text by writing it to buf.
-		// Make sure that outputted text creates valid JSON string with other logged tags.
-		// Optional.
-		CustomTagFunc func(c echo.Context, buf *bytes.Buffer) (int, error)
+	// CustomTagFunc is function called for `${custom}` tag to output user implemented text by writing it to buf.
+	// Make sure that outputted text creates valid JSON string with other logged tags.
+	// Optional.
+	CustomTagFunc func(c echo.Context, buf *bytes.Buffer) (int, error)
 
-		// Output is a writer where logs in JSON format are written.
-		// Optional. Default value os.Stdout.
-		Output io.Writer
+	// Output is a writer where logs in JSON format are written.
+	// Optional. Default value os.Stdout.
+	Output io.Writer
 
-		template *fasttemplate.Template
-		colorer  *color.Color
-		pool     *sync.Pool
-	}
-)
+	template *fasttemplate.Template
+	colorer  *color.Color
+	pool     *sync.Pool
+}
 
-var (
-	// DefaultLoggerConfig is the default Logger middleware config.
-	DefaultLoggerConfig = LoggerConfig{
-		Skipper: DefaultSkipper,
-		Format: `{"time":"${time_rfc3339_nano}","id":"${id}","remote_ip":"${remote_ip}",` +
-			`"host":"${host}","method":"${method}","uri":"${uri}","user_agent":"${user_agent}",` +
-			`"status":${status},"error":"${error}","latency":${latency},"latency_human":"${latency_human}"` +
-			`,"bytes_in":${bytes_in},"bytes_out":${bytes_out}}` + "\n",
-		CustomTimeFormat: "2006-01-02 15:04:05.00000",
-		colorer:          color.New(),
-	}
-)
+// DefaultLoggerConfig is the default Logger middleware config.
+var DefaultLoggerConfig = LoggerConfig{
+	Skipper: DefaultSkipper,
+	Format: `{"time":"${time_rfc3339_nano}","id":"${id}","remote_ip":"${remote_ip}",` +
+		`"host":"${host}","method":"${method}","uri":"${uri}","user_agent":"${user_agent}",` +
+		`"status":${status},"error":"${error}","latency":${latency},"latency_human":"${latency_human}"` +
+		`,"bytes_in":${bytes_in},"bytes_out":${bytes_out}}` + "\n",
+	CustomTimeFormat: "2006-01-02 15:04:05.00000",
+	colorer:          color.New(),
+}
 
 // Logger returns a middleware that logs HTTP requests.
 func Logger() echo.MiddlewareFunc {

--- a/middleware/method_override.go
+++ b/middleware/method_override.go
@@ -9,28 +9,24 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-type (
-	// MethodOverrideConfig defines the config for MethodOverride middleware.
-	MethodOverrideConfig struct {
-		// Skipper defines a function to skip middleware.
-		Skipper Skipper
+// MethodOverrideConfig defines the config for MethodOverride middleware.
+type MethodOverrideConfig struct {
+	// Skipper defines a function to skip middleware.
+	Skipper Skipper
 
-		// Getter is a function that gets overridden method from the request.
-		// Optional. Default values MethodFromHeader(echo.HeaderXHTTPMethodOverride).
-		Getter MethodOverrideGetter
-	}
+	// Getter is a function that gets overridden method from the request.
+	// Optional. Default values MethodFromHeader(echo.HeaderXHTTPMethodOverride).
+	Getter MethodOverrideGetter
+}
 
-	// MethodOverrideGetter is a function that gets overridden method from the request
-	MethodOverrideGetter func(echo.Context) string
-)
+// MethodOverrideGetter is a function that gets overridden method from the request
+type MethodOverrideGetter func(echo.Context) string
 
-var (
-	// DefaultMethodOverrideConfig is the default MethodOverride middleware config.
-	DefaultMethodOverrideConfig = MethodOverrideConfig{
-		Skipper: DefaultSkipper,
-		Getter:  MethodFromHeader(echo.HeaderXHTTPMethodOverride),
-	}
-)
+// DefaultMethodOverrideConfig is the default MethodOverride middleware config.
+var DefaultMethodOverrideConfig = MethodOverrideConfig{
+	Skipper: DefaultSkipper,
+	Getter:  MethodFromHeader(echo.HeaderXHTTPMethodOverride),
+}
 
 // MethodOverride returns a MethodOverride middleware.
 // MethodOverride  middleware checks for the overridden method from the request and

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -12,14 +12,12 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-type (
-	// Skipper defines a function to skip middleware. Returning true skips processing
-	// the middleware.
-	Skipper func(c echo.Context) bool
+// Skipper defines a function to skip middleware. Returning true skips processing
+// the middleware.
+type Skipper func(c echo.Context) bool
 
-	// BeforeFunc defines a function which is executed just before the middleware.
-	BeforeFunc func(c echo.Context)
-)
+// BeforeFunc defines a function which is executed just before the middleware.
+type BeforeFunc func(c echo.Context)
 
 func captureTokens(pattern *regexp.Regexp, input string) *strings.Replacer {
 	groups := pattern.FindAllStringSubmatch(input, -1)
@@ -56,7 +54,7 @@ func rewriteURL(rewriteRegex map[*regexp.Regexp]string, req *http.Request) error
 		return nil
 	}
 
-	// Depending how HTTP request is sent RequestURI could contain Scheme://Host/path or be just /path.
+	// Depending on how HTTP request is sent RequestURI could contain Scheme://Host/path or be just /path.
 	// We only want to use path part for rewriting and therefore trim prefix if it exists
 	rawURI := req.RequestURI
 	if rawURI != "" && rawURI[0] != '/' {

--- a/middleware/proxy.go
+++ b/middleware/proxy.go
@@ -22,117 +22,113 @@ import (
 
 // TODO: Handle TLS proxy
 
-type (
-	// ProxyConfig defines the config for Proxy middleware.
-	ProxyConfig struct {
-		// Skipper defines a function to skip middleware.
-		Skipper Skipper
+// ProxyConfig defines the config for Proxy middleware.
+type ProxyConfig struct {
+	// Skipper defines a function to skip middleware.
+	Skipper Skipper
 
-		// Balancer defines a load balancing technique.
-		// Required.
-		Balancer ProxyBalancer
+	// Balancer defines a load balancing technique.
+	// Required.
+	Balancer ProxyBalancer
 
-		// RetryCount defines the number of times a failed proxied request should be retried
-		// using the next available ProxyTarget. Defaults to 0, meaning requests are never retried.
-		RetryCount int
+	// RetryCount defines the number of times a failed proxied request should be retried
+	// using the next available ProxyTarget. Defaults to 0, meaning requests are never retried.
+	RetryCount int
 
-		// RetryFilter defines a function used to determine if a failed request to a
-		// ProxyTarget should be retried. The RetryFilter will only be called when the number
-		// of previous retries is less than RetryCount. If the function returns true, the
-		// request will be retried. The provided error indicates the reason for the request
-		// failure. When the ProxyTarget is unavailable, the error will be an instance of
-		// echo.HTTPError with a Code of http.StatusBadGateway. In all other cases, the error
-		// will indicate an internal error in the Proxy middleware. When a RetryFilter is not
-		// specified, all requests that fail with http.StatusBadGateway will be retried. A custom
-		// RetryFilter can be provided to only retry specific requests. Note that RetryFilter is
-		// only called when the request to the target fails, or an internal error in the Proxy
-		// middleware has occurred. Successful requests that return a non-200 response code cannot
-		// be retried.
-		RetryFilter func(c echo.Context, e error) bool
+	// RetryFilter defines a function used to determine if a failed request to a
+	// ProxyTarget should be retried. The RetryFilter will only be called when the number
+	// of previous retries is less than RetryCount. If the function returns true, the
+	// request will be retried. The provided error indicates the reason for the request
+	// failure. When the ProxyTarget is unavailable, the error will be an instance of
+	// echo.HTTPError with a Code of http.StatusBadGateway. In all other cases, the error
+	// will indicate an internal error in the Proxy middleware. When a RetryFilter is not
+	// specified, all requests that fail with http.StatusBadGateway will be retried. A custom
+	// RetryFilter can be provided to only retry specific requests. Note that RetryFilter is
+	// only called when the request to the target fails, or an internal error in the Proxy
+	// middleware has occurred. Successful requests that return a non-200 response code cannot
+	// be retried.
+	RetryFilter func(c echo.Context, e error) bool
 
-		// ErrorHandler defines a function which can be used to return custom errors from
-		// the Proxy middleware. ErrorHandler is only invoked when there has been
-		// either an internal error in the Proxy middleware or the ProxyTarget is
-		// unavailable. Due to the way requests are proxied, ErrorHandler is not invoked
-		// when a ProxyTarget returns a non-200 response. In these cases, the response
-		// is already written so errors cannot be modified. ErrorHandler is only
-		// invoked after all retry attempts have been exhausted.
-		ErrorHandler func(c echo.Context, err error) error
+	// ErrorHandler defines a function which can be used to return custom errors from
+	// the Proxy middleware. ErrorHandler is only invoked when there has been
+	// either an internal error in the Proxy middleware or the ProxyTarget is
+	// unavailable. Due to the way requests are proxied, ErrorHandler is not invoked
+	// when a ProxyTarget returns a non-200 response. In these cases, the response
+	// is already written so errors cannot be modified. ErrorHandler is only
+	// invoked after all retry attempts have been exhausted.
+	ErrorHandler func(c echo.Context, err error) error
 
-		// Rewrite defines URL path rewrite rules. The values captured in asterisk can be
-		// retrieved by index e.g. $1, $2 and so on.
-		// Examples:
-		// "/old":              "/new",
-		// "/api/*":            "/$1",
-		// "/js/*":             "/public/javascripts/$1",
-		// "/users/*/orders/*": "/user/$1/order/$2",
-		Rewrite map[string]string
+	// Rewrite defines URL path rewrite rules. The values captured in asterisk can be
+	// retrieved by index e.g. $1, $2 and so on.
+	// Examples:
+	// "/old":              "/new",
+	// "/api/*":            "/$1",
+	// "/js/*":             "/public/javascripts/$1",
+	// "/users/*/orders/*": "/user/$1/order/$2",
+	Rewrite map[string]string
 
-		// RegexRewrite defines rewrite rules using regexp.Rexexp with captures
-		// Every capture group in the values can be retrieved by index e.g. $1, $2 and so on.
-		// Example:
-		// "^/old/[0.9]+/":     "/new",
-		// "^/api/.+?/(.*)":    "/v2/$1",
-		RegexRewrite map[*regexp.Regexp]string
+	// RegexRewrite defines rewrite rules using regexp.Rexexp with captures
+	// Every capture group in the values can be retrieved by index e.g. $1, $2 and so on.
+	// Example:
+	// "^/old/[0.9]+/":     "/new",
+	// "^/api/.+?/(.*)":    "/v2/$1",
+	RegexRewrite map[*regexp.Regexp]string
 
-		// Context key to store selected ProxyTarget into context.
-		// Optional. Default value "target".
-		ContextKey string
+	// Context key to store selected ProxyTarget into context.
+	// Optional. Default value "target".
+	ContextKey string
 
-		// To customize the transport to remote.
-		// Examples: If custom TLS certificates are required.
-		Transport http.RoundTripper
+	// To customize the transport to remote.
+	// Examples: If custom TLS certificates are required.
+	Transport http.RoundTripper
 
-		// ModifyResponse defines function to modify response from ProxyTarget.
-		ModifyResponse func(*http.Response) error
-	}
+	// ModifyResponse defines function to modify response from ProxyTarget.
+	ModifyResponse func(*http.Response) error
+}
 
-	// ProxyTarget defines the upstream target.
-	ProxyTarget struct {
-		Name string
-		URL  *url.URL
-		Meta echo.Map
-	}
+// ProxyTarget defines the upstream target.
+type ProxyTarget struct {
+	Name string
+	URL  *url.URL
+	Meta echo.Map
+}
 
-	// ProxyBalancer defines an interface to implement a load balancing technique.
-	ProxyBalancer interface {
-		AddTarget(*ProxyTarget) bool
-		RemoveTarget(string) bool
-		Next(echo.Context) *ProxyTarget
-	}
+// ProxyBalancer defines an interface to implement a load balancing technique.
+type ProxyBalancer interface {
+	AddTarget(*ProxyTarget) bool
+	RemoveTarget(string) bool
+	Next(echo.Context) *ProxyTarget
+}
 
-	// TargetProvider defines an interface that gives the opportunity for balancer
-	// to return custom errors when selecting target.
-	TargetProvider interface {
-		NextTarget(echo.Context) (*ProxyTarget, error)
-	}
+// TargetProvider defines an interface that gives the opportunity for balancer
+// to return custom errors when selecting target.
+type TargetProvider interface {
+	NextTarget(echo.Context) (*ProxyTarget, error)
+}
 
-	commonBalancer struct {
-		targets []*ProxyTarget
-		mutex   sync.Mutex
-	}
+type commonBalancer struct {
+	targets []*ProxyTarget
+	mutex   sync.Mutex
+}
 
-	// RandomBalancer implements a random load balancing technique.
-	randomBalancer struct {
-		commonBalancer
-		random *rand.Rand
-	}
+// RandomBalancer implements a random load balancing technique.
+type randomBalancer struct {
+	commonBalancer
+	random *rand.Rand
+}
 
-	// RoundRobinBalancer implements a round-robin load balancing technique.
-	roundRobinBalancer struct {
-		commonBalancer
-		// tracking the index on `targets` slice for the next `*ProxyTarget` to be used
-		i int
-	}
-)
+// RoundRobinBalancer implements a round-robin load balancing technique.
+type roundRobinBalancer struct {
+	commonBalancer
+	// tracking the index on `targets` slice for the next `*ProxyTarget` to be used
+	i int
+}
 
-var (
-	// DefaultProxyConfig is the default Proxy middleware config.
-	DefaultProxyConfig = ProxyConfig{
-		Skipper:    DefaultSkipper,
-		ContextKey: "target",
-	}
-)
+// DefaultProxyConfig is the default Proxy middleware config.
+var DefaultProxyConfig = ProxyConfig{
+	Skipper:    DefaultSkipper,
+	ContextKey: "target",
+}
 
 func proxyRaw(t *ProxyTarget, c echo.Context) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/middleware/rate_limiter.go
+++ b/middleware/rate_limiter.go
@@ -12,39 +12,34 @@ import (
 	"golang.org/x/time/rate"
 )
 
-type (
-	// RateLimiterStore is the interface to be implemented by custom stores.
-	RateLimiterStore interface {
-		// Stores for the rate limiter have to implement the Allow method
-		Allow(identifier string) (bool, error)
-	}
-)
+// RateLimiterStore is the interface to be implemented by custom stores.
+type RateLimiterStore interface {
+	// Stores for the rate limiter have to implement the Allow method
+	Allow(identifier string) (bool, error)
+}
 
-type (
-	// RateLimiterConfig defines the configuration for the rate limiter
-	RateLimiterConfig struct {
-		Skipper    Skipper
-		BeforeFunc BeforeFunc
-		// IdentifierExtractor uses echo.Context to extract the identifier for a visitor
-		IdentifierExtractor Extractor
-		// Store defines a store for the rate limiter
-		Store RateLimiterStore
-		// ErrorHandler provides a handler to be called when IdentifierExtractor returns an error
-		ErrorHandler func(context echo.Context, err error) error
-		// DenyHandler provides a handler to be called when RateLimiter denies access
-		DenyHandler func(context echo.Context, identifier string, err error) error
-	}
-	// Extractor is used to extract data from echo.Context
-	Extractor func(context echo.Context) (string, error)
-)
+// RateLimiterConfig defines the configuration for the rate limiter
+type RateLimiterConfig struct {
+	Skipper    Skipper
+	BeforeFunc BeforeFunc
+	// IdentifierExtractor uses echo.Context to extract the identifier for a visitor
+	IdentifierExtractor Extractor
+	// Store defines a store for the rate limiter
+	Store RateLimiterStore
+	// ErrorHandler provides a handler to be called when IdentifierExtractor returns an error
+	ErrorHandler func(context echo.Context, err error) error
+	// DenyHandler provides a handler to be called when RateLimiter denies access
+	DenyHandler func(context echo.Context, identifier string, err error) error
+}
 
-// errors
-var (
-	// ErrRateLimitExceeded denotes an error raised when rate limit is exceeded
-	ErrRateLimitExceeded = echo.NewHTTPError(http.StatusTooManyRequests, "rate limit exceeded")
-	// ErrExtractorError denotes an error raised when extractor function is unsuccessful
-	ErrExtractorError = echo.NewHTTPError(http.StatusForbidden, "error while extracting identifier")
-)
+// Extractor is used to extract data from echo.Context
+type Extractor func(context echo.Context) (string, error)
+
+// ErrRateLimitExceeded denotes an error raised when rate limit is exceeded
+var ErrRateLimitExceeded = echo.NewHTTPError(http.StatusTooManyRequests, "rate limit exceeded")
+
+// ErrExtractorError denotes an error raised when extractor function is unsuccessful
+var ErrExtractorError = echo.NewHTTPError(http.StatusForbidden, "error while extracting identifier")
 
 // DefaultRateLimiterConfig defines default values for RateLimiterConfig
 var DefaultRateLimiterConfig = RateLimiterConfig{
@@ -153,25 +148,24 @@ func RateLimiterWithConfig(config RateLimiterConfig) echo.MiddlewareFunc {
 	}
 }
 
-type (
-	// RateLimiterMemoryStore is the built-in store implementation for RateLimiter
-	RateLimiterMemoryStore struct {
-		visitors map[string]*Visitor
-		mutex    sync.Mutex
-		rate     rate.Limit // for more info check out Limiter docs - https://pkg.go.dev/golang.org/x/time/rate#Limit.
+// RateLimiterMemoryStore is the built-in store implementation for RateLimiter
+type RateLimiterMemoryStore struct {
+	visitors map[string]*Visitor
+	mutex    sync.Mutex
+	rate     rate.Limit // for more info check out Limiter docs - https://pkg.go.dev/golang.org/x/time/rate#Limit.
 
-		burst       int
-		expiresIn   time.Duration
-		lastCleanup time.Time
+	burst       int
+	expiresIn   time.Duration
+	lastCleanup time.Time
 
-		timeNow func() time.Time
-	}
-	// Visitor signifies a unique user's limiter details
-	Visitor struct {
-		*rate.Limiter
-		lastSeen time.Time
-	}
-)
+	timeNow func() time.Time
+}
+
+// Visitor signifies a unique user's limiter details
+type Visitor struct {
+	*rate.Limiter
+	lastSeen time.Time
+}
 
 /*
 NewRateLimiterMemoryStore returns an instance of RateLimiterMemoryStore with

--- a/middleware/recover.go
+++ b/middleware/recover.go
@@ -12,56 +12,52 @@ import (
 	"github.com/labstack/gommon/log"
 )
 
-type (
+// LogErrorFunc defines a function for custom logging in the middleware.
+type LogErrorFunc func(c echo.Context, err error, stack []byte) error
+
+// RecoverConfig defines the config for Recover middleware.
+type RecoverConfig struct {
+	// Skipper defines a function to skip middleware.
+	Skipper Skipper
+
+	// Size of the stack to be printed.
+	// Optional. Default value 4KB.
+	StackSize int `yaml:"stack_size"`
+
+	// DisableStackAll disables formatting stack traces of all other goroutines
+	// into buffer after the trace for the current goroutine.
+	// Optional. Default value false.
+	DisableStackAll bool `yaml:"disable_stack_all"`
+
+	// DisablePrintStack disables printing stack trace.
+	// Optional. Default value as false.
+	DisablePrintStack bool `yaml:"disable_print_stack"`
+
+	// LogLevel is log level to printing stack trace.
+	// Optional. Default value 0 (Print).
+	LogLevel log.Lvl
+
 	// LogErrorFunc defines a function for custom logging in the middleware.
-	LogErrorFunc func(c echo.Context, err error, stack []byte) error
+	// If it's set you don't need to provide LogLevel for config.
+	// If this function returns nil, the centralized HTTPErrorHandler will not be called.
+	LogErrorFunc LogErrorFunc
 
-	// RecoverConfig defines the config for Recover middleware.
-	RecoverConfig struct {
-		// Skipper defines a function to skip middleware.
-		Skipper Skipper
+	// DisableErrorHandler disables the call to centralized HTTPErrorHandler.
+	// The recovered error is then passed back to upstream middleware, instead of swallowing the error.
+	// Optional. Default value false.
+	DisableErrorHandler bool `yaml:"disable_error_handler"`
+}
 
-		// Size of the stack to be printed.
-		// Optional. Default value 4KB.
-		StackSize int `yaml:"stack_size"`
-
-		// DisableStackAll disables formatting stack traces of all other goroutines
-		// into buffer after the trace for the current goroutine.
-		// Optional. Default value false.
-		DisableStackAll bool `yaml:"disable_stack_all"`
-
-		// DisablePrintStack disables printing stack trace.
-		// Optional. Default value as false.
-		DisablePrintStack bool `yaml:"disable_print_stack"`
-
-		// LogLevel is log level to printing stack trace.
-		// Optional. Default value 0 (Print).
-		LogLevel log.Lvl
-
-		// LogErrorFunc defines a function for custom logging in the middleware.
-		// If it's set you don't need to provide LogLevel for config.
-		// If this function returns nil, the centralized HTTPErrorHandler will not be called.
-		LogErrorFunc LogErrorFunc
-
-		// DisableErrorHandler disables the call to centralized HTTPErrorHandler.
-		// The recovered error is then passed back to upstream middleware, instead of swallowing the error.
-		// Optional. Default value false.
-		DisableErrorHandler bool `yaml:"disable_error_handler"`
-	}
-)
-
-var (
-	// DefaultRecoverConfig is the default Recover middleware config.
-	DefaultRecoverConfig = RecoverConfig{
-		Skipper:             DefaultSkipper,
-		StackSize:           4 << 10, // 4 KB
-		DisableStackAll:     false,
-		DisablePrintStack:   false,
-		LogLevel:            0,
-		LogErrorFunc:        nil,
-		DisableErrorHandler: false,
-	}
-)
+// DefaultRecoverConfig is the default Recover middleware config.
+var DefaultRecoverConfig = RecoverConfig{
+	Skipper:             DefaultSkipper,
+	StackSize:           4 << 10, // 4 KB
+	DisableStackAll:     false,
+	DisablePrintStack:   false,
+	LogLevel:            0,
+	LogErrorFunc:        nil,
+	DisableErrorHandler: false,
+}
 
 // Recover returns a middleware which recovers from panics anywhere in the chain
 // and handles the control to the centralized HTTPErrorHandler.

--- a/middleware/request_id.go
+++ b/middleware/request_id.go
@@ -7,32 +7,28 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-type (
-	// RequestIDConfig defines the config for RequestID middleware.
-	RequestIDConfig struct {
-		// Skipper defines a function to skip middleware.
-		Skipper Skipper
+// RequestIDConfig defines the config for RequestID middleware.
+type RequestIDConfig struct {
+	// Skipper defines a function to skip middleware.
+	Skipper Skipper
 
-		// Generator defines a function to generate an ID.
-		// Optional. Defaults to generator for random string of length 32.
-		Generator func() string
+	// Generator defines a function to generate an ID.
+	// Optional. Defaults to generator for random string of length 32.
+	Generator func() string
 
-		// RequestIDHandler defines a function which is executed for a request id.
-		RequestIDHandler func(echo.Context, string)
+	// RequestIDHandler defines a function which is executed for a request id.
+	RequestIDHandler func(echo.Context, string)
 
-		// TargetHeader defines what header to look for to populate the id
-		TargetHeader string
-	}
-)
+	// TargetHeader defines what header to look for to populate the id
+	TargetHeader string
+}
 
-var (
-	// DefaultRequestIDConfig is the default RequestID middleware config.
-	DefaultRequestIDConfig = RequestIDConfig{
-		Skipper:      DefaultSkipper,
-		Generator:    generator,
-		TargetHeader: echo.HeaderXRequestID,
-	}
-)
+// DefaultRequestIDConfig is the default RequestID middleware config.
+var DefaultRequestIDConfig = RequestIDConfig{
+	Skipper:      DefaultSkipper,
+	Generator:    generator,
+	TargetHeader: echo.HeaderXRequestID,
+}
 
 // RequestID returns a X-Request-ID middleware.
 func RequestID() echo.MiddlewareFunc {

--- a/middleware/rewrite.go
+++ b/middleware/rewrite.go
@@ -9,37 +9,33 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-type (
-	// RewriteConfig defines the config for Rewrite middleware.
-	RewriteConfig struct {
-		// Skipper defines a function to skip middleware.
-		Skipper Skipper
+// RewriteConfig defines the config for Rewrite middleware.
+type RewriteConfig struct {
+	// Skipper defines a function to skip middleware.
+	Skipper Skipper
 
-		// Rules defines the URL path rewrite rules. The values captured in asterisk can be
-		// retrieved by index e.g. $1, $2 and so on.
-		// Example:
-		// "/old":              "/new",
-		// "/api/*":            "/$1",
-		// "/js/*":             "/public/javascripts/$1",
-		// "/users/*/orders/*": "/user/$1/order/$2",
-		// Required.
-		Rules map[string]string `yaml:"rules"`
+	// Rules defines the URL path rewrite rules. The values captured in asterisk can be
+	// retrieved by index e.g. $1, $2 and so on.
+	// Example:
+	// "/old":              "/new",
+	// "/api/*":            "/$1",
+	// "/js/*":             "/public/javascripts/$1",
+	// "/users/*/orders/*": "/user/$1/order/$2",
+	// Required.
+	Rules map[string]string `yaml:"rules"`
 
-		// RegexRules defines the URL path rewrite rules using regexp.Rexexp with captures
-		// Every capture group in the values can be retrieved by index e.g. $1, $2 and so on.
-		// Example:
-		// "^/old/[0.9]+/":     "/new",
-		// "^/api/.+?/(.*)":     "/v2/$1",
-		RegexRules map[*regexp.Regexp]string `yaml:"-"`
-	}
-)
+	// RegexRules defines the URL path rewrite rules using regexp.Rexexp with captures
+	// Every capture group in the values can be retrieved by index e.g. $1, $2 and so on.
+	// Example:
+	// "^/old/[0.9]+/":     "/new",
+	// "^/api/.+?/(.*)":     "/v2/$1",
+	RegexRules map[*regexp.Regexp]string `yaml:"-"`
+}
 
-var (
-	// DefaultRewriteConfig is the default Rewrite middleware config.
-	DefaultRewriteConfig = RewriteConfig{
-		Skipper: DefaultSkipper,
-	}
-)
+// DefaultRewriteConfig is the default Rewrite middleware config.
+var DefaultRewriteConfig = RewriteConfig{
+	Skipper: DefaultSkipper,
+}
 
 // Rewrite returns a Rewrite middleware.
 //

--- a/middleware/secure.go
+++ b/middleware/secure.go
@@ -9,84 +9,80 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-type (
-	// SecureConfig defines the config for Secure middleware.
-	SecureConfig struct {
-		// Skipper defines a function to skip middleware.
-		Skipper Skipper
+// SecureConfig defines the config for Secure middleware.
+type SecureConfig struct {
+	// Skipper defines a function to skip middleware.
+	Skipper Skipper
 
-		// XSSProtection provides protection against cross-site scripting attack (XSS)
-		// by setting the `X-XSS-Protection` header.
-		// Optional. Default value "1; mode=block".
-		XSSProtection string `yaml:"xss_protection"`
+	// XSSProtection provides protection against cross-site scripting attack (XSS)
+	// by setting the `X-XSS-Protection` header.
+	// Optional. Default value "1; mode=block".
+	XSSProtection string `yaml:"xss_protection"`
 
-		// ContentTypeNosniff provides protection against overriding Content-Type
-		// header by setting the `X-Content-Type-Options` header.
-		// Optional. Default value "nosniff".
-		ContentTypeNosniff string `yaml:"content_type_nosniff"`
+	// ContentTypeNosniff provides protection against overriding Content-Type
+	// header by setting the `X-Content-Type-Options` header.
+	// Optional. Default value "nosniff".
+	ContentTypeNosniff string `yaml:"content_type_nosniff"`
 
-		// XFrameOptions can be used to indicate whether or not a browser should
-		// be allowed to render a page in a <frame>, <iframe> or <object> .
-		// Sites can use this to avoid clickjacking attacks, by ensuring that their
-		// content is not embedded into other sites.provides protection against
-		// clickjacking.
-		// Optional. Default value "SAMEORIGIN".
-		// Possible values:
-		// - "SAMEORIGIN" - The page can only be displayed in a frame on the same origin as the page itself.
-		// - "DENY" - The page cannot be displayed in a frame, regardless of the site attempting to do so.
-		// - "ALLOW-FROM uri" - The page can only be displayed in a frame on the specified origin.
-		XFrameOptions string `yaml:"x_frame_options"`
+	// XFrameOptions can be used to indicate whether or not a browser should
+	// be allowed to render a page in a <frame>, <iframe> or <object> .
+	// Sites can use this to avoid clickjacking attacks, by ensuring that their
+	// content is not embedded into other sites.provides protection against
+	// clickjacking.
+	// Optional. Default value "SAMEORIGIN".
+	// Possible values:
+	// - "SAMEORIGIN" - The page can only be displayed in a frame on the same origin as the page itself.
+	// - "DENY" - The page cannot be displayed in a frame, regardless of the site attempting to do so.
+	// - "ALLOW-FROM uri" - The page can only be displayed in a frame on the specified origin.
+	XFrameOptions string `yaml:"x_frame_options"`
 
-		// HSTSMaxAge sets the `Strict-Transport-Security` header to indicate how
-		// long (in seconds) browsers should remember that this site is only to
-		// be accessed using HTTPS. This reduces your exposure to some SSL-stripping
-		// man-in-the-middle (MITM) attacks.
-		// Optional. Default value 0.
-		HSTSMaxAge int `yaml:"hsts_max_age"`
+	// HSTSMaxAge sets the `Strict-Transport-Security` header to indicate how
+	// long (in seconds) browsers should remember that this site is only to
+	// be accessed using HTTPS. This reduces your exposure to some SSL-stripping
+	// man-in-the-middle (MITM) attacks.
+	// Optional. Default value 0.
+	HSTSMaxAge int `yaml:"hsts_max_age"`
 
-		// HSTSExcludeSubdomains won't include subdomains tag in the `Strict Transport Security`
-		// header, excluding all subdomains from security policy. It has no effect
-		// unless HSTSMaxAge is set to a non-zero value.
-		// Optional. Default value false.
-		HSTSExcludeSubdomains bool `yaml:"hsts_exclude_subdomains"`
+	// HSTSExcludeSubdomains won't include subdomains tag in the `Strict Transport Security`
+	// header, excluding all subdomains from security policy. It has no effect
+	// unless HSTSMaxAge is set to a non-zero value.
+	// Optional. Default value false.
+	HSTSExcludeSubdomains bool `yaml:"hsts_exclude_subdomains"`
 
-		// ContentSecurityPolicy sets the `Content-Security-Policy` header providing
-		// security against cross-site scripting (XSS), clickjacking and other code
-		// injection attacks resulting from execution of malicious content in the
-		// trusted web page context.
-		// Optional. Default value "".
-		ContentSecurityPolicy string `yaml:"content_security_policy"`
+	// ContentSecurityPolicy sets the `Content-Security-Policy` header providing
+	// security against cross-site scripting (XSS), clickjacking and other code
+	// injection attacks resulting from execution of malicious content in the
+	// trusted web page context.
+	// Optional. Default value "".
+	ContentSecurityPolicy string `yaml:"content_security_policy"`
 
-		// CSPReportOnly would use the `Content-Security-Policy-Report-Only` header instead
-		// of the `Content-Security-Policy` header. This allows iterative updates of the
-		// content security policy by only reporting the violations that would
-		// have occurred instead of blocking the resource.
-		// Optional. Default value false.
-		CSPReportOnly bool `yaml:"csp_report_only"`
+	// CSPReportOnly would use the `Content-Security-Policy-Report-Only` header instead
+	// of the `Content-Security-Policy` header. This allows iterative updates of the
+	// content security policy by only reporting the violations that would
+	// have occurred instead of blocking the resource.
+	// Optional. Default value false.
+	CSPReportOnly bool `yaml:"csp_report_only"`
 
-		// HSTSPreloadEnabled will add the preload tag in the `Strict Transport Security`
-		// header, which enables the domain to be included in the HSTS preload list
-		// maintained by Chrome (and used by Firefox and Safari): https://hstspreload.org/
-		// Optional.  Default value false.
-		HSTSPreloadEnabled bool `yaml:"hsts_preload_enabled"`
+	// HSTSPreloadEnabled will add the preload tag in the `Strict Transport Security`
+	// header, which enables the domain to be included in the HSTS preload list
+	// maintained by Chrome (and used by Firefox and Safari): https://hstspreload.org/
+	// Optional.  Default value false.
+	HSTSPreloadEnabled bool `yaml:"hsts_preload_enabled"`
 
-		// ReferrerPolicy sets the `Referrer-Policy` header providing security against
-		// leaking potentially sensitive request paths to third parties.
-		// Optional. Default value "".
-		ReferrerPolicy string `yaml:"referrer_policy"`
-	}
-)
+	// ReferrerPolicy sets the `Referrer-Policy` header providing security against
+	// leaking potentially sensitive request paths to third parties.
+	// Optional. Default value "".
+	ReferrerPolicy string `yaml:"referrer_policy"`
+}
 
-var (
-	// DefaultSecureConfig is the default Secure middleware config.
-	DefaultSecureConfig = SecureConfig{
-		Skipper:            DefaultSkipper,
-		XSSProtection:      "1; mode=block",
-		ContentTypeNosniff: "nosniff",
-		XFrameOptions:      "SAMEORIGIN",
-		HSTSPreloadEnabled: false,
-	}
-)
+// DefaultSecureConfig is the default Secure middleware config.
+var DefaultSecureConfig = SecureConfig{
+	Skipper:            DefaultSkipper,
+	XSSProtection:      "1; mode=block",
+	ContentTypeNosniff: "nosniff",
+	XFrameOptions:      "SAMEORIGIN",
+	HSTSPreloadEnabled: false,
+}
 
 // Secure returns a Secure middleware.
 // Secure middleware provides protection against cross-site scripting (XSS) attack,

--- a/middleware/slash.go
+++ b/middleware/slash.go
@@ -9,24 +9,20 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-type (
-	// TrailingSlashConfig defines the config for TrailingSlash middleware.
-	TrailingSlashConfig struct {
-		// Skipper defines a function to skip middleware.
-		Skipper Skipper
+// TrailingSlashConfig defines the config for TrailingSlash middleware.
+type TrailingSlashConfig struct {
+	// Skipper defines a function to skip middleware.
+	Skipper Skipper
 
-		// Status code to be used when redirecting the request.
-		// Optional, but when provided the request is redirected using this code.
-		RedirectCode int `yaml:"redirect_code"`
-	}
-)
+	// Status code to be used when redirecting the request.
+	// Optional, but when provided the request is redirected using this code.
+	RedirectCode int `yaml:"redirect_code"`
+}
 
-var (
-	// DefaultTrailingSlashConfig is the default TrailingSlash middleware config.
-	DefaultTrailingSlashConfig = TrailingSlashConfig{
-		Skipper: DefaultSkipper,
-	}
-)
+// DefaultTrailingSlashConfig is the default TrailingSlash middleware config.
+var DefaultTrailingSlashConfig = TrailingSlashConfig{
+	Skipper: DefaultSkipper,
+}
 
 // AddTrailingSlash returns a root level (before router) middleware which adds a
 // trailing slash to the request `URL#Path`.

--- a/middleware/static.go
+++ b/middleware/static.go
@@ -17,40 +17,38 @@ import (
 	"github.com/labstack/gommon/bytes"
 )
 
-type (
-	// StaticConfig defines the config for Static middleware.
-	StaticConfig struct {
-		// Skipper defines a function to skip middleware.
-		Skipper Skipper
+// StaticConfig defines the config for Static middleware.
+type StaticConfig struct {
+	// Skipper defines a function to skip middleware.
+	Skipper Skipper
 
-		// Root directory from where the static content is served.
-		// Required.
-		Root string `yaml:"root"`
+	// Root directory from where the static content is served.
+	// Required.
+	Root string `yaml:"root"`
 
-		// Index file for serving a directory.
-		// Optional. Default value "index.html".
-		Index string `yaml:"index"`
+	// Index file for serving a directory.
+	// Optional. Default value "index.html".
+	Index string `yaml:"index"`
 
-		// Enable HTML5 mode by forwarding all not-found requests to root so that
-		// SPA (single-page application) can handle the routing.
-		// Optional. Default value false.
-		HTML5 bool `yaml:"html5"`
+	// Enable HTML5 mode by forwarding all not-found requests to root so that
+	// SPA (single-page application) can handle the routing.
+	// Optional. Default value false.
+	HTML5 bool `yaml:"html5"`
 
-		// Enable directory browsing.
-		// Optional. Default value false.
-		Browse bool `yaml:"browse"`
+	// Enable directory browsing.
+	// Optional. Default value false.
+	Browse bool `yaml:"browse"`
 
-		// Enable ignoring of the base of the URL path.
-		// Example: when assigning a static middleware to a non root path group,
-		// the filesystem path is not doubled
-		// Optional. Default value false.
-		IgnoreBase bool `yaml:"ignoreBase"`
+	// Enable ignoring of the base of the URL path.
+	// Example: when assigning a static middleware to a non root path group,
+	// the filesystem path is not doubled
+	// Optional. Default value false.
+	IgnoreBase bool `yaml:"ignoreBase"`
 
-		// Filesystem provides access to the static content.
-		// Optional. Defaults to http.Dir(config.Root)
-		Filesystem http.FileSystem `yaml:"-"`
-	}
-)
+	// Filesystem provides access to the static content.
+	// Optional. Defaults to http.Dir(config.Root)
+	Filesystem http.FileSystem `yaml:"-"`
+}
 
 const html = `
 <!DOCTYPE html>
@@ -124,13 +122,11 @@ const html = `
 </html>
 `
 
-var (
-	// DefaultStaticConfig is the default Static middleware config.
-	DefaultStaticConfig = StaticConfig{
-		Skipper: DefaultSkipper,
-		Index:   "index.html",
-	}
-)
+// DefaultStaticConfig is the default Static middleware config.
+var DefaultStaticConfig = StaticConfig{
+	Skipper: DefaultSkipper,
+	Index:   "index.html",
+}
 
 // Static returns a Static middleware to serves static content from the provided
 // root directory.

--- a/middleware/timeout.go
+++ b/middleware/timeout.go
@@ -80,14 +80,12 @@ type TimeoutConfig struct {
 	Timeout time.Duration
 }
 
-var (
-	// DefaultTimeoutConfig is the default Timeout middleware config.
-	DefaultTimeoutConfig = TimeoutConfig{
-		Skipper:      DefaultSkipper,
-		Timeout:      0,
-		ErrorMessage: "",
-	}
-)
+// DefaultTimeoutConfig is the default Timeout middleware config.
+var DefaultTimeoutConfig = TimeoutConfig{
+	Skipper:      DefaultSkipper,
+	Timeout:      0,
+	ErrorMessage: "",
+}
 
 // Timeout returns a middleware which returns error (503 Service Unavailable error) to client immediately when handler
 // call runs for longer than its time limit. NB: timeout does not stop handler execution.

--- a/response.go
+++ b/response.go
@@ -10,20 +10,18 @@ import (
 	"net/http"
 )
 
-type (
-	// Response wraps an http.ResponseWriter and implements its interface to be used
-	// by an HTTP handler to construct an HTTP response.
-	// See: https://golang.org/pkg/net/http/#ResponseWriter
-	Response struct {
-		echo        *Echo
-		beforeFuncs []func()
-		afterFuncs  []func()
-		Writer      http.ResponseWriter
-		Status      int
-		Size        int64
-		Committed   bool
-	}
-)
+// Response wraps an http.ResponseWriter and implements its interface to be used
+// by an HTTP handler to construct an HTTP response.
+// See: https://golang.org/pkg/net/http/#ResponseWriter
+type Response struct {
+	echo        *Echo
+	beforeFuncs []func()
+	afterFuncs  []func()
+	Writer      http.ResponseWriter
+	Status      int
+	Size        int64
+	Committed   bool
+}
 
 // NewResponse creates a new instance of Response.
 func NewResponse(w http.ResponseWriter, e *Echo) (r *Response) {

--- a/router.go
+++ b/router.go
@@ -9,56 +9,58 @@ import (
 	"net/http"
 )
 
-type (
-	// Router is the registry of all registered routes for an `Echo` instance for
-	// request matching and URL path parameter parsing.
-	Router struct {
-		tree   *node
-		routes map[string]*Route
-		echo   *Echo
-	}
-	node struct {
-		kind           kind
-		label          byte
-		prefix         string
-		parent         *node
-		staticChildren children
-		originalPath   string
-		methods        *routeMethods
-		paramChild     *node
-		anyChild       *node
-		paramsCount    int
-		// isLeaf indicates that node does not have child routes
-		isLeaf bool
-		// isHandler indicates that node has at least one handler registered to it
-		isHandler bool
+// Router is the registry of all registered routes for an `Echo` instance for
+// request matching and URL path parameter parsing.
+type Router struct {
+	tree   *node
+	routes map[string]*Route
+	echo   *Echo
+}
 
-		// notFoundHandler is handler registered with RouteNotFound method and is executed for 404 cases
-		notFoundHandler *routeMethod
-	}
-	kind        uint8
-	children    []*node
-	routeMethod struct {
-		ppath   string
-		pnames  []string
-		handler HandlerFunc
-	}
-	routeMethods struct {
-		connect     *routeMethod
-		delete      *routeMethod
-		get         *routeMethod
-		head        *routeMethod
-		options     *routeMethod
-		patch       *routeMethod
-		post        *routeMethod
-		propfind    *routeMethod
-		put         *routeMethod
-		trace       *routeMethod
-		report      *routeMethod
-		anyOther    map[string]*routeMethod
-		allowHeader string
-	}
-)
+type node struct {
+	kind           kind
+	label          byte
+	prefix         string
+	parent         *node
+	staticChildren children
+	originalPath   string
+	methods        *routeMethods
+	paramChild     *node
+	anyChild       *node
+	paramsCount    int
+	// isLeaf indicates that node does not have child routes
+	isLeaf bool
+	// isHandler indicates that node has at least one handler registered to it
+	isHandler bool
+
+	// notFoundHandler is handler registered with RouteNotFound method and is executed for 404 cases
+	notFoundHandler *routeMethod
+}
+
+type kind uint8
+type children []*node
+
+type routeMethod struct {
+	ppath   string
+	pnames  []string
+	handler HandlerFunc
+}
+
+type routeMethods struct {
+	connect     *routeMethod
+	delete      *routeMethod
+	get         *routeMethod
+	head        *routeMethod
+	options     *routeMethod
+	patch       *routeMethod
+	post        *routeMethod
+	propfind    *routeMethod
+	put         *routeMethod
+	trace       *routeMethod
+	report      *routeMethod
+	anyOther    map[string]*routeMethod
+	allowHeader string
+}
 
 const (
 	staticKind kind = iota


### PR DESCRIPTION
Change type definition blocks to single declarations. This helps copy/pasting Echo code in examples (for issues and discussions and for Echo website). 

I admit this is yak shaving but answering issues with good examples is probably biggest time sink when it comes to maintaining Echo. And I feel that is important to answer with examples etc.   Also - website middleware part has block with middleware configurations. It is dedious to copy/paste middleware conf type there and have markdown intentation broken (blocks like that https://github.com/labstack/echox/blob/master/website/docs/middleware/csrf.md#configuration).