### PR TITLE
refactor: minor cleanup (errors.Is/As, unused params)

### DIFF
--- a/bind_test.go
+++ b/bind_test.go
@@ -725,7 +725,7 @@ func testBindArrayOkay(t *testing.T, r io.Reader, query url.Values, ctype string
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 	req.Header.Set(HeaderContentType, ctype)
-	u := []user{}
+	var u []user
 	err := c.Bind(&u)
 	if assert.NoError(t, err) {
 		assert.Equal(t, 1, len(u))

--- a/context_generic.go
+++ b/context_generic.go
@@ -3,7 +3,9 @@
 
 package echo
 
-import "errors"
+import (
+	"errors"
+)
 
 // ErrNonExistentKey is error that is returned when key does not exist
 var ErrNonExistentKey = errors.New("non existent key")
@@ -36,7 +38,7 @@ func ContextGet[T any](c *Context, key string) (T, error) {
 // is missing. Returns ErrInvalidKeyType error if the value is not castable to type T.
 func ContextGetOr[T any](c *Context, key string, defaultValue T) (T, error) {
 	typed, err := ContextGet[T](c, key)
-	if err == ErrNonExistentKey {
+	if errors.Is(err, ErrNonExistentKey) {
 		return defaultValue, nil
 	}
 	return typed, err

--- a/echotest/context.go
+++ b/echotest/context.go
@@ -95,7 +95,7 @@ func (conf ContextConfig) ToContextRecorder(t *testing.T) (*echo.Context, *httpt
 		conf.Request.Header = conf.Headers
 	}
 	if len(conf.FormValues) > 0 {
-		body := strings.NewReader(url.Values(conf.FormValues).Encode())
+		body := strings.NewReader(conf.FormValues.Encode())
 		conf.Request.Body = io.NopCloser(body)
 		conf.Request.ContentLength = int64(body.Len())
 

--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -193,7 +193,7 @@ func (w *gzipResponseWriter) Flush() {
 	}
 
 	if gw, ok := w.Writer.(*gzip.Writer); ok {
-		gw.Flush()
+		_ = gw.Flush()
 	}
 	_ = http.NewResponseController(w.ResponseWriter).Flush()
 }

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -286,11 +286,11 @@ func (config CORSConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
 	}, nil
 }
 
-func (config CORSConfig) starAllowOriginFunc(c *echo.Context, origin string) (string, bool, error) {
+func (config CORSConfig) starAllowOriginFunc(_ *echo.Context, _ string) (string, bool, error) {
 	return "*", true, nil
 }
 
-func (config CORSConfig) defaultAllowOriginFunc(c *echo.Context, origin string) (string, bool, error) {
+func (config CORSConfig) defaultAllowOriginFunc(_ *echo.Context, origin string) (string, bool, error) {
 	for _, allowedOrigin := range config.AllowOrigins {
 		if strings.EqualFold(allowedOrigin, origin) {
 			return allowedOrigin, true, nil

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -84,7 +84,7 @@ func rewriteURL(rewriteRegex map[*regexp.Regexp]string, req *http.Request) error
 }
 
 // DefaultSkipper returns false which processes the middleware.
-func DefaultSkipper(c *echo.Context) bool {
+func DefaultSkipper(_ *echo.Context) bool {
 	return false
 }
 

--- a/middleware/proxy.go
+++ b/middleware/proxy.go
@@ -234,7 +234,7 @@ func (b *commonBalancer) RemoveTarget(name string) bool {
 // Next randomly returns an upstream target.
 //
 // Note: `nil` is returned in case upstream target list is empty.
-func (b *randomBalancer) Next(c *echo.Context) (*ProxyTarget, error) {
+func (b *randomBalancer) Next(_ *echo.Context) (*ProxyTarget, error) {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
 	if len(b.targets) == 0 {
@@ -314,7 +314,8 @@ func (config ProxyConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
 	}
 	if config.RetryFilter == nil {
 		config.RetryFilter = func(c *echo.Context, e error) bool {
-			if httpErr, ok := e.(*echo.HTTPError); ok {
+			var httpErr *echo.HTTPError
+			if errors.As(e, &httpErr) {
 				return httpErr.Code == http.StatusBadGateway
 			}
 			return false

--- a/middleware/rate_limiter.go
+++ b/middleware/rate_limiter.go
@@ -210,7 +210,7 @@ func NewRateLimiterMemoryStoreWithConfig(config RateLimiterMemoryStoreConfig) (s
 		store.expiresIn = DefaultRateLimiterMemoryStoreConfig.ExpiresIn
 	}
 	if config.Burst == 0 {
-		store.burst = int(math.Max(1, math.Ceil(float64(config.Rate))))
+		store.burst = int(math.Max(1, math.Ceil(config.Rate)))
 	}
 	store.visitors = make(map[string]*Visitor)
 	store.timeNow = time.Now

--- a/renderer.go
+++ b/renderer.go
@@ -27,6 +27,6 @@ type TemplateRenderer struct {
 }
 
 // Render renders the template with given data.
-func (t *TemplateRenderer) Render(c *Context, w io.Writer, name string, data any) error {
+func (t *TemplateRenderer) Render(_ *Context, w io.Writer, name string, data any) error {
 	return t.Template.ExecuteTemplate(w, name, data)
 }

--- a/router.go
+++ b/router.go
@@ -885,10 +885,10 @@ func (r *DefaultRouter) Route(c *Context) HandlerFunc {
 				// NOTE: this case (backtracking from static node to previous any node) can not happen by current any matching logic. Any node is end of search currently
 				//} else if nk == anyKind {
 				//	goto Any
-			} else {
-				// Not found (this should never be possible for static node we are looking currently)
-				break
 			}
+
+			// Not found (this should never be possible for static node we are looking currently)
+			break
 		}
 
 		// The full prefix has matched, remove the prefix from the remaining search
@@ -977,10 +977,10 @@ func (r *DefaultRouter) Route(c *Context) HandlerFunc {
 			goto Param
 		} else if nk == anyKind {
 			goto Any
-		} else {
-			// Not found
-			break
 		}
+
+		// Not found
+		break
 	}
 
 	if currentNode == nil && previousBestMatchNode == nil {

--- a/server_test.go
+++ b/server_test.go
@@ -54,7 +54,7 @@ func waitForServerStart(addrChan <-chan string, errCh <-chan error) (string, err
 		case addr := <-addrChan:
 			return addr, nil
 		case err := <-errCh:
-			if err == http.ErrServerClosed { // was closed normally before listener callback was called. should not be possible
+			if errors.Is(err, http.ErrServerClosed) { // was closed normally before listener callback was called. should not be possible
 				return "", nil
 			}
 			// failed to start and we did not manage to get even listener part.
@@ -522,7 +522,7 @@ func TestStartConfig_WithHideBanner(t *testing.T) {
 				},
 			}
 
-			if err := s.Start(ctx, e); err != http.ErrServerClosed {
+			if err := s.Start(ctx, e); !errors.Is(err, http.ErrServerClosed) {
 				assert.NoError(t, err)
 			}
 			assert.NoError(t, <-errCh)
@@ -581,7 +581,7 @@ func TestStartConfig_WithHidePort(t *testing.T) {
 					addrChan <- addr.String()
 				},
 			}
-			if err := s.Start(ctx, e); err != http.ErrServerClosed {
+			if err := s.Start(ctx, e); !errors.Is(err, http.ErrServerClosed) {
 				assert.NoError(t, err)
 			}
 			assert.NoError(t, <-errCh)


### PR DESCRIPTION
Small refactor with no functional changes:
- Use errors.Is / errors.As instead of direct comparisons
- Mark unused function parameters as `_`
