### PR TITLE
Add StartConfig.Listener so server with custom Listener is easier to create

### DIFF
--- a/server.go
+++ b/server.go
@@ -33,9 +33,14 @@ type StartConfig struct {
 
 	// CertFilesystem is filesystem is used to read `certFile` and `keyFile` when StartTLS method is called.
 	CertFilesystem fs.FS
-	TLSConfig      *tls.Config
 
+	// TLSConfig is used to configure TLS. If Listener is set, TLSConfig is not used to create the listener.
+	TLSConfig *tls.Config
+
+	// Listener is used to start server with the custom listener.
+	Listener net.Listener
 	// ListenerNetwork is used configure on which Network listener will use.
+	// If Listener is set, ListenerNetwork is not used.
 	ListenerNetwork string
 	// ListenerAddrFunc will be called after listener is created and started to listen for connections. This is useful in
 	// testing situations when server is started on random port `address = ":0"` in that case you can get actual port where
@@ -108,20 +113,23 @@ func (sc StartConfig) start(ctx stdContext.Context, h http.Handler) error {
 		WriteTimeout: 30 * time.Second,
 	}
 
-	listenerNetwork := sc.ListenerNetwork
-	if listenerNetwork == "" {
-		listenerNetwork = "tcp"
+	listener := sc.Listener
+	if listener == nil {
+		listenerNetwork := sc.ListenerNetwork
+		if listenerNetwork == "" {
+			listenerNetwork = "tcp"
+		}
+		var err error
+		if sc.TLSConfig != nil {
+			listener, err = tls.Listen(listenerNetwork, sc.Address, sc.TLSConfig)
+		} else {
+			listener, err = net.Listen(listenerNetwork, sc.Address)
+		}
+		if err != nil {
+			return err
+		}
 	}
-	var listener net.Listener
-	var err error
-	if sc.TLSConfig != nil {
-		listener, err = tls.Listen(listenerNetwork, sc.Address, sc.TLSConfig)
-	} else {
-		listener, err = net.Listen(listenerNetwork, sc.Address)
-	}
-	if err != nil {
-		return err
-	}
+
 	if sc.ListenerAddrFunc != nil {
 		sc.ListenerAddrFunc(listener.Addr())
 	}


### PR DESCRIPTION
Add StartConfig.Listener so server with custom Listener is easier to create

relates to https://github.com/labstack/echo/issues/2918#issuecomment-4089341521
https://github.com/labstack/echo/issues/1942

Example:
```go
package main

import (
	"context"
	"net"
	"os"
	"os/signal"
	"syscall"
	"time"

	"github.com/labstack/echo/v5"
)

func main() {
	e := echo.New()

	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
	defer cancel()

	lc := net.ListenConfig{
		KeepAlive: 15 * time.Second,
		//Control:   nil,
		//KeepAliveConfig: net.KeepAliveConfig{
		//	Enable:   false,
		//	Idle:     0,
		//	Interval: 0,
		//	Count:    0,
		//},
	}
	l, err := lc.Listen(ctx, "tcp", ":8080")
	if err != nil {
		e.Logger.Error("failed to create listener", "error", err)
		return
	}
	defer l.Close()

	sc := echo.StartConfig{
		Listener: l,
	}
	if err := sc.Start(ctx, e); err != nil {
		e.Logger.Error("failed to run server", "error", err)
	}
}

```