### PR TITLE
Implement Context interceptor for ServeHTTP

### DIFF
--- a/echo_test.go
+++ b/echo_test.go
@@ -1843,7 +1843,7 @@ func TestEcho_ServeHTTPContextInterceptor(t *testing.T) {
 
 type serveHTTPContextInterceptorRW struct {
 	header     http.Header
-	buffer     *bytes.Buffer
+	buffer     bytes.Buffer
 	statusCode int
 	intercept  func(ctx Context, handle func(ctx Context))
 }
@@ -1856,9 +1856,6 @@ func (rw *serveHTTPContextInterceptorRW) Header() http.Header {
 }
 
 func (rw *serveHTTPContextInterceptorRW) Write(data []byte) (int, error) {
-	if rw.buffer == nil {
-		rw.buffer = &bytes.Buffer{}
-	}
 	return rw.buffer.Write(data)
 }
 


### PR DESCRIPTION
I need to adjust the Context when using ServeHTTP, when not feasible with normal middleware.

Consider the following scenario.

When using WebSockets, I want to convert a received message to a http.Request.
Together with a custom ResponseWriter the request is handled by echo's ServeHTTP.
But I want to adjust the Context and add my Socket reference to it.

There is no way to access the Context, except via middleware, but when handling middleware I have no actual access the the websocket anymore.

The easiest way to do this without interfering with other functionality or adding new functions, is checking if ResponseWriter conforms to a specific interface (ServeHTTPContextInterceptor) , if so, execute the interceptor and continue handling with the adjusted context.

Now a custom ResponseWriter can implement this interface and return a custom Context before `handle` and cleanup aftwards.

```
func (responseWriter *responseWriter) InterceptContext(ctx Echo.Context, handle func(ctx Echo.Context)) {

	handle(ctx)
}
```

Implemented and running in production at scale.

Another implemented usecase:

I have an Amazon AWS API Gateway routing all traffic to one Lambda Function, written in golang.

On receiving the call, I create a http.Request and ResponseWriter and perform ServeHTTP on echo, to handle the call.

Now I can create a Custom Context that hold various extra details about the request from API gateway.