### PR TITLE
Bind empty strings to nil pointers

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -357,6 +357,10 @@ func unmarshalInputsToField(valueKind reflect.Kind, values []string, field refle
 
 func unmarshalInputToField(valueKind reflect.Kind, val string, field reflect.Value) (bool, error) {
 	if valueKind == reflect.Ptr {
+		if val == "" {
+			field.Set(reflect.Zero(field.Type()))
+			return true, nil
+		}
 		if field.IsNil() {
 			field.Set(reflect.New(field.Type().Elem()))
 		}

--- a/bind_test.go
+++ b/bind_test.go
@@ -1453,6 +1453,37 @@ func TestBindInt8(t *testing.T) {
 	})
 }
 
+func TestBindPointer(t *testing.T) {
+	t.Run("nok, binding fails", func(t *testing.T) {
+		type target struct {
+			V *time.Time `query:"v"`
+		}
+		p := target{}
+		err := testBindURL("/?v=x", &p)
+		assert.EqualError(t, err, "code=400, message=parsing time \"x\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"x\" as \"2006\", internal=parsing time \"x\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"x\" as \"2006\"")
+	})
+
+	t.Run("ok, bind empty value to nil", func(t *testing.T) {
+		type target struct {
+			V *time.Time `query:"v"`
+		}
+		p := target{}
+		err := testBindURL("/?v=", &p)
+		assert.NoError(t, err)
+		assert.Nil(t, p.V)
+	})
+
+	t.Run("ok, binds to provided value", func(t *testing.T) {
+		type target struct {
+			V *time.Time `query:"v"`
+		}
+		p := target{}
+		err := testBindURL("/?v=2006-01-02T15:04:05Z", &p)
+		assert.NoError(t, err)
+		assert.Equal(t, "2006-01-02T15:04:05Z", p.V.Format(time.RFC3339))
+	})
+}
+
 func TestBindMultipartFormFiles(t *testing.T) {
 	file1 := createTestFormFile("file", "file1.txt")
 	file11 := createTestFormFile("file", "file11.txt")


### PR DESCRIPTION
This PR addresses an issue where empty parameter values (/?v=) are not properly handled when binding to pointer struct fields. Currently, when an empty value is passed for a field that is a pointer (e.g., *time.Time), the binding mechanism attempts to parse it rather than setting it to nil.

The change ensures that empty parameter values are treated differently from invalid values when binding to pointer fields:
- Invalid values (e.g., /?v=x for a time.Time field) correctly return a parsing error
- Empty values (e.g., /?v=) now properly set the pointer field to nil
- Valid values continue to work as expected

This behavior provides a cleaner way to handle optional fields in request parameters.

The motivation behind this change is handle empty optional params as mentioned above. This behaviour seems to be the default for a number of JS clients making requests to the echo handlers.