### PR TITLE
fix(middleware): avoid duplicate CORS headers behind proxies

### DIFF
--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -188,8 +188,6 @@ func CORSWithConfig(config CORSConfig) echo.MiddlewareFunc {
 			origin := req.Header.Get(echo.HeaderOrigin)
 			allowOrigin := ""
 
-			res.Header().Add(echo.HeaderVary, echo.HeaderOrigin)
-
 			// Preflight request is an OPTIONS request, using three HTTP request headers: Access-Control-Request-Method,
 			// Access-Control-Request-Headers, and the Origin header. See: https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request
 			// For simplicity we just consider method type and later `Origin` header.
@@ -211,6 +209,7 @@ func CORSWithConfig(config CORSConfig) echo.MiddlewareFunc {
 
 			// No Origin provided. This is (probably) not request from actual browser - proceed executing middleware chain
 			if origin == "" {
+				res.Header().Add(echo.HeaderVary, echo.HeaderOrigin)
 				if !preflight {
 					return next(c)
 				}
@@ -261,26 +260,36 @@ func CORSWithConfig(config CORSConfig) echo.MiddlewareFunc {
 
 			// Origin not allowed
 			if allowOrigin == "" {
+				res.Header().Add(echo.HeaderVary, echo.HeaderOrigin)
 				if !preflight {
 					return next(c)
 				}
 				return c.NoContent(http.StatusNoContent)
 			}
 
+			// Simple request
+			if !preflight {
+				err := next(c)
+				// Skip setting CORS headers when an upstream handler (e.g. reverse proxy) already set them.
+				if res.Header().Get(echo.HeaderAccessControlAllowOrigin) == "" {
+					res.Header().Add(echo.HeaderVary, echo.HeaderOrigin)
+					res.Header().Set(echo.HeaderAccessControlAllowOrigin, allowOrigin)
+					if config.AllowCredentials {
+						res.Header().Set(echo.HeaderAccessControlAllowCredentials, "true")
+					}
+					if exposeHeaders != "" {
+						res.Header().Set(echo.HeaderAccessControlExposeHeaders, exposeHeaders)
+					}
+				}
+				return err
+			}
+
+			// Preflight request
+			res.Header().Add(echo.HeaderVary, echo.HeaderOrigin)
 			res.Header().Set(echo.HeaderAccessControlAllowOrigin, allowOrigin)
 			if config.AllowCredentials {
 				res.Header().Set(echo.HeaderAccessControlAllowCredentials, "true")
 			}
-
-			// Simple request
-			if !preflight {
-				if exposeHeaders != "" {
-					res.Header().Set(echo.HeaderAccessControlExposeHeaders, exposeHeaders)
-				}
-				return next(c)
-			}
-
-			// Preflight request
 			res.Header().Add(echo.HeaderVary, echo.HeaderAccessControlRequestMethod)
 			res.Header().Add(echo.HeaderVary, echo.HeaderAccessControlRequestHeaders)
 

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -269,9 +269,11 @@ func CORSWithConfig(config CORSConfig) echo.MiddlewareFunc {
 
 			// Simple request
 			if !preflight {
-				err := next(c)
 				// Skip setting CORS headers when an upstream handler (e.g. reverse proxy) already set them.
-				if res.Header().Get(echo.HeaderAccessControlAllowOrigin) == "" {
+				setHeaders := func() {
+					if res.Header().Get(echo.HeaderAccessControlAllowOrigin) != "" {
+						return
+					}
 					res.Header().Add(echo.HeaderVary, echo.HeaderOrigin)
 					res.Header().Set(echo.HeaderAccessControlAllowOrigin, allowOrigin)
 					if config.AllowCredentials {
@@ -280,6 +282,11 @@ func CORSWithConfig(config CORSConfig) echo.MiddlewareFunc {
 					if exposeHeaders != "" {
 						res.Header().Set(echo.HeaderAccessControlExposeHeaders, exposeHeaders)
 					}
+				}
+				res.Before(setHeaders)
+				err := next(c)
+				if !res.Committed {
+					setHeaders()
 				}
 				return err
 			}

--- a/middleware/cors_test.go
+++ b/middleware/cors_test.go
@@ -7,6 +7,9 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/labstack/echo/v4"
@@ -682,4 +685,43 @@ func Test_allowOriginFunc(t *testing.T) {
 			assert.Equal(t, "", rec.Header().Get(echo.HeaderAccessControlAllowOrigin))
 		}
 	}
+}
+
+func TestCORSNoDuplicateHeadersFromUpstream(t *testing.T) {
+	t.Parallel()
+
+	backend := echo.New()
+	backend.Use(CORS())
+	backend.GET("/", func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+	backendServer := httptest.NewServer(backend)
+	t.Cleanup(backendServer.Close)
+
+	backendURL, err := url.Parse(backendServer.URL)
+	assert.NoError(t, err)
+	reverseProxy := httputil.NewSingleHostReverseProxy(backendURL)
+
+	proxy := echo.New()
+	proxy.Use(CORS())
+	proxy.Any("/*", func(c echo.Context) error {
+		req := c.Request()
+		res := c.Response()
+		req.URL.Path = strings.TrimPrefix(req.URL.Path, "/proxy")
+		if req.URL.Path == "" {
+			req.URL.Path = "/"
+		}
+		reverseProxy.ServeHTTP(res, req)
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/proxy/", nil)
+	req.Header.Set(echo.HeaderOrigin, "http://example.com")
+	rec := httptest.NewRecorder()
+	proxy.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 1, len(rec.Header()[echo.HeaderAccessControlAllowOrigin]))
+	assert.Equal(t, "*", rec.Header().Get(echo.HeaderAccessControlAllowOrigin))
+	assert.Equal(t, 1, len(rec.Header()[echo.HeaderVary]))
 }

--- a/middleware/cors_test.go
+++ b/middleware/cors_test.go
@@ -720,8 +720,11 @@ func TestCORSNoDuplicateHeadersFromUpstream(t *testing.T) {
 	rec := httptest.NewRecorder()
 	proxy.ServeHTTP(rec, req)
 
+	result := rec.Result()
+	defer result.Body.Close()
+
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, 1, len(rec.Header()[echo.HeaderAccessControlAllowOrigin]))
-	assert.Equal(t, "*", rec.Header().Get(echo.HeaderAccessControlAllowOrigin))
-	assert.Equal(t, 1, len(rec.Header()[echo.HeaderVary]))
+	assert.Equal(t, 1, len(result.Header[echo.HeaderAccessControlAllowOrigin]))
+	assert.Equal(t, "*", result.Header.Get(echo.HeaderAccessControlAllowOrigin))
+	assert.Equal(t, 1, len(result.Header[echo.HeaderVary]))
 }


### PR DESCRIPTION
## Summary

- For simple (non-preflight) CORS requests, apply CORS response headers after the handler runs
- Skip setting `Access-Control-Allow-Origin` and related headers when an upstream handler (e.g. reverse proxy) already set them
- Add regression test covering chained CORS + reverse proxy setup from #2853

## Test plan

- [x] `go test ./middleware/...`
- [x] `TestCORSNoDuplicateHeadersFromUpstream` — proxy layer + upstream both use CORS middleware, response has single `Access-Control-Allow-Origin` and `Vary`

Fixes #2853