### PR TITLE
Replace custom private IP range check with built-in net.IP.IsPrivate

### DIFF
--- a/ip.go
+++ b/ip.go
@@ -179,16 +179,6 @@ func newIPChecker(configs []TrustOption) *ipChecker {
 	return checker
 }
 
-// Go1.16+ added `ip.IsPrivate()` but until that use this implementation
-func isPrivateIPRange(ip net.IP) bool {
-	if ip4 := ip.To4(); ip4 != nil {
-		return ip4[0] == 10 ||
-			ip4[0] == 172 && ip4[1]&0xf0 == 16 ||
-			ip4[0] == 192 && ip4[1] == 168
-	}
-	return len(ip) == net.IPv6len && ip[0]&0xfe == 0xfc
-}
-
 func (c *ipChecker) trust(ip net.IP) bool {
 	if c.trustLoopback && ip.IsLoopback() {
 		return true
@@ -196,7 +186,7 @@ func (c *ipChecker) trust(ip net.IP) bool {
 	if c.trustLinkLocal && ip.IsLinkLocalUnicast() {
 		return true
 	}
-	if c.trustPrivateNet && isPrivateIPRange(ip) {
+	if c.trustPrivateNet && ip.IsPrivate() {
 		return true
 	}
 	for _, trustedRange := range c.trustExtraRanges {


### PR DESCRIPTION
Replace `isPrivateIPRange` with built-in method `net.IP.IsPrivate`