### PR TITLE
CSRF: support older token-based CSRF protection handler that want to render token into template

### DIFF
--- a/middleware/csrf.go
+++ b/middleware/csrf.go
@@ -13,6 +13,15 @@ import (
 	"github.com/labstack/echo/v5"
 )
 
+// CSRFUsingSecFetchSite is a context key for CSRF middleware what is set when the client browser is using Sec-Fetch-Site
+// header and the request is deemed safe.
+// It is a dummy token value that can be used to render CSRF token for form by handlers.
+//
+// We know that the client is using a browser that supports Sec-Fetch-Site header, so when the form is submitted in
+// the future with this dummy token value it is OK. Although the request is safe, the template rendered by the
+// handler may need this value to render CSRF token for form.
+const CSRFUsingSecFetchSite = "_echo_csrf_using_sec_fetch_site_"
+
 // CSRFConfig defines the config for CSRF middleware.
 type CSRFConfig struct {
 	// Skipper defines a function to skip middleware.
@@ -277,6 +286,11 @@ func (config CSRFConfig) checkSecFetchSiteRequest(c *echo.Context) (bool, error)
 	}
 
 	if isSafe {
+		// This helps handlers that support older token-based CSRF protection.
+		// We know that the client is using a browser that supports Sec-Fetch-Site header, so when the form is submitted in
+		// the future with this dummy token value it is OK. Although the request is safe, the template rendered by the
+		// handler may need this value to render CSRF token for form.
+		c.Set(config.ContextKey, CSRFUsingSecFetchSite)
 		return true, nil
 	}
 	// we are here when request is state-changing and `cross-site` or `same-site`


### PR DESCRIPTION
I though I already merged this.  I think  https://github.com/labstack/echo/pull/2876 got closed when I purged all old branches at my fork. I should not have deleted that branch as it was not merged yet

-------------

In case CSRF flow is using `Sec-Fetch-Site` header but there is form still wanting to render CSRF token fields into form we  can help them by setting dummy value to context that atleast something can be rendered into form. As we already know that this browser is able to send `Sec-Fetch-Site` header, we do not need to generate token value or deal with cookies.