### PR TITLE
docs: add missing err parameter to DenyHandler example

### DIFF
--- a/middleware/rate_limiter.go
+++ b/middleware/rate_limiter.go
@@ -81,7 +81,7 @@ RateLimiterWithConfig returns a rate limiting middleware
 	e := echo.New()
 
 	config := middleware.RateLimiterConfig{
-		Skipper: DefaultSkipper,https://github.com/labstack/echo/pulls
+		Skipper: DefaultSkipper,
 		Store: middleware.NewRateLimiterMemoryStore(
 			middleware.RateLimiterMemoryStoreConfig{Rate: 10, Burst: 30, ExpiresIn: 3 * time.Minute}
 		)


### PR DESCRIPTION
Hi maintainers,
Just a quick doc fix about the DenyHandler provided example.
