### PR TITLE
Allow content type middleware

### DIFF
--- a/middleware/allow_content_type.go
+++ b/middleware/allow_content_type.go
@@ -1,0 +1,24 @@
+package middleware
+
+import (
+	"mime"
+	"net/http"
+	"slices"
+
+	"github.com/labstack/echo/v4"
+)
+
+func AllowContentType(contentTypes ...string) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			mediaType, _, err := mime.ParseMediaType(c.Request().Header.Get("Content-Type"))
+			if err != nil {
+				return echo.NewHTTPError(http.StatusBadRequest, "invalid content-type value")
+			}
+			if slices.Contains(contentTypes, mediaType) {
+				return next(c)
+			}
+			return echo.NewHTTPError(http.StatusUnsupportedMediaType)
+		}
+	}
+}

--- a/middleware/allow_content_type.go
+++ b/middleware/allow_content_type.go
@@ -11,6 +11,16 @@ import (
 func AllowContentType(contentTypes ...string) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
+			var acceptTypes = ""
+			for i, contentType := range contentTypes {
+				acceptTypes += contentType
+
+				if i != len(contentTypes)-1 {
+					acceptTypes += ","
+				}
+			}
+			c.Response().Header().Set("Accept", acceptTypes)
+
 			mediaType, _, err := mime.ParseMediaType(c.Request().Header.Get("Content-Type"))
 			if err != nil {
 				return echo.NewHTTPError(http.StatusBadRequest, "invalid content-type value")

--- a/middleware/allow_content_type_test.go
+++ b/middleware/allow_content_type_test.go
@@ -13,7 +13,6 @@ func TestAllowContentType(t *testing.T) {
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	res := httptest.NewRecorder()
-	c := e.NewContext(req, res)
 
 	h := AllowContentType("application/json")(func(c echo.Context) error {
 		return c.String(http.StatusOK, "test")
@@ -21,9 +20,12 @@ func TestAllowContentType(t *testing.T) {
 
 	// Test valid content type
 	req.Header.Add("Content-Type", "application/json")
+	c := e.NewContext(req, res)
 	assert.NoError(t, h(c))
 
 	// Test invalid content type
-	req.Header.Add("Content-Type", "text/plain")
-	assert.NoError(t, h(c))
+	req.Header.Set("Content-Type", "text/plain")
+	c = e.NewContext(req, res)
+	he := h(c).(*echo.HTTPError)
+	assert.Equal(t, http.StatusUnsupportedMediaType, he.Code)
 }

--- a/middleware/allow_content_type_test.go
+++ b/middleware/allow_content_type_test.go
@@ -1,0 +1,29 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAllowContentType(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	res := httptest.NewRecorder()
+	c := e.NewContext(req, res)
+
+	h := AllowContentType("application/json")(func(c echo.Context) error {
+		return c.String(http.StatusOK, "test")
+	})
+
+	// Test valid content type
+	req.Header.Add("Content-Type", "application/json")
+	assert.NoError(t, h(c))
+
+	// Test invalid content type
+	req.Header.Add("Content-Type", "text/plain")
+	assert.NoError(t, h(c))
+}

--- a/middleware/allow_content_type_test.go
+++ b/middleware/allow_content_type_test.go
@@ -22,6 +22,7 @@ func TestAllowContentType(t *testing.T) {
 	req.Header.Add("Content-Type", "application/json")
 	c := e.NewContext(req, res)
 	assert.NoError(t, h(c))
+	assert.Equal(t, "application/json", res.Header().Get("Accept"))
 
 	// Test invalid content type
 	req.Header.Set("Content-Type", "text/plain")


### PR DESCRIPTION
Based on #2551

Adds a new middleware `AllowContentType` which restricts routes to only accepts requests with certain `Content-Type` header values. 

It's similar to the middleware of the same name available with Chi 

The middleware also sets the `Accept` header field to the specified content types for all requests