### PR TITLE
Context.Json should not unwrap response 

### DIFF
--- a/context.go
+++ b/context.go
@@ -479,13 +479,9 @@ func (c *Context) json(code int, i any, indent string) error {
 	// as JSONSerializer.Serialize can fail, and in that case we need to delay sending status code to the client until
 	// (global) error handler decides correct status code for the error to be sent to the client.
 	// For that we need to use writer that can store the proposed status code until the first Write is called.
-	if r, err := UnwrapResponse(c.response); err == nil {
-		r.Status = code
-	} else {
-		resp := c.Response()
-		c.SetResponse(&delayedStatusWriter{ResponseWriter: resp, status: code})
-		defer c.SetResponse(resp)
-	}
+	resp := c.Response()
+	c.SetResponse(&delayedStatusWriter{ResponseWriter: resp, status: code})
+	defer c.SetResponse(resp)
 
 	return c.echo.JSONSerializer.Serialize(c, i, indent)
 }


### PR DESCRIPTION
Context.Json should not unwrap response and just wrap Response so other middlewares can use their own "wrapping" Responses and see the status code.

I found this during #2895 when to tried to create middleware that wraps existing response to own and status code setting did not work anymore with `Context.JSON` (always sends 200 to client).