### PR TITLE
When struct tag is not set, use actual field name for binding

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -215,6 +215,11 @@ func (b *DefaultBinder) bindData(destination interface{}, data map[string][]stri
 			inputFieldName = typeField.Name
 		}
 
+		// skipped by struct tag
+		if inputFieldName[0] == '-' {
+			continue
+		}
+
 		inputValue, exists := data[inputFieldName]
 		if !exists {
 			// Go json.Unmarshal supports case insensitive binding.  However the

--- a/bind_test.go
+++ b/bind_test.go
@@ -1462,3 +1462,26 @@ func TestBindWithFallback(t *testing.T) {
 		assert.Equal(t, &fptr, ts.PtrF64)
 	})
 }
+
+func TestBindWithSkip(t *testing.T) {
+	t.Run("skip with dash", func(t *testing.T) {
+		var ts = struct {
+			Value   string `form:"val"`
+			Comment string `form:"-"`
+		}{}
+
+		b := &DefaultBinder{}
+		err := b.bindData(&ts, map[string][]string{
+			"key":     {"name"},
+			"val":     {"echo"},
+			"-":       {"dash"},
+			"comment": {"none"},
+		}, "form")
+
+		assert.NoError(t, err)
+		assert.Equal(t, "echo", ts.Value)
+		assert.NotEqual(t, "dash", ts.Comment)
+		assert.NotEqual(t, "none", ts.Comment)
+		assert.Equal(t, "", ts.Comment)
+	})
+}


### PR DESCRIPTION
recently been using echo and even porting apps to echo from net/http and others.

i have added some tiny improvements in struct binding:
- if struct tag is missing then try to use field name as lookup key in data map (similar behavior as bson) 
  - this feature is controlled by flag, `(*Echo).Binder` continues to work as it is
  - user can opt in to use this feature by setting `(*Echo).Binder = echo.BinderWithFallback()`)
- if the struct tag value is specified as a dash `-` it is skipped (similar behavior as encoding/json)
  - this feature is right there without a flag but it should not be a problem as reading certain value from `-` field is extremely unlikely and us gophers already treat it as a skipper (from well known behavior of json and others)
