### PR TITLE
Make StartConfig listener creation context-aware

### DIFF
--- a/server.go
+++ b/server.go
@@ -4,6 +4,7 @@
 package echo
 
 import (
+	"cmp"
 	stdContext "context"
 	"crypto/tls"
 	"errors"
@@ -117,18 +118,16 @@ func (sc StartConfig) start(ctx stdContext.Context, h http.Handler) error {
 
 	listener := sc.Listener
 	if listener == nil {
-		listenerNetwork := sc.ListenerNetwork
-		if listenerNetwork == "" {
-			listenerNetwork = "tcp"
-		}
-		var err error
-		if sc.TLSConfig != nil {
-			listener, err = tls.Listen(listenerNetwork, sc.Address, sc.TLSConfig)
-		} else {
-			listener, err = net.Listen(listenerNetwork, sc.Address)
-		}
+		listenerNetwork := cmp.Or(sc.ListenerNetwork, "tcp")
+
+		ln, err := (&net.ListenConfig{}).Listen(ctx, listenerNetwork, sc.Address)
 		if err != nil {
 			return err
+		}
+		listener = ln
+
+		if sc.TLSConfig != nil {
+			listener = tls.NewListener(listener, sc.TLSConfig)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Create listeners with net.ListenConfig so StartConfig respects the provided context during listener setup
- Keep the existing serving behavior by defaulting ListenerNetwork to `tcp` and wrapping TLS listeners with
`tls.NewListener`
- simplify the listener creation path by using the same flow for TLS and non-TLS listeners

## Benefit
`StartConfig.Start` and `StartConfig.StartTLS` already accept a context, but listener creation previously used `net.Listen`
and `tls.Listen`, which do not use that context. This change makes listener setup context-aware without changing how the
server behaves after the listener is created.