### PR TITLE
Fix matchSubdomain function to correctly handle exact domain matches

### DIFF
--- a/middleware/util.go
+++ b/middleware/util.go
@@ -57,7 +57,7 @@ func matchSubdomain(domain, pattern string) bool {
 			return false
 		}
 	}
-	return false
+	return len(domComp) == len(patComp)
 }
 
 // https://tip.golang.org/doc/go1.19#:~:text=Read%20no%20longer%20buffers%20random%20data%20obtained%20from%20the%20operating%20system%20between%20calls


### PR DESCRIPTION
### Problem
The `matchSubdomain` function incorrectly returns `false` for exact domain matches without wildcards—for example, `http://example.com` vs. `http://example.com`.

### Cause
Even if all parts match during iteration, the function still returns false at the end.

### Fix
After the loop, if all parts match and the number of parts is equal between the pattern and the domain, it should return `true`—i.e., treat it as an exact match.

This PR adds that check.