### PR TITLE
Router: auto HEAD to GET

### DIFF
--- a/echo_test.go
+++ b/echo_test.go
@@ -1423,6 +1423,325 @@ func TestDefaultHTTPErrorHandler_CommitedResponse(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.Code)
 }
 
+func TestRouterAutoHandleHEADFullHTTPHandlerFlow(t *testing.T) {
+	tests := []struct {
+		name                string
+		givenAutoHandleHEAD bool
+		whenMethod          string
+		expectBody          string
+		expectCode          int
+		expectContentLength string
+	}{
+		{
+			name:                "AutoHandleHEAD disabled - HEAD returns 405",
+			givenAutoHandleHEAD: false,
+			whenMethod:          http.MethodHead,
+			expectCode:          http.StatusMethodNotAllowed,
+			expectBody:          "",
+		},
+		{
+			name:                "AutoHandleHEAD enabled - HEAD returns 200 with Content-Length",
+			givenAutoHandleHEAD: true,
+			whenMethod:          http.MethodHead,
+			expectCode:          http.StatusOK,
+			expectBody:          "",
+			expectContentLength: "4",
+		},
+		{
+			name:                "GET request works normally with AutoHandleHEAD enabled",
+			givenAutoHandleHEAD: true,
+			whenMethod:          http.MethodGet,
+			expectCode:          http.StatusOK,
+			expectBody:          "test",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := NewWithConfig(Config{
+				Router: NewRouter(RouterConfig{
+					AutoHandleHEAD: tc.givenAutoHandleHEAD,
+				}),
+			})
+
+			e.GET("/hello", func(c *Context) error {
+				return c.String(http.StatusOK, "test")
+			})
+
+			req := httptest.NewRequest(tc.whenMethod, "/hello", nil)
+			rec := httptest.NewRecorder()
+
+			e.ServeHTTP(rec, req)
+
+			assert.Equal(t, tc.expectCode, rec.Code)
+			assert.Equal(t, tc.expectContentLength, rec.Header().Get(HeaderContentLength))
+			assert.Equal(t, tc.expectBody, rec.Body.String())
+		})
+	}
+}
+
+func TestAutoHeadExplicitHeadTakesPrecedence(t *testing.T) {
+	e := NewWithConfig(Config{
+		Router: NewRouter(RouterConfig{
+			AutoHandleHEAD: true,
+		}),
+	})
+
+	// Register explicit HEAD route FIRST with custom behavior
+	e.HEAD("/api/users", func(c *Context) error {
+		c.Response().Header().Set("X-Custom-Header", "explicit-head")
+		return c.NoContent(http.StatusTeapot)
+	})
+
+	e.GET("/api/users", func(c *Context) error {
+		return c.JSON(http.StatusNotFound, map[string]string{"name": "John"})
+	})
+
+	req := httptest.NewRequest(http.MethodHead, "/api/users", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusTeapot, rec.Code)
+	assert.Equal(t, "explicit-head", rec.Header().Get("X-Custom-Header"))
+	assert.Equal(t, "", rec.Body.String())
+}
+
+func TestRouterAutoHandleHEAD_PathParams(t *testing.T) {
+	e := NewWithConfig(Config{
+		Router: NewRouter(RouterConfig{AutoHandleHEAD: true}),
+	})
+
+	e.GET("/users/:id", func(c *Context) error {
+		return c.String(http.StatusOK, "id="+c.Param("id"))
+	})
+
+	req := httptest.NewRequest(http.MethodHead, "/users/42", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, fmt.Sprintf("%d", len("id=42")), rec.Header().Get(HeaderContentLength))
+	assert.Equal(t, "", rec.Body.String())
+}
+
+func TestRouterAutoHandleHEAD_MultipleWriteCalls(t *testing.T) {
+	e := NewWithConfig(Config{
+		Router: NewRouter(RouterConfig{AutoHandleHEAD: true}),
+	})
+
+	e.GET("/multi", func(c *Context) error {
+		c.Response().WriteHeader(http.StatusOK)
+		c.Response().Write([]byte("foo")) // 3
+		c.Response().Write([]byte("bar")) // 3
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodHead, "/multi", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "6", rec.Header().Get(HeaderContentLength))
+	assert.Equal(t, "", rec.Body.String())
+}
+
+func TestRouterAutoHandleHEAD_ExplicitContentLength(t *testing.T) {
+	e := NewWithConfig(Config{
+		Router: NewRouter(RouterConfig{AutoHandleHEAD: true}),
+	})
+
+	e.GET("/explicit", func(c *Context) error {
+		c.Response().Header().Set(HeaderContentLength, "1000")
+		return c.String(http.StatusOK, "short")
+	})
+
+	req := httptest.NewRequest(http.MethodHead, "/explicit", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, "1000", rec.Header().Get(HeaderContentLength))
+}
+
+func TestRouterAutoHandleHEAD_TransferEncoding(t *testing.T) {
+	e := NewWithConfig(Config{
+		Router: NewRouter(RouterConfig{AutoHandleHEAD: true}),
+	})
+
+	e.GET("/chunked", func(c *Context) error {
+		c.Response().Header().Set("Transfer-Encoding", "chunked")
+		return c.String(http.StatusOK, "data")
+	})
+
+	req := httptest.NewRequest(http.MethodHead, "/chunked", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, "", rec.Header().Get(HeaderContentLength))
+}
+
+func TestRouterAutoHandleHEAD_204Response(t *testing.T) {
+	e := NewWithConfig(Config{
+		Router: NewRouter(RouterConfig{AutoHandleHEAD: true}),
+	})
+
+	e.GET("/nocontent", func(c *Context) error {
+		return c.NoContent(http.StatusNoContent)
+	})
+
+	req := httptest.NewRequest(http.MethodHead, "/nocontent", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, "", rec.Header().Get(HeaderContentLength))
+}
+
+func TestRouterAutoHandleHEAD_304Response(t *testing.T) {
+	e := NewWithConfig(Config{
+		Router: NewRouter(RouterConfig{AutoHandleHEAD: true}),
+	})
+
+	e.GET("/notmodified", func(c *Context) error {
+		return c.NoContent(http.StatusNotModified)
+	})
+
+	req := httptest.NewRequest(http.MethodHead, "/notmodified", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotModified, rec.Code)
+	assert.Equal(t, "", rec.Header().Get(HeaderContentLength))
+}
+
+func TestRouterAutoHandleHEAD_CustomResponseHeaders(t *testing.T) {
+	e := NewWithConfig(Config{
+		Router: NewRouter(RouterConfig{AutoHandleHEAD: true}),
+	})
+
+	e.GET("/headers", func(c *Context) error {
+		c.Response().Header().Set("X-Foo", "bar")
+		return c.String(http.StatusOK, "body")
+	})
+
+	req := httptest.NewRequest(http.MethodHead, "/headers", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, "bar", rec.Header().Get("X-Foo"))
+	assert.Equal(t, "", rec.Body.String())
+}
+
+func TestRouterAutoHandleHEAD_ContentType(t *testing.T) {
+	e := NewWithConfig(Config{
+		Router: NewRouter(RouterConfig{AutoHandleHEAD: true}),
+	})
+
+	e.GET("/json", func(c *Context) error {
+		return c.JSON(http.StatusOK, map[string]string{"key": "value"})
+	})
+
+	req := httptest.NewRequest(http.MethodHead, "/json", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Header().Get(HeaderContentType), MIMEApplicationJSON)
+	assert.Equal(t, "", rec.Body.String())
+}
+
+func TestRouterAutoHandleHEAD_WithMiddleware(t *testing.T) {
+	e := NewWithConfig(Config{
+		Router: NewRouter(RouterConfig{AutoHandleHEAD: true}),
+	})
+	e.Use(func(next HandlerFunc) HandlerFunc {
+		return func(c *Context) error {
+			c.Response().Header().Set("X-Middleware", "ran")
+			return next(c)
+		}
+	})
+
+	e.GET("/mw", func(c *Context) error {
+		return c.String(http.StatusOK, "body")
+	})
+
+	req := httptest.NewRequest(http.MethodHead, "/mw", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, "ran", rec.Header().Get("X-Middleware"))
+	assert.Equal(t, "", rec.Body.String())
+}
+
+func TestRouterAutoHandleHEAD_HandlerError_ErrorHandlerRuns(t *testing.T) {
+	e := NewWithConfig(Config{
+		Router: NewRouter(RouterConfig{AutoHandleHEAD: true}),
+	})
+
+	e.GET("/err", func(c *Context) error {
+		return ErrBadRequest
+	})
+
+	req := httptest.NewRequest(http.MethodHead, "/err", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, "", rec.Body.String())
+}
+
+func TestRouterAutoHandleHEAD_NoGetRoute_Returns405(t *testing.T) {
+	e := NewWithConfig(Config{
+		Router: NewRouter(RouterConfig{AutoHandleHEAD: true}),
+	})
+
+	e.POST("/post-only", func(c *Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodHead, "/post-only", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+func TestRouterAutoHandleHEAD_AnyRoute_NotWrapped(t *testing.T) {
+	e := NewWithConfig(Config{
+		Router: NewRouter(RouterConfig{AutoHandleHEAD: true}),
+	})
+
+	e.Any("/resource", func(c *Context) error {
+		return c.String(http.StatusOK, "any-body")
+	})
+
+	req := httptest.NewRequest(http.MethodHead, "/resource", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "any-body", rec.Body.String())
+	// Content-Length must NOT be injected by wrapHeadHandler for RouteAny
+	assert.Equal(t, "", rec.Header().Get(HeaderContentLength))
+}
+
+func TestRouterAutoHandleHEAD_CatchAllRoute(t *testing.T) {
+	e := NewWithConfig(Config{
+		Router: NewRouter(RouterConfig{AutoHandleHEAD: true}),
+	})
+
+	e.GET("/*", func(c *Context) error {
+		return c.String(http.StatusOK, "wildcard")
+	})
+
+	req := httptest.NewRequest(http.MethodHead, "/anything/here", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, fmt.Sprintf("%d", len("wildcard")), rec.Header().Get(HeaderContentLength))
+	assert.Equal(t, "", rec.Body.String())
+}
+
 func benchmarkEchoRoutes(b *testing.B, routes []testRoute) {
 	e := New()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)

--- a/response.go
+++ b/response.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strconv"
 )
 
 // Response wraps an http.ResponseWriter and implements its interface to be used
@@ -169,4 +170,110 @@ func (w *delayedStatusWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 
 func (w *delayedStatusWriter) Unwrap() http.ResponseWriter {
 	return w.ResponseWriter
+}
+
+// headResponseWriter captures the response that a GET handler would produce for a
+// rewritten HEAD request, suppresses the body, and preserves response metadata.
+//
+// The writer buffers status until the downstream handler returns, so it
+// can compute a Content-Length value from the number of body bytes that would have
+// been written by the GET handler. If the handler already sets Content-Length
+// explicitly, that value is preserved.
+//
+// Flush is intentionally a no-op because emitting headers early would prevent
+// finalizing Content-Length after the handler completes.
+type headResponseWriter struct {
+	rw          http.ResponseWriter
+	status      int
+	wroteStatus bool
+	bodyBytes   int64
+}
+
+func (w *headResponseWriter) Header() http.Header {
+	return w.rw.Header()
+}
+
+func (w *headResponseWriter) WriteHeader(code int) {
+	if w.wroteStatus {
+		return
+	}
+	w.wroteStatus = true
+	w.status = code
+	if r, err := UnwrapResponse(w.rw); err == nil {
+		r.Committed = true
+	}
+}
+
+func (w *headResponseWriter) Write(b []byte) (int, error) {
+	if !w.wroteStatus {
+		w.WriteHeader(http.StatusOK)
+	}
+	w.bodyBytes += int64(len(b))
+	return len(b), nil
+}
+
+func (w *headResponseWriter) Flush() {
+	// No-op on purpose. A HEAD response has no body, and flushing early would
+	// commit headers before Content-Length can be finalized.
+}
+
+func (w *headResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return http.NewResponseController(w.rw).Hijack()
+}
+
+func (w *headResponseWriter) Unwrap() http.ResponseWriter {
+	return w.rw
+}
+
+func (w *headResponseWriter) commit() {
+	dst := w.rw.Header()
+	if w.wroteStatus &&
+		dst.Get(HeaderContentLength) == "" &&
+		dst.Get("Transfer-Encoding") == "" &&
+		!statusMustNotHaveBody(w.status) {
+		dst.Set(HeaderContentLength, strconv.FormatInt(w.bodyBytes, 10))
+	}
+
+	// "commit" the Response only when the headers were written otherwise the Echo errorhandler cannot properly handle errors
+	if w.wroteStatus {
+		// WriteHeader set Committed=true early so route middleware could observe it.
+		// Reset it here so *Response.WriteHeader can fire beforeFuncs and reach the transport.
+		if r, err := UnwrapResponse(w.rw); err == nil {
+			r.Committed = false
+		}
+		w.rw.WriteHeader(w.status)
+		// Fire After hooks on the underlying *Response so that middleware such as
+		// loggers and metrics collectors observe HEAD requests the same as GET.
+		// Size is set to bodyBytes (what GET would have written) so hooks see the
+		// correct value when computing Content-Length or recording response size.
+		if r, err := UnwrapResponse(w.rw); err == nil {
+			r.Size = w.bodyBytes
+			for _, fn := range r.afterFuncs {
+				fn()
+			}
+		}
+	}
+}
+
+func statusMustNotHaveBody(code int) bool {
+	return (code >= 100 && code < 200) ||
+		code == http.StatusNoContent ||
+		code == http.StatusResetContent ||
+		code == http.StatusNotModified
+}
+
+func wrapHeadHandler(handler HandlerFunc) HandlerFunc {
+	return func(c *Context) error {
+		originalWriter := c.Response()
+		headWriter := &headResponseWriter{rw: originalWriter}
+
+		c.SetResponse(headWriter)
+		defer func() {
+			c.SetResponse(originalWriter)
+		}()
+
+		err := handler(c)
+		headWriter.commit()
+		return err
+	}
 }

--- a/response_test.go
+++ b/response_test.go
@@ -4,6 +4,7 @@
 package echo
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -130,4 +131,293 @@ func TestResponse_UnwrapResponse_error(t *testing.T) {
 
 	assert.Nil(t, res)
 	assert.EqualError(t, err, "ResponseWriter does not implement 'Unwrap() http.ResponseWriter' interface or unwrap to *echo.Response")
+}
+
+// headResponseWriter unit tests
+
+func TestHeadResponseWriter_Write_CountsBytes(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := &headResponseWriter{rw: rec}
+
+	n, err := w.Write([]byte("hello"))
+
+	assert.NoError(t, err)
+	assert.Equal(t, 5, n)
+	assert.Equal(t, int64(5), w.bodyBytes)
+	assert.Equal(t, "", rec.Body.String())
+}
+
+func TestHeadResponseWriter_Write_MultipleCallsSumBytes(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := &headResponseWriter{rw: rec}
+
+	w.Write([]byte("foo"))   // 3 bytes
+	w.Write([]byte("bar"))   // 3 bytes
+	w.Write([]byte("baz!!")) // 5 bytes
+
+	assert.Equal(t, int64(11), w.bodyBytes)
+	assert.Equal(t, "", rec.Body.String())
+}
+
+func TestHeadResponseWriter_Write_ImpliesStatus200(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := &headResponseWriter{rw: rec}
+
+	w.Write([]byte("x"))
+
+	assert.True(t, w.wroteStatus)
+	assert.Equal(t, http.StatusOK, w.status)
+}
+
+func TestHeadResponseWriter_WriteHeader_FirstCallWins(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := &headResponseWriter{rw: rec}
+
+	w.WriteHeader(http.StatusAccepted)   // 202 — should stick
+	w.WriteHeader(http.StatusBadRequest) // 400 — should be ignored
+
+	assert.Equal(t, http.StatusAccepted, w.status)
+}
+
+func TestHeadResponseWriter_Commit_SetsContentLength(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := &headResponseWriter{rw: rec}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("hello world")) // 11 bytes
+
+	w.commit()
+
+	assert.Equal(t, "11", rec.Header().Get(HeaderContentLength))
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestHeadResponseWriter_Commit_PreservesExplicitContentLength(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rec.Header().Set(HeaderContentLength, "999") // handler set this explicitly
+	w := &headResponseWriter{rw: rec}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("hi")) // 2 bytes — must NOT overwrite
+
+	w.commit()
+
+	assert.Equal(t, "999", rec.Header().Get(HeaderContentLength))
+}
+
+func TestHeadResponseWriter_Commit_NoContentLength_TransferEncoding(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rec.Header().Set("Transfer-Encoding", "chunked")
+	w := &headResponseWriter{rw: rec}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("some data"))
+
+	w.commit()
+
+	assert.Equal(t, "", rec.Header().Get(HeaderContentLength))
+}
+
+func TestHeadResponseWriter_Commit_NoContentLength_204(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := &headResponseWriter{rw: rec}
+
+	w.WriteHeader(http.StatusNoContent)
+	w.commit()
+
+	assert.Equal(t, "", rec.Header().Get(HeaderContentLength))
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+func TestHeadResponseWriter_Commit_NoContentLength_304(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := &headResponseWriter{rw: rec}
+
+	w.WriteHeader(http.StatusNotModified)
+	w.commit()
+
+	assert.Equal(t, "", rec.Header().Get(HeaderContentLength))
+}
+
+func TestHeadResponseWriter_Commit_NoContentLength_1xx(t *testing.T) {
+	for _, code := range []int{100, 101} {
+		t.Run(fmt.Sprintf("status_%d", code), func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			w := &headResponseWriter{rw: rec}
+
+			w.WriteHeader(code)
+			w.commit()
+
+			assert.Equal(t, "", rec.Header().Get(HeaderContentLength))
+		})
+	}
+}
+
+// TestHeadResponseWriter_Commit_NoWriteHeader_WhenNotCommitted verifies that
+// commit() does not set Content-Length or call WriteHeader when the handler
+// never wrote a status (error-handler path).
+func TestHeadResponseWriter_Commit_NoWriteHeader_WhenNotCommitted(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := &headResponseWriter{rw: rec}
+
+	w.commit()
+
+	assert.False(t, w.wroteStatus)
+	assert.Equal(t, "", rec.Header().Get(HeaderContentLength))
+}
+
+func TestHeadResponseWriter_Flush_IsNoop(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := &headResponseWriter{rw: rec}
+
+	w.WriteHeader(http.StatusOK)
+	assert.NotPanics(t, func() { w.Flush() })
+
+	// Headers must not have been committed to the recorder yet
+	assert.Equal(t, "", rec.Header().Get(HeaderContentLength))
+}
+
+func TestHeadResponseWriter_Header_DelegatesToUnderlying(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := &headResponseWriter{rw: rec}
+
+	w.Header().Set("X-Test", "value")
+
+	assert.Equal(t, "value", rec.Header().Get("X-Test"))
+}
+
+func TestHeadResponseWriter_Unwrap_ReturnsUnderlying(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := &headResponseWriter{rw: rec}
+
+	assert.Equal(t, rec, w.Unwrap())
+}
+
+func TestHeadResponseWriter_Hijack_DelegatesToUnderlying(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := &headResponseWriter{rw: rec}
+
+	// httptest.Recorder does not support Hijack; expect an error, not a panic
+	_, _, err := w.Hijack()
+	assert.Error(t, err)
+}
+
+// wrapHeadHandler unit tests
+
+func TestWrapHeadHandler_SuppressesBodyWrittenByHandler(t *testing.T) {
+	e := New()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodHead, "/", nil)
+	c := e.NewContext(req, rec)
+
+	handler := func(c *Context) error {
+		return c.String(http.StatusOK, "hello") // 5 bytes
+	}
+	wrapped := wrapHeadHandler(handler)
+
+	err := wrapped(c)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "", rec.Body.String())
+	assert.Equal(t, "5", rec.Header().Get(HeaderContentLength))
+}
+
+func TestWrapHeadHandler_PreservesCustomResponseHeaders(t *testing.T) {
+	e := New()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodHead, "/", nil)
+	c := e.NewContext(req, rec)
+
+	handler := func(c *Context) error {
+		c.Response().Header().Set("X-Custom", "present")
+		return c.String(http.StatusOK, "body")
+	}
+	wrapped := wrapHeadHandler(handler)
+
+	wrapped(c)
+
+	assert.Equal(t, "present", rec.Header().Get("X-Custom"))
+}
+
+func TestWrapHeadHandler_RestoresOriginalWriterAfterHandler(t *testing.T) {
+	e := New()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodHead, "/", nil)
+	c := e.NewContext(req, rec)
+	original := c.Response()
+
+	handler := func(c *Context) error { return nil }
+	wrapHeadHandler(handler)(c)
+
+	assert.Equal(t, original, c.Response())
+}
+
+func TestWrapHeadHandler_PropagatesHandlerError(t *testing.T) {
+	e := New()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodHead, "/", nil)
+	c := e.NewContext(req, rec)
+
+	handler := func(c *Context) error {
+		return ErrNotFound
+	}
+	wrapped := wrapHeadHandler(handler)
+
+	err := wrapped(c)
+
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestWrapHeadHandler_HandlerPanic_OriginalWriterRestored(t *testing.T) {
+	e := New()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodHead, "/", nil)
+	c := e.NewContext(req, rec)
+	original := c.Response()
+
+	handler := func(c *Context) error {
+		panic("intentional")
+	}
+	wrapped := wrapHeadHandler(handler)
+
+	assert.Panics(t, func() { wrapped(c) })
+	assert.Equal(t, original, c.Response()) // defer must have run
+}
+
+func TestHeadResponseWriter_WriteHeader_SetsCommittedOnUnderlying(t *testing.T) {
+	e := New()
+	rec := httptest.NewRecorder()
+	underlying := NewResponse(rec, e.Logger)
+	w := &headResponseWriter{rw: underlying}
+
+	w.WriteHeader(http.StatusOK)
+
+	assert.True(t, underlying.Committed)
+}
+
+func TestWrapHeadHandler_RouteLevelMiddlewareSeesTrueCommitted(t *testing.T) {
+	e := New()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodHead, "/", nil)
+	c := e.NewContext(req, rec)
+
+	var committedAfterHandler bool
+
+	mw := func(next HandlerFunc) HandlerFunc {
+		return func(c *Context) error {
+			err := next(c)
+			if r, unwrapErr := UnwrapResponse(c.Response()); unwrapErr == nil {
+				committedAfterHandler = r.Committed
+			}
+			return err
+		}
+	}
+
+	chain := mw(func(c *Context) error {
+		return c.String(http.StatusOK, "hello")
+	})
+	wrapped := wrapHeadHandler(chain)
+
+	assert.NoError(t, wrapped(c))
+	assert.True(t, committedAfterHandler)
 }

