### PR TITLE
Add doc comments to clarify usage of File related methods and leading slash handling

### DIFF
--- a/context.go
+++ b/context.go
@@ -566,6 +566,9 @@ func (c *Context) Stream(code int, contentType string, r io.Reader) (err error) 
 }
 
 // File sends a response with the content of the file.
+//
+// Avoid using the leading `/` slash as most of the Go standard library fs.FS implementations require relative paths for
+// file operations.
 func (c *Context) File(file string) error {
 	return fsFile(c, file, c.echo.Filesystem)
 }
@@ -608,11 +611,17 @@ func fsFile(c *Context, file string, filesystem fs.FS) error {
 }
 
 // Attachment sends a response as attachment, prompting client to save the file.
+//
+// Avoid using the leading `/` slash as most of the Go standard library fs.FS implementations require relative paths for
+// file operations.
 func (c *Context) Attachment(file, name string) error {
 	return c.contentDisposition(file, name, "attachment")
 }
 
 // Inline sends a response as inline, opening the file in the browser.
+//
+// Avoid using the leading `/` slash as most of the Go standard library fs.FS implementations require relative paths for
+// file operations.
 func (c *Context) Inline(file, name string) error {
 	return c.contentDisposition(file, name, "inline")
 }

--- a/echo.go
+++ b/echo.go
@@ -68,7 +68,8 @@ import (
 type Echo struct {
 	serveHTTPFunc func(http.ResponseWriter, *http.Request)
 
-	Binder           Binder
+	Binder Binder
+	// Filesystem is the file system used for serving static files. Defaults to the current working directory.
 	Filesystem       fs.FS
 	Renderer         Renderer
 	Validator        Validator
@@ -576,11 +577,17 @@ func StaticDirectoryHandler(fileSystem fs.FS, disablePathUnescaping bool) Handle
 }
 
 // FileFS registers a new route with path to serve file from the provided file system.
+//
+// Avoid using the leading `/` slash as most of the Go standard library fs.FS implementations require relative paths for
+// file operations.
 func (e *Echo) FileFS(path, file string, filesystem fs.FS, m ...MiddlewareFunc) RouteInfo {
 	return e.GET(path, StaticFileHandler(file, filesystem), m...)
 }
 
-// StaticFileHandler creates handler function to serve file from provided file system
+// StaticFileHandler creates handler function to serve file from provided file system.
+//
+// Avoid using the leading `/` slash as most of the Go standard library fs.FS implementations require relative paths for
+// file operations.
 func StaticFileHandler(file string, filesystem fs.FS) HandlerFunc {
 	return func(c *Context) error {
 		return fsFile(c, file, filesystem)
@@ -588,6 +595,9 @@ func StaticFileHandler(file string, filesystem fs.FS) HandlerFunc {
 }
 
 // File registers a new route with path to serve a static file with optional route-level middleware. Panics on error.
+//
+// Avoid using the leading `/` slash as most of the Go standard library fs.FS implementations require relative paths for
+// file operations.
 func (e *Echo) File(path, file string, middleware ...MiddlewareFunc) RouteInfo {
 	handler := func(c *Context) error {
 		return c.File(file)

--- a/group.go
+++ b/group.go
@@ -129,11 +129,17 @@ func (g *Group) StaticFS(pathPrefix string, filesystem fs.FS, middleware ...Midd
 }
 
 // FileFS implements `Echo#FileFS()` for sub-routes within the Group.
+//
+// Avoid using the leading `/` slash as most of the Go standard library fs.FS implementations require relative paths for
+// file operations.
 func (g *Group) FileFS(path, file string, filesystem fs.FS, m ...MiddlewareFunc) RouteInfo {
 	return g.GET(path, StaticFileHandler(file, filesystem), m...)
 }
 
 // File implements `Echo#File()` for sub-routes within the Group. Panics on error.
+//
+// Avoid using the leading `/` slash as most of the Go standard library fs.FS implementations require relative paths for
+// file operations.
 func (g *Group) File(path, file string, middleware ...MiddlewareFunc) RouteInfo {
 	handler := func(c *Context) error {
 		return c.File(file)


### PR DESCRIPTION
Add doc comments to clarify usage of File related methods and leading slash handling

Relates to https://github.com/labstack/echo/issues/2922#issuecomment-4150975101

Example:
```go
package main

import (
	"embed"

	"github.com/labstack/echo/v5"
)

//go:embed dist/*
var efs embed.FS

func main() {
	e := echo.New()
	e.Filesystem = efs

	e.File("/test", "dist/private.txt") // <--- file path must not have a leading slash

	if err := e.Start(":8080"); err != nil {
		e.Logger.Error("failed to start server", "error", err)
	}
}

```

and 
```go
package main

import (
	"os"

	"github.com/labstack/echo/v5"
)

func main() {
	e := echo.New()
	e.Filesystem = os.DirFS("/")

	e.File("/test.jpg", "opt/app/assets/test.jpg") // <--- file path must not have a leading slash

	if err := e.Start(":8080"); err != nil {
		e.Logger.Error("failed to start server", "error", err)
	}
}
```