### PR TITLE
fix: Unclear behaviour of * in routes

### DIFF
--- a/router.go
+++ b/router.go
@@ -699,10 +699,10 @@ func (r *Router) Find(method, path string, c Context) {
 				for ; i < l && search[i] != '/'; i++ {
 				}
 				search = search[i:]
-				searchIndex = searchIndex + len(search)
 				previousBestMatchNode = currentNode
 				if len(search) != 0 {
 					if child := currentNode.findStaticChild(search[0]); child != nil {
+						searchIndex = searchIndex + len(child.prefix)
 						currentNode = child
 						continue
 					}

--- a/router.go
+++ b/router.go
@@ -692,6 +692,22 @@ func (r *Router) Find(method, path string, c Context) {
 
 			// update indexes/search in case we need to backtrack when no handler match is found
 			paramIndex++
+			if !currentNode.isLeaf {
+				i := 0
+				l := len(search)
+
+				for ; i < l && search[i] != '/'; i++ {
+				}
+				search = search[i:]
+				searchIndex = searchIndex + len(search)
+				previousBestMatchNode = currentNode
+				if len(search) != 0 {
+					if child := currentNode.findStaticChild(search[0]); child != nil {
+						currentNode = child
+						continue
+					}
+				}
+			}
 			searchIndex += +len(search)
 			search = ""
 

--- a/router_test.go
+++ b/router_test.go
@@ -1579,13 +1579,19 @@ func TestRouterAnyMatchesLastAddedAnyRoute(t *testing.T) {
 	assert.Equal(t, "/users/*/action*", c.Get("path"))
 	assert.Equal(t, "xxx/action/sea", c.Param("*"))
 
-	// if we add another route then it is the last added and so it is matched
 	r.Add(http.MethodGet, "/users/*/action/search", handlerHelper("case", 3))
 
+	// should not match incomplete route with wildcard but match previous one
 	r.Find(http.MethodGet, "/users/xxx/action/sea", c)
 	c.handler(c)
-	assert.Equal(t, "/users/*/action/search", c.Get("path"))
+	assert.Equal(t, "/users/*/action*", c.Get("path"))
 	assert.Equal(t, "xxx/action/sea", c.Param("*"))
+
+	// should match route with wildcard and static suffix
+	r.Find(http.MethodGet, "/users/xxx/action/search", c)
+	c.handler(c)
+	assert.Equal(t, "/users/*/action/search", c.Get("path"))
+	assert.Equal(t, "xxx/action/search", c.Param("*"))
 }
 
 // Issue #1739


### PR DESCRIPTION
This should hopefully bring more clarity into this issue https://github.com/labstack/echo/issues/2619

Examples would explain this better so here's similar to one from discussion

```
func main() {
	handler := func(c echo.Context) error {
		fmt.Printf("%s\n", c.Path())
		return nil
	}

	e := echo.New()
	v2 := e.Group("/v2")

	v2.DELETE("/*/blobs/:digest", handler)
	v2.GET("/*/blobs/:digest", handler)
	v2.HEAD("/*/blobs/:digest", handler)

	v2.DELETE("/*/manifests/:ref", handler)
	v2.GET("/*/manifests/:ref", handler)
	v2.HEAD("/*/manifests/:ref", handler)
	v2.PUT("/*/manifests/:ref", handler)

	v2.GET("/*/tags/list", handler)     // one wildcard
	v2.GET("/*/*/tags/list", handler)   // two wildcards
	v2.GET("/*/*/tags/list2*", handler) // two wildcards and trailing one
	v2.GET("/*/*/tags/list2", handler)  // two wildcards with fixed ending that may conflict with previous route

	v2.GET("/*/blobs/uploads/:ref", handler)
	v2.PATCH("/*/blobs/uploads/:ref", handler)
	v2.POST("/*/blobs/uploads", handler)
	v2.PUT("/*/blobs/uploads/:ref", handler)

	v2.GET("", handler)
	err := e.Start(":8080")
	if err != nil {
		panic(err)
	}
}
```

Example curl calls that should match those routes:

```
curl -ik  http://localhost:8080/v2/wildcard1/tags/list
# Matches /*/tags/list

curl -ik  http://localhost:8080/v2/wildcard1/wildcard2/tags/list
# Matches /*/*/tags/list

curl -ik  http://localhost:8080/v2/wildcard1/wildcard2/tags/list2wildcard3
# Matches /*/*/tags/list2*

curl -ik  http://localhost:8080/v2/wildcard1/wildcard2/tags/list2
# Matches /*/*/tags/list2
```


This one doesn't match since you would need to register it as `/*/*/*/tags/list` and this probably better implemented as separate `**` wildcard
```
curl -ik  http://localhost:8080/v2/wildcard1/wildcard2/nowildcard/tags/list
{"message":"Method Not Allowed"}
```