--- a/router.go
+++ b/router.go
@@ -69,6 +69,7 @@ type DefaultRouter struct {
 	allowOverwritingRoute    bool
 	unescapePathParamValues  bool
 	useEscapedPathForRouting bool
+	autoHandleHEAD           bool
 }
 
 // RouterConfig is configuration options for (default) router
@@ -79,6 +80,31 @@ type RouterConfig struct {
 	AllowOverwritingRoute     bool
 	UnescapePathParamValues   bool
 	UseEscapedPathForMatching bool
+
+	// AutoHandleHEAD enables automatic handling of HTTP HEAD requests by
+	// falling back to the corresponding GET route.
+	//
+	// When enabled, a HEAD request will match the same handler as GET for
+	// the route, but the response body is suppressed in accordance with
+	// HTTP semantics. Headers (e.g., Content-Length, Content-Type) are
+	// preserved as if a GET request was made.
+	//
+	// Security considerations: the GET handler is fully executed for every
+	// HEAD request, including all side effects:
+	//   - State-mutating operations (DB writes, audit logs, counters) run.
+	//   - Rate-limiting middleware consumes quota, enabling low-cost exhaustion.
+	//   - Expensive computations run with no response body returned to the
+	//     caller, making HEAD cheaper to abuse for DoS than GET.
+	//   - All GET routes become enumerable via HEAD probing (200 = route
+	//     exists, 405 = route absent).
+	//
+	// If route confidentiality/state-mutation is a concern, leave AutoHandleHEAD disabled
+	// and register explicit HEAD handlers only for routes that are safe to
+	// expose (e.g. e.HEAD("/public", handler)).
+	// You can leverage Echo.OnAddRoute callback to add HEAD routes explicitly from a single place.
+	//
+	// Disabled by default.
+	AutoHandleHEAD bool
 }
 
 // NewRouter returns a new Router instance.
