### PR TITLE
Add golangci linter configuration

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,24 @@
+version: "2"
+linters:
+#  default: none
+  enable:
+    - revive
+  disable:
+    - errcheck
+  settings:
+    revive:
+      rules:
+        - name: exported
+  exclusions:
+    generated: lax
+    presets:
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - _test\.go$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - _test\.go$


### PR DESCRIPTION
Relates to: https://github.com/labstack/echo/issues/2924

NB: it does not fix couple of staticcheck problems that are being reported
```bash
[x@x echo]$ golangci-lint run 
bind.go:158:6: QF1001: could apply De Morgan's law (staticcheck)
                if !(isElemSliceOfStrings || isElemString || isElemInterface) {
                   ^
middleware/basic_auth.go:124:8: QF1001: could apply De Morgan's law (staticcheck)
                                if !(len(auth) > l+1 && strings.EqualFold(auth[:l], basic)) {
                                   ^
middleware/static.go:253:8: QF1001: could apply De Morgan's law (staticcheck)
                                if !(errors.As(err, &he) && config.HTML5 && he.StatusCode() == http.StatusNotFound) {
                                   ^
route.go:88:4: QF1012: Use fmt.Fprintf(...) instead of WriteString(fmt.Sprintf(...)) (staticcheck)
                        uri.WriteString(fmt.Sprintf("%v", pathValues[n]))
                        ^
router.go:998:30: QF1008: could remove embedded field "RouteInfo" from selector (staticcheck)
                rPath = matchedRouteMethod.RouteInfo.Path
```