### PR TITLE
Fix: Use WriteHeader in json method for consistent status handling

### DIFF
--- a/context.go
+++ b/context.go
@@ -501,7 +501,7 @@ func (c *context) jsonPBlob(code int, callback string, i any) (err error) {
 
 func (c *context) json(code int, i any, indent string) error {
 	c.writeContentType(MIMEApplicationJSON)
-	c.response.Status = code
+	c.response.WriteHeader(code)
 	return c.echo.JSONSerializer.Serialize(c, i, indent)
 }
 


### PR DESCRIPTION
##  Bug Fix

### Problem
The `json()` method in `context.go` (line 504) was inconsistent with other response methods in how it sets the HTTP status code.

**Current behavior:**
```go
func (c *context) json(code int, i any, indent string) error {
    c.writeContentType(MIMEApplicationJSON)
    c.response.Status = code  // ❌ Directly setting Status field
    return c.echo.JSONSerializer.Serialize(c, i, indent)
}
```

This approach directly sets the `Status` field instead of properly calling `WriteHeader()`, which bypasses header commitment and prevents warnings about header modifications after the status is set.

### Solution
Updated the method to use `c.response.WriteHeader(code)` for consistency with other response methods:

```go
func (c *context) json(code int, i any, indent string) error {
    c.writeContentType(MIMEApplicationJSON)
    c.response.WriteHeader(code)  // ✅ Properly calls WriteHeader
    return c. echo.JSONSerializer.Serialize(c, i, indent)
}
```

All other similar response methods already use `WriteHeader()`:
- `jsonPBlob()` - line 489:  `c.response.WriteHeader(code)`
- `xml()` - line 543: `c.response.WriteHeader(code)` 
- `Blob()` - line 578: `c.response.WriteHeader(code)`
- `JSONPBlob()` - line 530: `c.response.WriteHeader(code)`