@@ -98,6 +124,7 @@ func NewRouter(config RouterConfig) *DefaultRouter {
 		notFoundHandler:         notFoundHandler,
 		methodNotAllowedHandler: methodNotAllowedHandler,
 		optionsMethodHandler:    optionsMethodHandler,
+		autoHandleHEAD:          config.AutoHandleHEAD,
 	}
 	if config.NotFoundHandler != nil {
 		r.notFoundHandler = config.NotFoundHandler
@@ -145,8 +172,9 @@ const (
 
 type routeMethod struct {
 	*RouteInfo
-	handler      HandlerFunc
-	orgRouteInfo RouteInfo
+	handler            HandlerFunc
+	wrappedHeadHandler HandlerFunc // non-nil only for GET routes when autoHandleHEAD=true
+	orgRouteInfo       RouteInfo
 }
 
 type routeMethods struct {
@@ -217,7 +245,7 @@ func (m *routeMethods) set(method string, r *routeMethod) {
 	m.updateAllowHeader()
 }
 
-func (m *routeMethods) find(method string, fallbackToAny bool) *routeMethod {
+func (m *routeMethods) find(method string, fallbackToAny bool, autoHandleHEAD bool) *routeMethod {
 	var r *routeMethod
 	switch method {
 	case http.MethodConnect:
@@ -228,6 +256,9 @@ func (m *routeMethods) find(method string, fallbackToAny bool) *routeMethod {
 		r = m.get
 	case http.MethodHead:
 		r = m.head
+		if autoHandleHEAD && r == nil {
+			r = m.get
+		}
 	case http.MethodOptions:
 		r = m.options
 	case http.MethodPatch:
@@ -387,7 +418,7 @@ func (r *DefaultRouter) Remove(method string, path string) error {
 		return errors.New("could not find route to remove by given path")
 	}
 
-	if mh := nodeToRemove.methods.find(method, false); mh == nil {
+	if mh := nodeToRemove.methods.find(method, false, false); mh == nil {
 		return errors.New("could not find route to remove by given path and method")
 	}
 	nodeToRemove.setHandler(method, nil)
@@ -473,6 +504,10 @@ func (r *DefaultRouter) Add(route Route) (RouteInfo, error) {
 			}
 		}
 	}
+	var headH HandlerFunc
+	if r.autoHandleHEAD && method == http.MethodGet {
+		headH = wrapHeadHandler(h)
+	}
 
 	paramNames := make([]string, 0)
 	originalPath := path
@@ -500,9 +535,10 @@ func (r *DefaultRouter) Add(route Route) (RouteInfo, error) {
 				// path node is last fragment of route path. ie. `/users/:id`
 				ri = route.ToRouteInfo(paramNames)
 				rm := routeMethod{
-					RouteInfo:    &RouteInfo{Method: method, Path: originalPath, Parameters: paramNames, Name: route.Name},
-					handler:      h,
-					orgRouteInfo: ri,
+					RouteInfo:          &RouteInfo{Method: method, Path: originalPath, Parameters: paramNames, Name: route.Name},
+					handler:            h,
+					orgRouteInfo:       ri,
+					wrappedHeadHandler: headH,
 				}
 				r.insert(paramKind, path[:i], method, rm)
 				wasAdded = true
@@ -515,9 +551,10 @@ func (r *DefaultRouter) Add(route Route) (RouteInfo, error) {
 			paramNames = append(paramNames, "*")
 			ri = route.ToRouteInfo(paramNames)
 			rm := routeMethod{
-				RouteInfo:    &RouteInfo{Method: method, Path: originalPath, Parameters: paramNames, Name: route.Name},
-				handler:      h,
-				orgRouteInfo: ri,
+				RouteInfo:          &RouteInfo{Method: method, Path: originalPath, Parameters: paramNames, Name: route.Name},
+				handler:            h,
+				orgRouteInfo:       ri,
+				wrappedHeadHandler: headH,
 			}
 			r.insert(anyKind, path[:i+1], method, rm)
 			wasAdded = true
@@ -528,9 +565,10 @@ func (r *DefaultRouter) Add(route Route) (RouteInfo, error) {
 	if !wasAdded {
 		ri = route.ToRouteInfo(paramNames)
 		rm := routeMethod{
-			RouteInfo:    &RouteInfo{Method: method, Path: originalPath, Parameters: paramNames, Name: route.Name},
-			handler:      h,
-			orgRouteInfo: ri,
+			RouteInfo:          &RouteInfo{Method: method, Path: originalPath, Parameters: paramNames, Name: route.Name},
+			handler:            h,
+			orgRouteInfo:       ri,
+			wrappedHeadHandler: headH,
 		}
 		r.insert(staticKind, path, method, rm)
 	}
@@ -932,7 +970,7 @@ func (r *DefaultRouter) Route(c *Context) HandlerFunc {
 				if previousBestMatchNode == nil {
 					previousBestMatchNode = currentNode
 				}
-				if h := currentNode.methods.find(req.Method, true); h != nil {
+				if h := currentNode.methods.find(req.Method, true, r.autoHandleHEAD); h != nil {
 					matchedRouteMethod = h
 					break
 				}
@@ -983,7 +1021,7 @@ func (r *DefaultRouter) Route(c *Context) HandlerFunc {
 			searchIndex += len(search)
 			search = ""
 
-			if rMethod := currentNode.methods.find(req.Method, true); rMethod != nil {
+			if rMethod := currentNode.methods.find(req.Method, true, r.autoHandleHEAD); rMethod != nil {
 				matchedRouteMethod = rMethod
 				break
 			}
@@ -1023,6 +1061,11 @@ func (r *DefaultRouter) Route(c *Context) HandlerFunc {
 	var rInfo *RouteInfo
 	if matchedRouteMethod != nil {
 		rHandler = matchedRouteMethod.handler
+		if req.Method == http.MethodHead && matchedRouteMethod.wrappedHeadHandler != nil {
+			rHandler = matchedRouteMethod.wrappedHeadHandler
+			// we are not touching rInfo.Method and let it be value from GET routeInfo
+		}
+
 		rPath = matchedRouteMethod.Path
 		rInfo = matchedRouteMethod.RouteInfo
 	} else {


### PR DESCRIPTION
Proposal for alternative solution to https://github.com/labstack/echo/pull/2944 (https://github.com/labstack/echo/issues/2895) - do not register extra routes. use router internals to fallback from head to get. these extra IF checks do not register as meaningful change when running `benchstat`, but registering another route along with GET looks like a quick hack.

store benchmarks for this change
```bash
go test -run="-" -bench=".*" -count=8 ./... > benchmark_with_head.txt
```

check out current version
```bash
go test -run="-" -bench=".*" -count=8 ./... > benchmark_5_1_0.txt
```

and compare these two
```bash
benchstat benchmark_5_1_0.txt benchmark_with_head.txt 
```

-----------------

usage:

Create Echo instance with Router that is configured with `AutoHandleHEAD = true`
```go
			e := echo.NewWithConfig(echo.Config{
				Router: echo.NewRouter(echo.RouterConfig{
					AutoHandleHEAD: true,
				}),
			})
```