### PR TITLE
When route is registered with empty path it is normalized to `/`. 

### DIFF
--- a/echo_test.go
+++ b/echo_test.go
@@ -1599,6 +1599,11 @@ func TestEchoReverse(t *testing.T) {
 		expect        string
 	}{
 		{
+			name:          "ok, not existing path returns empty url",
+			whenRouteName: "not-existing",
+			expect:        "",
+		},
+		{
 			name:          "ok,static with no params",
 			whenRouteName: "/static",
 			expect:        "/static",

--- a/router_test.go
+++ b/router_test.go
@@ -2770,6 +2770,22 @@ func TestRouter_Routes(t *testing.T) {
 	}
 }
 
+func TestRouter_addEmptyPathToSlashReverse(t *testing.T) {
+	e := New()
+	r := e.router
+	r.add(http.MethodGet, "", "empty", handlerFunc) // emtpy path is normalized to `/`
+
+	assert.Equal(t, "/", r.Reverse("empty"))
+}
+
+func TestRouter_ReverseNotFound(t *testing.T) {
+	e := New()
+	r := e.router
+	r.add(http.MethodGet, "", "empty", handlerFunc)
+
+	assert.Equal(t, "", r.Reverse("not-existing"))
+}
+
 func TestRouter_Reverse(t *testing.T) {
 	e := New()
 	r := e.router


### PR DESCRIPTION
When route is registered with empty path it is normalized to `/`. Make sure that returned echo.Route structs reflect that behavior.  Internally router has changed `` (empty path) to `/` for a long time but Route that is returned did not reflect that. Is is problematic with `Reverse` function that uses empty string as "not found"

Related to #2615

Previous behavior can be seen with this test:
```go
func TestTest(t *testing.T) {
	e := echo.New()

	handler := func(c echo.Context) error {
		return c.String(http.StatusNotImplemented, "Nope")
	}
	r := e.GET("", handler) // path is registered as "" previously. After change `/` is registered
	r.Name = "test"

	existingEmpty := e.Reverse("test")
	assert.Equal(t, "", existingEmpty)

	notExistingEmpty := e.Reverse("not-existing")
	assert.Equal(t, "", notExistingEmpty)
}
```

whis this change `assert.Equal(t, "", existingEmpty)` shoulb be change to  `assert.Equal(t, "/", existingEmpty)`to pass the test