### PR TITLE
Add authorization header handling in proxy middleware

### DIFF
--- a/middleware/proxy.go
+++ b/middleware/proxy.go
@@ -430,5 +430,16 @@ func proxyHTTP(tgt *ProxyTarget, c echo.Context, config ProxyConfig) http.Handle
 	}
 	proxy.Transport = config.Transport
 	proxy.ModifyResponse = config.ModifyResponse
+
+	// Handle authorization from target URL
+	if tgt.URL.User != nil {
+		originalDirector := proxy.Director
+		proxy.Director = func(req *http.Request) {
+			originalDirector(req)
+			password, _ := tgt.URL.User.Password()
+			req.SetBasicAuth(tgt.URL.User.Username(), password)
+		}
+	}
+
 	return proxy
 }


### PR DESCRIPTION
## Problem

When a proxy target URL contains User credentials, proxy middleware does not send request with the authorization header. This can lead to UnAuthorized Error (401) when connecting to upstream server.

## Solution

- Implemented logic to pass the Authorization header to the target if the proxy URL includes user credentials.
- Added unit tests to verify behavior for both scenarios: with and without user credentials in the proxy URL.