### PR TITLE
fix(router): walk parent tree for RouteNotFound handler in groups

### DIFF
--- a/router.go
+++ b/router.go
@@ -1011,12 +1011,28 @@ func (r *DefaultRouter) Route(c *Context) HandlerFunc {
 			rPath = matchedRouteMethod.Path
 			rHandler = matchedRouteMethod.handler
 		} else if currentNode.isHandler {
-			rInfo = methodNotAllowedRouteInfo
+			// Walk up the tree to find a parent's notFoundHandler
+			// This allows RouteNotFound handlers defined at a higher level in the tree
+			// (e.g., root level) to handle 404s for sub-paths (e.g., groups)
+			var parentNode *node
+			for parentNode = currentNode.parent; parentNode != nil; parentNode = parentNode.parent {
+				if parentNode.methods.notFoundHandler != nil {
+					matchedRouteMethod = parentNode.methods.notFoundHandler
+					rInfo = matchedRouteMethod.RouteInfo
+					rPath = matchedRouteMethod.Path
+					rHandler = matchedRouteMethod.handler
+					break
+				}
+			}
 
-			c.Set(ContextKeyHeaderAllow, currentNode.methods.allowHeader)
-			rHandler = r.methodNotAllowedHandler
-			if req.Method == http.MethodOptions {
-				rHandler = r.optionsMethodHandler
+			// If no parent notFoundHandler was found, use methodNotAllowedHandler
+			if rHandler == nil {
+				rInfo = methodNotAllowedRouteInfo
+				c.Set(ContextKeyHeaderAllow, currentNode.methods.allowHeader)
+				rHandler = r.methodNotAllowedHandler
+				if req.Method == http.MethodOptions {
+					rHandler = r.optionsMethodHandler
+				}
 			}
 		}
 	}

--- a/router_test.go
+++ b/router_test.go
@@ -3656,3 +3656,39 @@ func BenchmarkRouterGooglePlusAPIMisses(b *testing.B) {
 func BenchmarkRouterParamsAndAnyAPI(b *testing.B) {
 	benchmarkRouterRoutes(b, paramAndAnyAPI, paramAndAnyAPIToFind)
 }
+
+// TestRouterRouteNotFoundParentWalkBug verifies the fix for issue #2485
+// This test should FAIL on unpatched code and PASS with the fix
+func TestRouterRouteNotFoundParentWalkBug(t *testing.T) {
+	e := New()
+	handlerID := ""
+
+	// Register a GET route inside a group
+	g := e.Group("/api")
+	g.GET("/users", func(c *Context) error {
+		handlerID = "users-get"
+		return nil
+	})
+
+	// Register RouteNotFound on the root at exact prefix "/api" (no wildcard)
+	// This is the critical scenario: without parent-walk fix, this handler won't be found
+	e.RouteNotFound("/api", func(c *Context) error {
+		handlerID = "root-not-found"
+		return nil
+	})
+
+	// Test case: request exists in router but with wrong HTTP method
+	// Without fix: should fall back to methodNotAllowedHandler (405)
+	// With fix: should find parent's RouteNotFound handler
+	req := httptest.NewRequest(http.MethodPost, "/api/users", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	handler := e.router.Route(c)
+
+	_ = handler(c)
+
+	// This assertion should FAIL on unpatched code (handlerID will be empty)
+	// and PASS with the fix (handlerID will be "root-not-found")
+	assert.Equal(t, "root-not-found", handlerID,
+		"Expected root RouteNotFound handler to fire for POST /api/users")
+}


### PR DESCRIPTION
## Summary

Fixes #2485

When a route exists in the router but the HTTP method is not allowed, the router previously always fell back to `methodNotAllowedHandler`. However, this bypassed any `RouteNotFound` handler registered at a parent or root group level.

## Root Cause

In `DefaultRouter.Route()`, when `currentNode.isHandler` is true (path matched but method not), the code immediately set `rInfo = methodNotAllowedRouteInfo` without checking if any parent node had a `notFoundHandler` registered.

## Fix

Traverse the parent node chain to look for a `notFoundHandler`. If found, use it; otherwise fall back to the existing `methodNotAllowedHandler` behavior.

## Test

Existing route tests pass. The fix ensures `RouteNotFound` handlers registered at a group level are properly invoked for sub-paths.

Signed-off-by: lyydsheep <2230561977@qq.com>