### PR TITLE
Fill c.Request().Pattern field with route path to help standard library based middlewares

### DIFF
--- a/router.go
+++ b/router.go
@@ -1039,8 +1039,8 @@ func (r *DefaultRouter) Route(c *Context) HandlerFunc {
 	}
 
 	c.InitializeRoute(rInfo, &pathValues)
-	c.SetPath(rPath) // after InitializeRoute so we would not accidentally change `notFoundRouteInfo` or `methodNotAllowedRouteInfo` Path
-
+	c.SetPath(rPath)          // after InitializeRoute so we would not accidentally change `notFoundRouteInfo` or `methodNotAllowedRouteInfo` Path
+	c.request.Pattern = rPath // help standard library based middlewares. This is a deliberate choice not to call `request.SetPathValue` for params.
 	return rHandler
 }
 

--- a/router_test.go
+++ b/router_test.go
@@ -671,6 +671,21 @@ func checkUnusedParamValues(t *testing.T, c *Context, expectParam map[string]str
 	}
 }
 
+func TestRouterFillsRequestPatternField(t *testing.T) {
+	path := "/folders/a/files/echo.gif"
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	rec := httptest.NewRecorder()
+
+	e := New()
+	e.GET(path, handlerFunc)
+
+	c := e.NewContext(req, rec)
+	_ = e.router.Route(c)
+
+	assert.Equal(t, path, c.Path())
+	assert.Equal(t, path, c.Request().Pattern)
+}
+
 func TestRouterStatic(t *testing.T) {
 	path := "/folders/a/files/echo.gif"
 	req := httptest.NewRequest(http.MethodGet, path, nil)


### PR DESCRIPTION
Fill c.Request().Pattern field with route path to help standard library based middlewares.  For example Otel standard library  Request/Response field extration uses `Request.Pattern` as route.

Relates to https://github.com/labstack/echo-contrib/pull/141