### PR TITLE
fix(middleware): gzip Write must return len(b), not the buffer length

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -168,7 +168,15 @@ func (w *gzipResponseWriter) Write(b []byte) (int, error) {
 				w.ResponseWriter.WriteHeader(w.code)
 			}
 
-			return w.Writer.Write(w.buffer.Bytes())
+			// The whole buffer (which already contains b) is flushed to the
+			// underlying writer, but we must report only len(b) as written to
+			// satisfy the io.Writer contract (0 <= n <= len(b)). Returning the
+			// buffer length here would over-report and panic callers such as
+			// io.Copy with "invalid write count".
+			if _, err := w.Writer.Write(w.buffer.Bytes()); err != nil {
+				return 0, err
+			}
+			return n, nil
 		}
 
 		return n, err

--- a/middleware/compress_writecount_test.go
+++ b/middleware/compress_writecount_test.go
@@ -1,0 +1,73 @@
+package middleware
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGzipWriteReturnsCorrectCount verifies that gzipResponseWriter.Write honours
+// the io.Writer contract: it must return n == len(b) (never more) for the slice
+// passed to a single Write call. Before the fix, when a buffered write crossed the
+// MinLength threshold, Write returned the full buffer length (previous chunks + b),
+// over-reporting the count and panicking callers like io.Copy.
+func TestGzipWriteReturnsCorrectCount(t *testing.T) {
+	e := echo.New()
+	mw := GzipWithConfig(GzipConfig{MinLength: 100})
+
+	var n1, n2 int
+	h := mw(func(c echo.Context) error {
+		chunk1 := []byte("hello ")               // 6 bytes, stays below MinLength
+		chunk2 := bytes.Repeat([]byte("x"), 200) // crosses MinLength
+		var err error
+		if n1, err = c.Response().Write(chunk1); err != nil {
+			return err
+		}
+		if n2, err = c.Response().Write(chunk2); err != nil {
+			return err
+		}
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(echo.HeaderAcceptEncoding, "gzip")
+	rec := httptest.NewRecorder()
+	assert.NoError(t, h(e.NewContext(req, rec)))
+
+	// Each Write must report exactly the length of the slice it was given.
+	assert.Equal(t, 6, n1, "first Write should report len of its own slice")
+	assert.Equal(t, 200, n2, "second Write must report len(b), not the buffered total")
+}
+
+// TestGzipIoCopyDoesNotPanic reproduces the real-world failure: streaming through
+// the gzip response writer with io.Copy (as echo.Context#Stream does) panics with
+// "invalid write count" when Write over-reports the byte count.
+func TestGzipIoCopyDoesNotPanic(t *testing.T) {
+	e := echo.New()
+	mw := GzipWithConfig(GzipConfig{MinLength: 100})
+
+	h := mw(func(c echo.Context) error {
+		// Small write keeps us below MinLength so the buffer holds previous bytes.
+		if _, err := c.Response().Write([]byte("prefix")); err != nil {
+			return err
+		}
+		// io.Copy validates that the returned write count never exceeds len(p);
+		// an over-reported count makes bytes.Reader.WriteTo panic.
+		src := bytes.NewReader(bytes.Repeat([]byte("y"), 200))
+		_, err := io.Copy(c.Response(), src)
+		return err
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(echo.HeaderAcceptEncoding, "gzip")
+	rec := httptest.NewRecorder()
+
+	assert.NotPanics(t, func() {
+		assert.NoError(t, h(e.NewContext(req, rec)))
+	})
+}


### PR DESCRIPTION
## Issue

`middleware.gzipResponseWriter.Write` violates the `io.Writer` contract. When a buffered write crosses `MinLength`, it flushes the whole buffer and returns the buffer length:

```go
return w.Writer.Write(w.buffer.Bytes())
```

Because the buffer also holds bytes from earlier (sub-`MinLength`) writes, the returned `n` can exceed `len(b)`. The `io.Writer` contract requires `0 <= n <= len(b)`, and consumers that validate this panic.

In particular `io.Copy` — which `echo.Context#Stream` uses internally (`io.Copy(c.Response(), r)`) — panics with:

```
bytes.Reader.WriteTo: invalid Write count
```

So streaming a response through the Gzip middleware crashes the request whenever a small write was buffered before the threshold-crossing write.

## Fix

Flush the buffer as before, but report only `len(b)` (the bytes accepted from this call):

```go
if _, err := w.Writer.Write(w.buffer.Bytes()); err != nil {
    return 0, err
}
return n, nil
```

`n` is already `len(b)` from the preceding `w.buffer.Write(b)`.

## Tests

Added `middleware/compress_writecount_test.go`:

- `TestGzipWriteReturnsCorrectCount` — `Write` reports `len(b)`, never the buffered total.
- `TestGzipIoCopyDoesNotPanic` — streaming through gzip with `io.Copy` no longer panics.

Both fail on `master` (the second panics with `invalid Write count`) and pass with the fix. Existing compress tests (incl. `TestGzipWithMinLengthChunked`) and the full suite stay green under `go test -race ./...`.