### PR TITLE
security (static middleware): fix bowser=true listing all file names from given filesystem root

### DIFF
--- a/_fixture/dist/private.txt
+++ b/_fixture/dist/private.txt
@@ -1,0 +1,1 @@
+private file

--- a/_fixture/dist/public/assets/readme.md
+++ b/_fixture/dist/public/assets/readme.md
@@ -1,0 +1,1 @@
+readme in assets

--- a/_fixture/dist/public/assets/subfolder/subfolder.md
+++ b/_fixture/dist/public/assets/subfolder/subfolder.md
@@ -1,0 +1,1 @@
+file inside subfolder

--- a/_fixture/dist/public/index.html
+++ b/_fixture/dist/public/index.html
@@ -1,0 +1,1 @@
+<h1>Hello from index</h1>


### PR DESCRIPTION
fix Static middleware listing all files from given filesystem root when browser=true

fixes: https://github.com/labstack/echo/issues/2886