### PR TITLE
Fixes #2789 Fix panic messages in Flush()

### DIFF
--- a/response.go
+++ b/response.go
@@ -5,6 +5,7 @@ package echo
 
 import (
 	"bufio"
+	"fmt"
 	"errors"
 	"net"
 	"net/http"
@@ -88,7 +89,7 @@ func (r *Response) Write(b []byte) (n int, err error) {
 func (r *Response) Flush() {
 	err := http.NewResponseController(r.Writer).Flush()
 	if err != nil && errors.Is(err, http.ErrNotSupported) {
-		panic(errors.New("response writer flushing is not supported"))
+		panic(fmt.Errorf("echo: response writer %T does not support flushing (http.Flusher interface)", r.Writer))
 	}
 }
 


### PR DESCRIPTION
## Changes
Changed the PANIC message to be more specific.

## Improved debugging efficiency.
When Flush is not supported, it is clear which ResponseWriter is the culprit, speeding problem identification and resolution.

## Improved Developer Experience:
More specific error information makes it easier for developers to understand the cause of problems.
More specific error information helps developers understand the cause of problems.