### PR TITLE
Fix typo in ContextTimeout middleware comment

### DIFF
--- a/middleware/context_timeout.go
+++ b/middleware/context_timeout.go
@@ -16,7 +16,7 @@ type ContextTimeoutConfig struct {
 	// Skipper defines a function to skip middleware.
 	Skipper Skipper
 
-	// ErrorHandler is a function when error aries in middleware execution.
+	// ErrorHandler is a function when error arises in middleware execution.
 	ErrorHandler func(err error, c echo.Context) error
 
 	// Timeout configures a timeout for the middleware, defaults to 0 for no timeout


### PR DESCRIPTION
## Summary

Fixes a simple typo in the ContextTimeout middleware documentation.

**Change:**
- Line 19: `aries` → `arises` in ErrorHandler comment

**Benefits:**
- Correct English grammar
- Better code documentation

## Test plan

- [x] No functional changes
- [x] Tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)