### PR TITLE
Revert "CORS: reject requests with 401 for non-preflight request with not matching origin header"

### DIFF
--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -262,7 +262,7 @@ func CORSWithConfig(config CORSConfig) echo.MiddlewareFunc {
 			// Origin not allowed
 			if allowOrigin == "" {
 				if !preflight {
-					return echo.ErrUnauthorized
+					return next(c)
 				}
 				return c.NoContent(http.StatusNoContent)
 			}

--- a/middleware/cors_test.go
+++ b/middleware/cors_test.go
@@ -525,7 +525,7 @@ func TestCorsHeaders(t *testing.T) {
 			allowedOrigin: "http://example.com",
 			method:        http.MethodGet,
 			expected:      false,
-			expectStatus:  http.StatusUnauthorized,
+			expectStatus:  http.StatusOK,
 		},
 		{
 			name:          "non-preflight request, allow specific origin, matching origin header = CORS logic done",


### PR DESCRIPTION
Reverts labstack/echo#2732

See: https://github.com/labstack/echo/issues/2767