### PR TITLE
fix(bind body): content-length can be -1

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -67,7 +67,7 @@ func (b *DefaultBinder) BindQueryParams(c Context, i interface{}) error {
 // See MIMEMultipartForm: https://golang.org/pkg/net/http/#Request.ParseMultipartForm
 func (b *DefaultBinder) BindBody(c Context, i interface{}) (err error) {
 	req := c.Request()
-	if req.ContentLength == 0 {
+	if req.ContentLength <= 0 {
 		return
 	}
 

--- a/bind_test.go
+++ b/bind_test.go
@@ -1060,6 +1060,14 @@ func TestDefaultBinder_BindBody(t *testing.T) {
 			expect:           &Node{ID: 0, Node: ""},
 			expectError:      "code=415, message=Unsupported Media Type",
 		},
+		{
+			name:             "ok, JSON POST bind to struct with: path + query + http.NoBody",
+			givenURL:         "/api/real_node/endpoint?node=xxx",
+			givenMethod:      http.MethodPost,
+			givenContentType: MIMEApplicationJSON,
+			givenContent:     http.NoBody,
+			expect:           &Node{ID: 0, Node: ""},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
I am writing a unit test and using httptest.NewRequestWithContext to create an http request, it will return a new http request with content-length = -1 with body as http.NoBody

```go
httpReq := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
httpReq.Header.Set(echo.HeaderContentType, "application/json")
```

https://github.com/golang/go/blob/master/src/net/http/httptest/httptest.go#L46C1-L77C3
```go
func NewRequestWithContext(ctx context.Context, method, target string, body io.Reader) *http.Request {
	if method == "" {
		method = "GET"
	}
	req, err := http.ReadRequest(bufio.NewReader(strings.NewReader(method + " " + target + " HTTP/1.0\r\n\r\n")))
	if err != nil {
		panic("invalid NewRequest arguments; " + err.Error())
	}
	req = req.WithContext(ctx)

	// HTTP/1.0 was used above to avoid needing a Host field. Change it to 1.1 here.
	req.Proto = "HTTP/1.1"
	req.ProtoMinor = 1
	req.Close = false

	if body != nil {
		switch v := body.(type) {
		case *bytes.Buffer:
			req.ContentLength = int64(v.Len())
		case *bytes.Reader:
			req.ContentLength = int64(v.Len())
		case *strings.Reader:
			req.ContentLength = int64(v.Len())
		default:
			req.ContentLength = -1
		}
		if rc, ok := body.(io.ReadCloser); ok {
			req.Body = rc
		} else {
			req.Body = io.NopCloser(body)
		}
	}
```
this is inconsistent in go-source-code as http.NewRequestWithContext with body as http.NoBody will have content-length as 0. i don't know if this should be fixed in go-source-code. https://github.com/golang/go/issues/18117
https://github.com/golang/go/blob/master/src/net/http/request.go#L946-L951
```go
func NewRequestWithContext(ctx context.Context, method, url string, body io.Reader) (*Request, error) {
...
      if body != nil {
      ...
		case *bytes.Reader:
			req.ContentLength = int64(v.Len())
			snapshot := *v
			req.GetBody = func() (io.ReadCloser, error) {
				r := snapshot
				return io.NopCloser(&r), nil
			}
		case *strings.Reader:
			req.ContentLength = int64(v.Len())
			snapshot := *v
			req.GetBody = func() (io.ReadCloser, error) {
				r := snapshot
				return io.NopCloser(&r), nil
			}
		default:
			// This is where we'd set it to -1 (at least
			// if body != NoBody) to mean unknown, but
			// that broke people during the Go 1.8 testing
			// period. People depend on it being 0 I
			// guess. Maybe retry later. See Issue 18117.
```
