### PR TITLE
Fix misleading Context.Bind documentation comment

### DIFF
--- a/context.go
+++ b/context.go
@@ -102,8 +102,11 @@ type Context interface {
 	// Set saves data in the context.
 	Set(key string, val interface{})
 
-	// Bind binds path params, query params and the request body into provided type `i`. The default binder
-	// binds body based on Content-Type header.
+	// Bind binds data from multiple sources to the provided type `i` in this order:
+	// 1) path parameters, 2) query parameters (for GET/DELETE/HEAD only), 3) request body.
+	// Each step can override values from the previous step. For single source binding use
+	// BindPathParams, BindQueryParams, BindHeaders, or BindBody directly.
+	// The default binder handles body based on Content-Type header.
 	Bind(i interface{}) error
 
 	// Validate validates provided `i`. It is usually called after `Context#Bind()`.


### PR DESCRIPTION
## Summary

Addresses issue #2382 by correcting the misleading comment on `Context.Bind` that did not accurately describe the actual binding behavior.

## Problem

The comment on `Context.Bind` in `context.go` was incomplete and confusing:

**Previous comment:**
```go
// Bind binds path params, query params and the request body into provided type `i`. The default binder
// binds body based on Content-Type header.
```

**Issues with the old comment:**
1. ❌ Didn't explain the binding **order** (path → query → body)
2. ❌ Didn't mention that later steps can **override** earlier values  
3. ❌ Didn't specify that query params are only bound for **GET/DELETE/HEAD**
4. ❌ Didn't reference **single-source binding methods** for more control

## Solution

**New accurate comment:**
```go
// Bind binds data from multiple sources to the provided type `i` in this order:
// 1) path parameters, 2) query parameters (for GET/DELETE/HEAD only), 3) request body.
// Each step can override values from the previous step. For single source binding use
// BindPathParams, BindQueryParams, BindHeaders, or BindBody directly.
// The default binder handles body based on Content-Type header.
```

**Improvements:**
- ✅ **Clear binding order**: Explicitly states the 1-2-3 sequence
- ✅ **Override behavior**: Warns that later steps can override earlier values
- ✅ **HTTP method specifics**: Notes query param binding only for GET/DELETE/HEAD  
- ✅ **Alternative methods**: References single-source binding methods
- ✅ **Content-Type info**: Preserves useful body binding information

## Impact

This fix prevents confusion for developers who might expect different behavior from `Context.Bind()` based on the previous misleading documentation. Now the comment accurately reflects the actual implementation in `bind.go`.

## Type of Change

- 📚 **Documentation fix** - No code logic changes
- 🔧 **Comment improvement** - Better developer experience
- 🎯 **Issue resolution** - Directly addresses reported confusion

## Testing

- ✅ Code compiles without issues
- ✅ No functional changes - documentation only
- ✅ Comment aligns with actual `DefaultBinder.Bind` implementation

Fixes #2382

---

*This is a simple documentation improvement that enhances clarity for Echo developers using the binding functionality.*