### PR TITLE
Fix duplicate plus operator in router backtracking logic

### DIFF
--- a/router.go
+++ b/router.go
@@ -692,7 +692,7 @@ func (r *Router) Find(method, path string, c Context) {
 
 			// update indexes/search in case we need to backtrack when no handler match is found
 			paramIndex++
-			searchIndex += +len(search)
+			searchIndex += len(search)
 			search = ""
 
 			if h := currentNode.findMethod(method); h != nil {


### PR DESCRIPTION
# Summary

This PR fixes a typo where searchIndex += +len(search) was incorrectly written with
duplicate plus operators. The correct expression should be searchIndex += len(search).

# Description

## Problem

In router.go at line 695, there is a syntax error with duplicate plus operators:

searchIndex += +len(search)

While Go interprets this as searchIndex = searchIndex + (+len(search)) (treating the
second + as a unary plus operator), it's clearly a typo and not the intended expression.

## Solution

Changed the expression to the correct form:

searchIndex += len(search)

## Impact

• Functionality: The behavior remains the same since Go's unary plus operator doesn't
change the value, but the code is now clearer and matches the intended logic.
• Readability: Improves code clarity by removing the confusing duplicate operator.

## Testing

• Existing tests should continue to pass as the functional behavior is unchanged
• The fix is in the router's backtracking logic for "any" node matching

## Location

• File: router.go
• Line: 695
• Function: Router.Find()