### PR TITLE
fix: check array values

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -232,7 +232,12 @@ func (b *DefaultBinder) bindData(destination interface{}, data map[string][]stri
 			}
 		}
 
-		inputValue, exists := data[inputFieldName]
+		var inputValue []string
+		var exists bool
+		inputValue, exists = data[inputFieldName]
+		if !exists {
+			inputValue, exists = data[inputFieldName+"[]"]
+		}
 		if !exists {
 			// Go json.Unmarshal supports case-insensitive binding.  However the
 			// url params are bound case-sensitive which is inconsistent.  To


### PR DESCRIPTION
TL;DR: This fixes an issue where query bindings would not work for slices due to the way browsers would pass them.

Consider a struct like this:

```go
type Foo struct {
    Values []string `query:"values"`
}
```

Binding that struct using Echo's `ctx.Bind` function would work, as long as the request only contains query parameters which exactly match the `query` tag, like this:

```
?values=foo&values=bar
```

This is expected and works as it should. The HTTP spec even says that it's completely fine to pass the same query value multiple times.
However, major browsers (I've tested Firefox and Chromium), when asked to construct a query from an array, will create a query string like this:

```
?values[]=foo&values[]=bar
```

Notice the additional `[]` in the string. The spec [is somewhat murky](https://stackoverflow.com/a/9547490/10924593) on this and it seems there are differences between languages. Echo only supports the first version and will treat `[]` suffixes on query parameters as literal values. Creating a struct like `values[]` will pass that in, but then I need more custom logic to parse that if I want to support both. This PR fixes that. 

The fix I'm proposing here is the simplest I could come up with. It might not be the best or optimal.