### PR TITLE
clickable URL

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -798,7 +798,7 @@ func (e *Echo) configureServer(s *http.Server) error {
 			e.Listener = l
 		}
 		if !e.HidePort {
-			e.colorer.Printf("⇨ http server started on %s\n", e.colorer.Green(e.Listener.Addr()))
+			e.colorer.Printf("⇨ http server started on http://%s\n", e.colorer.Green(e.Listener.Addr()))
 		}
 		return nil
 	}
@@ -810,7 +810,7 @@ func (e *Echo) configureServer(s *http.Server) error {
 		e.TLSListener = tls.NewListener(l, s.TLSConfig)
 	}
 	if !e.HidePort {
-		e.colorer.Printf("⇨ https server started on %s\n", e.colorer.Green(e.TLSListener.Addr()))
+		e.colorer.Printf("⇨ https server started on https://%s\n", e.colorer.Green(e.TLSListener.Addr()))
 	}
 	return nil
 }
@@ -861,7 +861,7 @@ func (e *Echo) StartH2CServer(address string, h2s *http2.Server) error {
 		e.Listener = l
 	}
 	if !e.HidePort {
-		e.colorer.Printf("⇨ http server started on %s\n", e.colorer.Green(e.Listener.Addr()))
+		e.colorer.Printf("⇨ http server started on http://%s\n", e.colorer.Green(e.Listener.Addr()))
 	}
 	e.startupMutex.Unlock()
 	return s.Serve(e.Listener)


### PR DESCRIPTION
just added http:// or https:// in front of the address when printed into the console to make it clickable.
probably better if i print it myself but this way its the last thing that's printed in the console and it's just easier