### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/middleware/body_dump.go
+++ b/middleware/body_dump.go
@@ -189,10 +189,7 @@ func (w *limitedWriter) Write(b []byte) (n int, err error) {
 	// Write to dump buffer only up to limit
 	if w.dumped < w.limit {
 		remaining := w.limit - w.dumped
-		toDump := int64(n)
-		if toDump > remaining {
-			toDump = remaining
-		}
+		toDump := min(int64(n), remaining)
 		w.dumpBuf.Write(b[:toDump])
 		w.dumped += toDump
 	}

--- a/router.go
+++ b/router.go
@@ -558,10 +558,7 @@ func (r *DefaultRouter) insert(t kind, path string, method string, ri routeMetho
 		lcpLen := 0
 
 		// LCP - Longest Common Prefix (https://en.wikipedia.org/wiki/LCP_array)
-		maxL := prefixLen
-		if searchLen < maxL {
-			maxL = searchLen
-		}
+		maxL := min(searchLen, prefixLen)
 		for ; lcpLen < maxL && search[lcpLen] == currentNode.prefix[lcpLen]; lcpLen++ {
 		}
 
@@ -867,10 +864,7 @@ func (r *DefaultRouter) Route(c *Context) HandlerFunc {
 			prefixLen = len(currentNode.prefix)
 
 			// LCP - Longest Common Prefix (https://en.wikipedia.org/wiki/LCP_array)
-			lMax := prefixLen
-			if searchLen < lMax {
-				lMax = searchLen
-			}
+			lMax := min(searchLen, prefixLen)
 			for ; lcpLen < lMax && search[lcpLen] == currentNode.prefix[lcpLen]; lcpLen++ {
 			}
 		}


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.