### PR TITLE
CORS: reject requests with 401 for non-preflight request with not matching origin header

### DIFF
--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -262,7 +262,7 @@ func CORSWithConfig(config CORSConfig) echo.MiddlewareFunc {
 			// Origin not allowed
 			if allowOrigin == "" {
 				if !preflight {
-					return next(c)
+					return echo.ErrUnauthorized
 				}
 				return c.NoContent(http.StatusNoContent)
 			}

--- a/middleware/cors_test.go
+++ b/middleware/cors_test.go
@@ -525,7 +525,7 @@ func TestCorsHeaders(t *testing.T) {
 			allowedOrigin: "http://example.com",
 			method:        http.MethodGet,
 			expected:      false,
-			expectStatus:  http.StatusOK,
+			expectStatus:  http.StatusUnauthorized,
 		},
 		{
 			name:          "non-preflight request, allow specific origin, matching origin header = CORS logic done",


### PR DESCRIPTION
reject requests with 401 for non-preflight request with not matching origin header

fixes #2730