### PR TITLE
Increased code robustness and consistency within the framework

### DIFF
--- a/middleware/body_dump_test.go
+++ b/middleware/body_dump_test.go
@@ -5,6 +5,7 @@ package middleware
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -92,11 +93,12 @@ func TestBodyDumpFails(t *testing.T) {
 }
 
 func TestBodyDumpResponseWriter_CanNotFlush(t *testing.T) {
+	rw := new(testResponseWriterNoFlushHijack)
 	bdrw := bodyDumpResponseWriter{
-		ResponseWriter: new(testResponseWriterNoFlushHijack), // this RW does not support flush
+		ResponseWriter: rw, // this RW does not support flush
 	}
 
-	assert.PanicsWithError(t, "response writer flushing is not supported", func() {
+	assert.PanicsWithError(t, fmt.Sprintf("echo: response writer %T does not support flushing (http.Flusher interface)", rw), func() {
 		bdrw.Flush()
 	})
 }


### PR DESCRIPTION
## Proposal
### 1. Error handling when reading request body:
Currently, errors in io.ReadAll(c.Request().Body) are ignored. If the read fails, subsequent handlers may receive an incomplete body, causing unexpected behavior. I believe that the robustness of the middleware can be improved by interrupting processing when an error occurs and returning an error.

```diff
import (
	"bufio"
	"bytes"
+++	"fmt"
	"errors"
	"io"
	"net"
// omission of sentence
			// Request
			reqBody := []byte{}
			if c.Request().Body != nil { // Read
---				reqBody, _ = io.ReadAll(c.Request().Body)
+++				var errRead error
+++				reqBody, errRead = io.ReadAll(c.Request().Body)
+++				if errRead != nil {
+++					return errRead
+++				}
			}
			c.Request().Body = io.NopCloser(bytes.NewBuffer(reqBody)) // Reset
```

### 2. Improvement of Flush panic messages:
Improve the messages when a panic occurs in the Flush method to be more detailed and consistent with the rest of the Echo framework (e.g., response.go). We believe this will make it clearer which ResponseWriters do not support the Flusher interface and make debugging easier.

```diff
import (
	"bufio"
	"bytes"
+++	"fmt"
	"errors"
	"io"
	"net"
// omission of sentence
func (w *bodyDumpResponseWriter) Flush() {
	err := http.NewResponseController(w.ResponseWriter).Flush()
	if err != nil && errors.Is(err, http.ErrNotSupported) {
		panic(errors.New("response writer flushing is not supported"))
		panic(fmt.Errorf("echo: response writer %T does not support flushing (http.Flusher interface)", w.ResponseWriter))
	}
}
```

### 3. Modification of tests to accommodate the above changes