### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/middleware/extractor.go
+++ b/middleware/extractor.go
@@ -85,9 +85,9 @@ func createExtractors(lookups string, limit uint) ([]ValuesExtractor, error) {
 		limit = extractorLimit
 	}
 
-	sources := strings.Split(lookups, ",")
+	sources := strings.SplitSeq(lookups, ",")
 	var extractors = make([]ValuesExtractor, 0)
-	for _, source := range sources {
+	for source := range sources {
 		parts := strings.Split(source, ":")
 		if len(parts) < 2 {
 			return nil, fmt.Errorf("extractor source for lookup could not be split into needed parts: %v", source)

--- a/router_test.go
+++ b/router_test.go
@@ -2235,8 +2235,8 @@ func testRouterAPI(t *testing.T, api []testRoute) {
 			c.SetRequest(httptest.NewRequest(route.Method, route.Path, nil))
 			e.router.Route(c)
 
-			tokens := strings.Split(route.Path[1:], "/")
-			for _, token := range tokens {
+			tokens := strings.SplitSeq(route.Path[1:], "/")
+			for token := range tokens {
 				if token[0] == ':' {
 					assert.Equal(t, c.pathValues.GetOr(token[1:], "---none---"), token)
 				}


### PR DESCRIPTION
strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

It significantly reduces memory allocations and can improve performance for long strings.

More info: https://github.com/golang/go/issues/61901