### PR TITLE
ocs: add missing err parameter to DenyHandler example

### DIFF
--- a/middleware/rate_limiter.go
+++ b/middleware/rate_limiter.go
@@ -89,10 +89,10 @@ RateLimiterWithConfig returns a rate limiting middleware
 			id := ctx.RealIP()
 			return id, nil
 		},
-		ErrorHandler: func(context *echo.Context, err error) error {
+		ErrorHandler: func(ctx *echo.Context, err error) error {
 			return context.JSON(http.StatusTooManyRequests, nil)
 		},
-		DenyHandler: func(context *echo.Context, identifier string) error {
+		DenyHandler: func(ctx *echo.Context, identifier string, err error) error {
 			return context.JSON(http.StatusForbidden, nil)
 		},
 	}


### PR DESCRIPTION
Hi maintainers,
Just a quick doc fix about the DenyHandler provided example.

Re-opened from #2864