### PR TITLE
fix(bind): restore []string values for map[string]interface{} duplicates

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -181,9 +181,11 @@ func (b *DefaultBinder) bindData(destination interface{}, data map[string][]stri
 			if isElemString {
 				val.SetMapIndex(reflect.ValueOf(k), reflect.ValueOf(v[0]))
 			} else if isElemInterface {
-				// To maintain backward compatibility, we always bind to the first string value
-				// and not the slice of strings when dealing with map[string]interface{}{}
-				val.SetMapIndex(reflect.ValueOf(k), reflect.ValueOf(v[0]))
+				if len(v) == 1 {
+					val.SetMapIndex(reflect.ValueOf(k), reflect.ValueOf(v[0]))
+				} else {
+					val.SetMapIndex(reflect.ValueOf(k), reflect.ValueOf(v))
+				}
 			} else {
 				val.SetMapIndex(reflect.ValueOf(k), reflect.ValueOf(v))
 			}

--- a/bind_test.go
+++ b/bind_test.go
@@ -498,7 +498,7 @@ func TestDefaultBinder_bindDataToMap(t *testing.T) {
 		assert.NoError(t, new(DefaultBinder).bindData(&dest, exampleData, "param", nil))
 		assert.Equal(t,
 			map[string]interface{}{
-				"multiple": "1",
+				"multiple": []string{"1", "2"},
 				"single":   "3",
 			},
 			dest,
@@ -510,7 +510,7 @@ func TestDefaultBinder_bindDataToMap(t *testing.T) {
 		assert.NoError(t, new(DefaultBinder).bindData(&dest, exampleData, "param", nil))
 		assert.Equal(t,
 			map[string]interface{}{
-				"multiple": "1",
+				"multiple": []string{"1", "2"},
 				"single":   "3",
 			},
 			dest,
@@ -540,6 +540,24 @@ func TestDefaultBinder_bindDataToMap(t *testing.T) {
 		assert.NoError(t, new(DefaultBinder).bindData(&dest, exampleData, "param", nil))
 		assert.Equal(t, map[string][]int(nil), dest)
 	})
+}
+
+func TestBindMultipartFormToMapInterface(t *testing.T) {
+	bodyBuffer := new(bytes.Buffer)
+	mw := multipart.NewWriter(bodyBuffer)
+	assert.NoError(t, mw.WriteField("ima_slice", "WEBHOOK"))
+	assert.NoError(t, mw.WriteField("ima_slice", "OTHER"))
+	assert.NoError(t, mw.Close())
+
+	e := New()
+	req := httptest.NewRequest(http.MethodPost, "/", bodyBuffer)
+	req.Header.Set(HeaderContentType, mw.FormDataContentType())
+	c := e.NewContext(req, nil)
+
+	data := map[string]interface{}{}
+	err := c.Bind(&data)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"WEBHOOK", "OTHER"}, data["ima_slice"])
 }
 
 func TestBindbindData(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fix regression when binding multipart form data with duplicate field names to `map[string]interface{}`
- Store a single value as `string` and multiple values as `[]string`

## Problem
Since v4.13.0, binding duplicate multipart fields like two `ima_slice` values to `map[string]interface{}` only kept the first value. Applications expecting a slice silently broke.

This regressed after #2656, which intended to preserve pre-v4.12.0 single-string behavior but always bound `v[0]`.

## Fix
For `map[string]interface{}` / `map[string]any`:
- one value → `string`
- multiple values → `[]string`

## Test plan
- [x] Updated `TestDefaultBinder_bindDataToMap`
- [x] Added `TestBindMultipartFormToMapInterface`
- [x] `go test ./... -run 'TestDefaultBinder_bindDataToMap|TestBindMultipartFormToMapInterface'`

Fixes #2731