### PR TITLE
add DefaultBinder negative-path tests (multipart & non-struct)

### DIFF
--- a/bind_test.go
+++ b/bind_test.go
@@ -1577,7 +1577,7 @@ func TestTimeFormatBinding(t *testing.T) {
 		DateTimeLocal time.Time  `form:"datetime_local" format:"2006-01-02T15:04"`
 		Date          time.Time  `query:"date" format:"2006-01-02"`
 		CustomFormat  time.Time  `form:"custom" format:"01/02/2006 15:04:05"`
-		DefaultTime   time.Time  `form:"default_time"`                      // No format tag - should use default parsing
+		DefaultTime   time.Time  `form:"default_time"` // No format tag - should use default parsing
 		PtrTime       *time.Time `query:"ptr_time" format:"2006-01-02"`
 	}
 
@@ -1623,7 +1623,7 @@ func TestTimeFormatBinding(t *testing.T) {
 		{
 			name:        "nok, wrong format should fail",
 			contentType: MIMEApplicationForm,
-			data:        "datetime_local=2023-12-25",  // Missing time part
+			data:        "datetime_local=2023-12-25", // Missing time part
 			expectError: true,
 		},
 	}
@@ -1683,4 +1683,41 @@ func TestTimeFormatBinding(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsFieldMultipartFile_NonPointer_FileHeader_ReturnsError(t *testing.T) {
+	ok, err := isFieldMultipartFile(reflect.TypeOf(multipart.FileHeader{}))
+	assert.True(t, ok)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "binding to multipart.FileHeader struct is not supported")
+
+	// pointer type should be ok and no error
+	ok, err = isFieldMultipartFile(reflect.TypeOf((*multipart.FileHeader)(nil)))
+	assert.True(t, ok)
+	assert.NoError(t, err)
+}
+
+func TestSetMultipartFileHeaderTypes_NoFiles_ReturnsFalse(t *testing.T) {
+	var s struct {
+		Files []multipart.FileHeader
+	}
+	v := reflect.ValueOf(&s).Elem().Field(0)
+	ok := setMultipartFileHeaderTypes(v, "files", map[string][]*multipart.FileHeader{})
+	assert.False(t, ok)
+}
+
+func TestDefaultBinder_bindData_NonStruct_ReturnsError(t *testing.T) {
+	b := &DefaultBinder{}
+	// destination is pointer to slice (non-struct), tag is form -> should return error
+	err := b.bindData(&[]int{}, map[string][]string{"a": {"1"}}, "form", nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "binding element must be a struct")
+
+	// for param/query/header tag should return nil (handled earlier)
+	err = b.bindData(&[]int{}, map[string][]string{"a": {"1"}}, "param", nil)
+	assert.NoError(t, err)
+
+	// also header
+	err = b.bindData(&[]int{}, map[string][]string{"a": {"1"}}, "header", nil)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
### Summary
Add three focused unit tests to cover negative/error branches in the binder:
`TestIsFieldMultipartFile_NonPointer_FileHeader_ReturnsError`
`TestSetMultipartFileHeaderTypes_NoFiles_ReturnsFalse`
`TestDefaultBinder_bindData_NonStruct_ReturnsError`

improve test coverage for multipart binding and non-struct binding error handling.
