### PR TITLE
Fix typo in SetParamValues comment

### DIFF
--- a/context.go
+++ b/context.go
@@ -359,7 +359,7 @@ func (c *context) ParamValues() []string {
 
 func (c *context) SetParamValues(values ...string) {
 	// NOTE: Don't just set c.pvalues = values, because it has to have length c.echo.maxParam (or bigger) at all times
-	// It will brake the Router#Find code
+	// It will break the Router#Find code
 	limit := len(values)
 	if limit > len(c.pvalues) {
 		c.pvalues = make([]string, limit)


### PR DESCRIPTION
## Summary

Fixes a simple typo in the SetParamValues method documentation.

**Change:**
- Line 362: `brake` → `break` in Router#Find code comment

**Benefits:**
- Correct English spelling
- Better code documentation clarity

## Test plan

- [x] No functional changes
- [x] Tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)