### PR TITLE
Fix error in README example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,12 @@ Latest version of Echo supports last four Go major [releases](https://go.dev/doc
 package main
 
 import (
-  "github.com/labstack/echo/v4"
-  "github.com/labstack/echo/v4/middleware"
+  "errors"
   "log/slog"
   "net/http"
+
+  "github.com/labstack/echo/v4"
+  "github.com/labstack/echo/v4/middleware"
 )
 
 func main() {


### PR DESCRIPTION
the example code is missing an `errors` package import