### PR TITLE
Do not set http.Server.WriteTimeout in StartConfig

### DIFF
--- a/server.go
+++ b/server.go
@@ -111,8 +111,8 @@ func (sc StartConfig) start(ctx stdContext.Context, h http.Handler) error {
 		// G112 (CWE-400): Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server
 		ReadTimeout: 30 * time.Second,
 		// WriteTimeout is a max time allowed to write the response
-		// IMPORTANT: set this to 0 when using Server-Sent-Events (SSE)
-		WriteTimeout: 30 * time.Second,
+		// IMPORTANT: set this to 0 when using Server-Sent-Events (SSE) or some larger duration when serving static files
+		// WriteTimeout: 30 * time.Second,
 	}
 
 	listener := sc.Listener


### PR DESCRIPTION
Relates to https://github.com/labstack/echox/issues/397 and https://github.com/labstack/echo/issues/2918

we did not set in `v4` and it causing problems for users