### PR TITLE
router: return error when registering nil handler

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -574,6 +574,9 @@ func (e *Echo) File(path, file string, m ...MiddlewareFunc) *Route {
 
 func (e *Echo) add(host, method, path string, handler HandlerFunc, middlewares ...MiddlewareFunc) *Route {
 	router := e.findRouter(host)
+	if handler == nil {
+		panic(fmt.Errorf("echo: adding route without handler function: %s:%s", method, path))
+	}
 	//FIXME: when handler+middleware are both nil ... make it behave like handler removal
 	name := handlerName(handler)
 	route := router.add(method, path, name, func(c Context) error {

--- a/echo_test.go
+++ b/echo_test.go
@@ -1860,3 +1860,13 @@ func BenchmarkEchoGitHubAPIMisses(b *testing.B) {
 func BenchmarkEchoParseAPI(b *testing.B) {
 	benchmarkEchoRoutes(b, parseAPI)
 }
+
+func TestEcho_AddNilHandlerPanics(t *testing.T) {
+	e := New()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic when adding route with nil handler")
+		}
+	}()
+	e.Add(http.MethodGet, "/nil", nil)
+}

--- a/router.go
+++ b/router.go
@@ -216,9 +216,8 @@ func (r *Router) insert(method, path string, h HandlerFunc) {
 	pnames := []string{} // Param names
 	ppath := path        // Pristine path
 
-	if h == nil && r.echo.Logger != nil {
-		// FIXME: in future we should return error
-		r.echo.Logger.Errorf("Adding route without handler function: %v:%v", method, path)
+	if h == nil {
+		panic(fmt.Errorf("echo: adding route without handler function: %v:%v", method, path))
 	}
 
 	for i, lcpIndex := 0, len(path); i < lcpIndex; i++ {

--- a/router_test.go
+++ b/router_test.go
@@ -2889,3 +2889,16 @@ func BenchmarkRouterGooglePlusAPIMisses(b *testing.B) {
 func BenchmarkRouterParamsAndAnyAPI(b *testing.B) {
 	benchmarkRouterRoutes(b, paramAndAnyAPI, paramAndAnyAPIToFind)
 }
+
+func TestRouter_AddNilHandlerPanics(t *testing.T) {
+	e := New()
+	r := e.router
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic when adding route with nil handler")
+		}
+	}()
+
+	r.Add(http.MethodGet, "/nil", nil)
+}


### PR DESCRIPTION
Currently, `router.insert` only logs a warning when a nil handler is registered,
and continues processing. This can lead to runtime panics due to unnoticed misconfiguration.

This change makes router registration fail fast by returning an error
when a nil handler is provided, so that misconfigurations can be detected earlier.
