### PR TITLE
set cookie to request

### DIFF
--- a/context.go
+++ b/context.go
@@ -424,6 +424,7 @@ func (c *context) Cookie(name string) (*http.Cookie, error) {
 
 func (c *context) SetCookie(cookie *http.Cookie) {
 	http.SetCookie(c.Response(), cookie)
+	c.Request().AddCookie(cookie)
 }
 
 func (c *context) Cookies() []*http.Cookie {

--- a/context_test.go
+++ b/context_test.go
@@ -594,6 +594,9 @@ func TestContextCookie(t *testing.T) {
 	assert.Contains(t, rec.Header().Get(HeaderSetCookie), "labstack.com")
 	assert.Contains(t, rec.Header().Get(HeaderSetCookie), "Secure")
 	assert.Contains(t, rec.Header().Get(HeaderSetCookie), "HttpOnly")
+
+	_, reqCookieErr := req.Cookie("SSID")
+	assert.NoError(t, reqCookieErr)
 }
 
 func TestContextPath(t *testing.T) {


### PR DESCRIPTION
When setting a cookie to response also set it the request so that it can be retrieved in the same request.