### PR TITLE
Fixes #2789 Fix panic messages in Flush() and test

### DIFF
--- a/response.go
+++ b/response.go
@@ -5,6 +5,7 @@ package echo
 
 import (
 	"bufio"
+	"fmt"
 	"errors"
 	"net"
 	"net/http"
@@ -88,7 +89,7 @@ func (r *Response) Write(b []byte) (n int, err error) {
 func (r *Response) Flush() {
 	err := http.NewResponseController(r.Writer).Flush()
 	if err != nil && errors.Is(err, http.ErrNotSupported) {
-		panic(errors.New("response writer flushing is not supported"))
+		panic(fmt.Errorf("echo: response writer %T does not support flushing (http.Flusher interface)", r.Writer))
 	}
 }
 

--- a/response_test.go
+++ b/response_test.go
@@ -80,7 +80,7 @@ func TestResponse_FlushPanics(t *testing.T) {
 	res := &Response{echo: e, Writer: rw}
 
 	// we test that we behave as before unwrapping flushers - flushing writer that does not support it causes panic
-	assert.PanicsWithError(t, "response writer flushing is not supported", func() {
+	assert.PanicsWithError(t, "echo: response writer *echo.testResponseWriter does not support flushing (http.Flusher interface)", func() {
 		res.Flush()
 	})
 }


### PR DESCRIPTION
Sorry, I accidentally deleted the local directory I forked from, so I created a new Pull Request!

## Changes
Changed the PANIC message to be more specific.
`Tests related to it's changes`

## Improved debugging efficiency.
When Flush is not supported, it is clear which ResponseWriter is the culprit, speeding problem identification and resolution.

## Improved Developer Experience:
More specific error information makes it easier for developers to understand the cause of problems.
More specific error information helps developers understand the cause of problems.