### PR TITLE
Fix/only set request id if not exists

### DIFF
--- a/middleware/request_id.go
+++ b/middleware/request_id.go
@@ -59,8 +59,8 @@ func RequestIDWithConfig(config RequestIDConfig) echo.MiddlewareFunc {
 			rid := req.Header.Get(config.TargetHeader)
 			if rid == "" {
 				rid = config.Generator()
+				res.Header().Set(config.TargetHeader, rid)
 			}
-			res.Header().Set(config.TargetHeader, rid)
 			if config.RequestIDHandler != nil {
 				config.RequestIDHandler(c, rid)
 			}


### PR DESCRIPTION
A small optimization of not trying to reset request id incase one already exists