### PR TITLE
fix: correct spelling mistakes in comments and field name

### DIFF
--- a/echotest/context.go
+++ b/echotest/context.go
@@ -24,10 +24,10 @@ type ContextConfig struct {
 	// Response will be used instead of default `httptest.NewRecorder()`
 	Response *httptest.ResponseRecorder
 
-	// QueryValues wil be set as Request.URL.RawQuery value
+	// QueryValues will be set as Request.URL.RawQuery value
 	QueryValues url.Values
 
-	// Headers wil be set as Request.Header value
+	// Headers will be set as Request.Header value
 	Headers http.Header
 
 	// PathValues initializes context.PathValues with given value.

--- a/middleware/csrf.go
+++ b/middleware/csrf.go
@@ -28,7 +28,7 @@ type CSRFConfig struct {
 	Skipper Skipper
 	// TrustedOrigin permits any request with `Sec-Fetch-Site` header whose `Origin` header
 	// exactly matches the specified value.
-	// Values should be formated as Origin header "scheme://host[:port]".
+	// Values should be formatted as Origin header "scheme://host[:port]".
 	//
 	// See [Origin]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin
 	// See [Sec-Fetch-Site]: https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#fetch-metadata-headers

--- a/middleware/request_logger.go
+++ b/middleware/request_logger.go
@@ -405,7 +405,7 @@ func RequestLogger() echo.MiddlewareFunc {
 		LogContentLength: true,
 		LogResponseSize:  true,
 		// forwards error to the global error handler, so it can decide appropriate status code.
-		// NB: side-effect of that is - request is now "commited" written to the client. Middlewares up in chain can not
+		// NB: side-effect of that is - request is now "committed" written to the client. Middlewares up in chain can not
 		// change Response status code or response body.
 		HandleError: true,
 		LogValuesFunc: func(c *echo.Context, v RequestLoggerValues) error {

--- a/response.go
+++ b/response.go
@@ -135,19 +135,19 @@ func UnwrapResponse(rw http.ResponseWriter) (*Response, error) {
 // This allows (global) error handler to decide correct status code to be sent to the client.
 type delayedStatusWriter struct {
 	http.ResponseWriter
-	commited bool
+	committed bool
 	status   int
 }
 
 func (w *delayedStatusWriter) WriteHeader(statusCode int) {
-	// in case something else writes status code explicitly before us we need mark response commited
-	w.commited = true
+	// in case something else writes status code explicitly before us we need mark response committed
+	w.committed = true
 	w.ResponseWriter.WriteHeader(statusCode)
 }
 
 func (w *delayedStatusWriter) Write(data []byte) (int, error) {
-	if !w.commited {
-		w.commited = true
+	if !w.committed {
+		w.committed = true
 		if w.status == 0 {
 			w.status = http.StatusOK
 		}

--- a/server.go
+++ b/server.go
@@ -38,7 +38,7 @@ type StartConfig struct {
 	// ListenerNetwork is used configure on which Network listener will use.
 	ListenerNetwork string
 	// ListenerAddrFunc will be called after listener is created and started to listen for connections. This is useful in
-	// testing situations when server is started on random port `addres = ":0"` in that case you can get actual port where
+	// testing situations when server is started on random port `address = ":0"` in that case you can get actual port where
 	// listener is listening on.
 	ListenerAddrFunc func(addr net.Addr)
 


### PR DESCRIPTION
Fix multiple typos found across the codebase:

- `response.go`: rename unexported field `commited` to `committed` and fix related comments
- `server.go`: fix `addres` to `address` in comment
- `middleware/csrf.go`: fix `formated` to `formatted` in comment
- `middleware/request_logger.go`: fix `commited` to `committed` in comment
- `echotest/context.go`: fix `wil` to `will` in comments (2 occurrences)

All changes are either in comments or in an unexported (internal) struct field name. No behavioral changes.