### PR TITLE
Shorten Github issue template and add test example

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,23 +1,32 @@
 ### Issue Description
 
-### Checklist
-
-- [ ] Dependencies installed
-- [ ] No typos
-- [ ] Searched existing issues and docs
-
-### Expected behaviour
-
-### Actual behaviour
-
-### Steps to reproduce
-
 ### Working code to debug
 
 ```go
 package main
 
-func main() {
+import (
+  "github.com/labstack/echo/v4"
+  "net/http"
+  "net/http/httptest"
+  "testing"
+)
+
+func TestExample(t *testing.T) {
+  e := echo.New()
+
+  e.GET("/", func(c echo.Context) error {
+    return c.String(http.StatusOK, "Hello, World!")
+  })
+
+  req := httptest.NewRequest(http.MethodGet, "/", nil)
+  rec := httptest.NewRecorder()
+
+  e.ServeHTTP(rec, req)
+
+  if rec.Code != http.StatusOK {
+    t.Errorf("got %d, want %d", rec.Code, http.StatusOK)
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ package main
 import (
   "github.com/labstack/echo/v4"
   "github.com/labstack/echo/v4/middleware"
+  "log/slog"
   "net/http"
 )
 
@@ -90,7 +91,9 @@ func main() {
   e.GET("/", hello)
 
   // Start server
-  e.Logger.Fatal(e.Start(":1323"))
+  if err := e.Start(":8080"); err != nil && !errors.Is(err, http.ErrServerClosed) {
+    slog.Error("failed to start server", "error", err)
+  }
 }
 
 // Handler


### PR DESCRIPTION
Issue template is such a hassle to fill. hardly anyone does that correctly. it is better to concentrate people focus to provide test to demonstrate the problem than filling paragraphs that they will not fill, most of the time.