### PR TITLE
Add Conditions to Ensure Bind Succeeds with `Transfer-Encoding: chunked`

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -67,14 +67,7 @@ func (b *DefaultBinder) BindQueryParams(c Context, i interface{}) error {
 // See MIMEMultipartForm: https://golang.org/pkg/net/http/#Request.ParseMultipartForm
 func (b *DefaultBinder) BindBody(c Context, i interface{}) (err error) {
 	req := c.Request()
-	var isChunked bool
-	for _, enc := range req.TransferEncoding {
-		if enc == "chunked" {
-			isChunked = true
-			break
-		}
-	}
-	if req.ContentLength <= 0 && !isChunked {
+	if req.ContentLength == 0 {
 		return
 	}
 

--- a/bind.go
+++ b/bind.go
@@ -67,7 +67,14 @@ func (b *DefaultBinder) BindQueryParams(c Context, i interface{}) error {
 // See MIMEMultipartForm: https://golang.org/pkg/net/http/#Request.ParseMultipartForm
 func (b *DefaultBinder) BindBody(c Context, i interface{}) (err error) {
 	req := c.Request()
-	if req.ContentLength <= 0 {
+	var isChunked bool
+	for _, enc := range req.TransferEncoding {
+		if enc == "chunked" {
+			isChunked = true
+			break
+		}
+	}
+	if req.ContentLength <= 0 && !isChunked {
 		return
 	}
 

--- a/bind_test.go
+++ b/bind_test.go
@@ -13,6 +13,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httputil"
 	"net/url"
 	"reflect"
 	"strconv"
@@ -941,6 +942,7 @@ func TestDefaultBinder_BindBody(t *testing.T) {
 		givenMethod      string
 		givenContentType string
 		whenNoPathParams bool
+		whenChunkedBody  bool
 		whenBindTarget   interface{}
 		expect           interface{}
 		expectError      string
@@ -1068,6 +1070,15 @@ func TestDefaultBinder_BindBody(t *testing.T) {
 			givenContent:     http.NoBody,
 			expect:           &Node{ID: 0, Node: ""},
 		},
+		{
+			name:             "ok, JSON POST bind to struct with: path + query + chunked body",
+			givenURL:         "/api/real_node/endpoint?node=xxx",
+			givenMethod:      http.MethodPost,
+			givenContentType: MIMEApplicationJSON,
+			givenContent:     httputil.NewChunkedReader(strings.NewReader("18\r\n" + `{"id": 1, "node": "zzz"}` + "\r\n0\r\n")),
+			whenChunkedBody:  true,
+			expect:           &Node{ID: 1, Node: "zzz"},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1082,6 +1093,10 @@ func TestDefaultBinder_BindBody(t *testing.T) {
 				req.Header.Set(HeaderContentType, MIMEApplicationForm)
 			case MIMEApplicationJSON:
 				req.Header.Set(HeaderContentType, MIMEApplicationJSON)
+			}
+			if tc.whenChunkedBody {
+				req.ContentLength = -1
+				req.TransferEncoding = append(req.TransferEncoding, "chunked")
 			}
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)

--- a/bind_test.go
+++ b/bind_test.go
@@ -1063,11 +1063,20 @@ func TestDefaultBinder_BindBody(t *testing.T) {
 			expectError:      "code=415, message=Unsupported Media Type",
 		},
 		{
-			name:             "ok, JSON POST bind to struct with: path + query + http.NoBody",
+			name:             "nok, JSON POST with http.NoBody",
 			givenURL:         "/api/real_node/endpoint?node=xxx",
 			givenMethod:      http.MethodPost,
 			givenContentType: MIMEApplicationJSON,
 			givenContent:     http.NoBody,
+			expect:           &Node{ID: 0, Node: ""},
+			expectError:      "code=400, message=EOF, internal=EOF",
+		},
+		{
+			name:             "ok, JSON POST with empty body",
+			givenURL:         "/api/real_node/endpoint?node=xxx",
+			givenMethod:      http.MethodPost,
+			givenContentType: MIMEApplicationJSON,
+			givenContent:     strings.NewReader(""),
 			expect:           &Node{ID: 0, Node: ""},
 		},
 		{


### PR DESCRIPTION
In Go, when the length of the Body is unknown, `ContentLength` is set to -1. As demonstrated in #2716, this applies to cases where `Transfer-Encoding: chunked` is used.

```
	// ContentLength records the length of the associated content.
	// The value -1 indicates that the length is unknown.
	// Values >= 0 indicate that the given number of bytes may
	// be read from Body.
	//
	// For client requests, a value of 0 with a non-nil Body is
	// also treated as unknown.
	ContentLength [int64](https://pkg.go.dev/builtin#int64)
```

https://pkg.go.dev/net/http#Request

Previously, only `0` was excluded during Bind, but starting from #2710, `-1` was also excluded, making it impossible to Bind requests with `Transfer-Encoding: chunked`. I have fixed this issue.


Fixes #2716.