### PR TITLE
Sorting directories and files for static file serving

### DIFF
--- a/middleware/static.go
+++ b/middleware/static.go
@@ -6,6 +6,7 @@ package middleware
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"html/template"
 	"net/http"
 	"net/url"
@@ -49,6 +50,12 @@ type StaticConfig struct {
 	// Optional. Defaults to http.Dir(config.Root)
 	Filesystem http.FileSystem `yaml:"-"`
 }
+
+// Used for sorting directories in listDir
+type byName []os.FileInfo
+func (s byName) Len() int           { return len(s) }
+func (s byName) Less(i, j int) bool { return s[i].Name() < s[j].Name() }
+func (s byName) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 
 const html = `
 <!DOCTYPE html>
@@ -250,6 +257,9 @@ func listDir(t *template.Template, name string, dir http.File, res *echo.Respons
 	if err != nil {
 		return
 	}
+
+	// Sort directories first
+	sort.Sort(byName(files))
 
 	// Create directory index
 	res.Header().Set(echo.HeaderContentType, echo.MIMETextHTMLCharsetUTF8)


### PR DESCRIPTION
echo.Static serves files but unsorted. To make them sorted, I've followed the same procedure as was done for [net/http](https://github.com/golang/go/issues/11879) (the fix they did is shown [here](https://github.com/golang/go/commit/25b00177af9f62f683ec68f1d697c2607d087ea6#diff-0661442fffb473f85dc4d4472172edbfb4b9b1837db3ab1a73e838bed3e6ab70R597)).

