### PR TITLE
chore: fix typo in file path

### DIFF
--- a/group_test.go
+++ b/group_test.go
@@ -28,7 +28,7 @@ func TestGroup(t *testing.T) {
 	g.Any("/", h)
 	g.Match([]string{http.MethodGet, http.MethodPost}, "/", h)
 	g.Static("/static", "/tmp")
-	g.File("/walle", "_fixture/images//walle.png")
+	g.File("/walle", "_fixture/images/walle.png")
 }
 
 func TestGroupFile(t *testing.T) {


### PR DESCRIPTION
Correct the fixture path used in `group_test.go`.

### Change

- Remove the redundant slash in the file path used in `group_test.go`