### PR TITLE
Run route middleware for OPTIONS fallbacks

### DIFF
--- a/middleware/cors_test.go
+++ b/middleware/cors_test.go
@@ -581,6 +581,35 @@ func TestCorsHeaders(t *testing.T) {
 	}
 }
 
+func TestCORSWithConfig_GroupPreflightWithoutOptionsRoute(t *testing.T) {
+	e := echo.New()
+	g := e.Group("/myroute", CORSWithConfig(CORSConfig{
+		AllowOrigins: []string{"https://example.com"},
+		AllowHeaders: []string{
+			echo.HeaderOrigin,
+			echo.HeaderContentType,
+			echo.HeaderAccept,
+			echo.HeaderAuthorization,
+		},
+	}))
+	g.GET("", func(c *echo.Context) error {
+		return c.String(http.StatusOK, "OK")
+	})
+
+	req := httptest.NewRequest(http.MethodOptions, "/myroute", nil)
+	req.Header.Set(echo.HeaderOrigin, "https://example.com")
+	req.Header.Set(echo.HeaderAccessControlRequestMethod, http.MethodGet)
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, "https://example.com", rec.Header().Get(echo.HeaderAccessControlAllowOrigin))
+	assert.Equal(t, "OPTIONS, GET", rec.Header().Get(echo.HeaderAccessControlAllowMethods))
+	assert.Equal(t, "Origin,Content-Type,Accept,Authorization", rec.Header().Get(echo.HeaderAccessControlAllowHeaders))
+	assert.Equal(t, "OPTIONS, GET", rec.Header().Get(echo.HeaderAllow))
+}
+
 func Test_allowOriginFunc(t *testing.T) {
 	returnTrue := func(c *echo.Context, origin string) (string, bool, error) {
 		return origin, true, nil

--- a/router.go
+++ b/router.go
@@ -142,6 +142,7 @@ const (
 type routeMethod struct {
 	*RouteInfo
 	handler      HandlerFunc
+	middlewares  []MiddlewareFunc
 	orgRouteInfo RouteInfo
 }
 
@@ -296,6 +297,54 @@ func (m *routeMethods) updateAllowHeader() {
 		buf.WriteString(method)
 	}
 	m.allowHeader = buf.String()
+}
+
+func (m *routeMethods) optionsFallbackHandler(requestedMethod string) *routeMethod {
+	if requestedMethod != "" {
+		if h := m.find(requestedMethod, true); h != nil {
+			return h
+		}
+	}
+	if m.connect != nil {
+		return m.connect
+	}
+	if m.delete != nil {
+		return m.delete
+	}
+	if m.get != nil {
+		return m.get
+	}
+	if m.head != nil {
+		return m.head
+	}
+	if m.options != nil {
+		return m.options
+	}
+	if m.patch != nil {
+		return m.patch
+	}
+	if m.post != nil {
+		return m.post
+	}
+	if m.propfind != nil {
+		return m.propfind
+	}
+	if m.put != nil {
+		return m.put
+	}
+	if m.trace != nil {
+		return m.trace
+	}
+	if m.report != nil {
+		return m.report
+	}
+	if m.any != nil {
+		return m.any
+	}
+	for _, r := range m.anyOther {
+		return r
+	}
+	return nil
 }
 
 func (m *routeMethods) isHandler() bool {
@@ -488,6 +537,7 @@ func (r *DefaultRouter) Add(route Route) (RouteInfo, error) {
 				rm := routeMethod{
 					RouteInfo:    &RouteInfo{Method: method, Path: originalPath, Parameters: paramNames, Name: route.Name},
 					handler:      h,
+					middlewares:  append([]MiddlewareFunc(nil), route.Middlewares...),
 					orgRouteInfo: ri,
 				}
 				r.insert(paramKind, path[:i], method, rm)
@@ -503,6 +553,7 @@ func (r *DefaultRouter) Add(route Route) (RouteInfo, error) {
 			rm := routeMethod{
 				RouteInfo:    &RouteInfo{Method: method, Path: originalPath, Parameters: paramNames, Name: route.Name},
 				handler:      h,
+				middlewares:  append([]MiddlewareFunc(nil), route.Middlewares...),
 				orgRouteInfo: ri,
 			}
 			r.insert(anyKind, path[:i+1], method, rm)
@@ -516,6 +567,7 @@ func (r *DefaultRouter) Add(route Route) (RouteInfo, error) {
 		rm := routeMethod{
 			RouteInfo:    &RouteInfo{Method: method, Path: originalPath, Parameters: paramNames, Name: route.Name},
 			handler:      h,
+			middlewares:  append([]MiddlewareFunc(nil), route.Middlewares...),
 			orgRouteInfo: ri,
 		}
 		r.insert(staticKind, path, method, rm)
@@ -1011,6 +1063,10 @@ func (r *DefaultRouter) Route(c *Context) HandlerFunc {
 			rHandler = r.methodNotAllowedHandler
 			if req.Method == http.MethodOptions {
 				rHandler = r.optionsMethodHandler
+				requestedMethod := req.Header.Get(HeaderAccessControlRequestMethod)
+				if fallbackMethod := currentNode.methods.optionsFallbackHandler(requestedMethod); fallbackMethod != nil {
+					rHandler = applyMiddleware(rHandler, fallbackMethod.middlewares...)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
**Overview**:
- Preserve route middleware on the router's implicit OPTIONS fallback for an existing path.
- Use `Access-Control-Request-Method` to choose the matched route middleware when handling browser preflights.
- Add a regression test for grouped CORS middleware without an explicit OPTIONS route.

**What problem does it solve?**:
Closes #2950. In v5, grouped CORS middleware could be skipped for preflight requests when the group had a matching GET route but no explicit OPTIONS route. The router returned its implicit OPTIONS handler directly, so the CORS middleware never added `Access-Control-Allow-Origin`. This keeps the fallback handler but wraps it with the matched route middleware chain, allowing CORS to handle the preflight before the fallback writes the 204 response.

**Special notes for a reviewer**:
Verified with:
- `GOMODCACHE=/tmp/echo-gomodcache GOCACHE=/tmp/echo-gocache go test ./middleware -run TestCORSWithConfig_GroupPreflightWithoutOptionsRoute -count=1`
- `GOMODCACHE=/tmp/echo-gomodcache GOCACHE=/tmp/echo-gocache go test ./...`
- `GOMODCACHE=/tmp/echo-gomodcache GOCACHE=/tmp/echo-gocache go vet ./...`
- `GOMODCACHE=/tmp/echo-gomodcache GOCACHE=/tmp/echo-gocache go test -race ./...`
- `PATH=/tmp/echo-bin:$PATH GOMODCACHE=/tmp/echo-gomodcache GOCACHE=/tmp/echo-gocache staticcheck ./...`
- `PATH=/tmp/echo-bin:$PATH GOMODCACHE=/tmp/echo-gomodcache GOCACHE=/tmp/echo-gocache golint -set_exit_status ./...`
- `git diff --check`