### PR TITLE
fix(middleware): keep handler 404 responses with Static HTML5 mode

### DIFF
--- a/middleware/static.go
+++ b/middleware/static.go
@@ -204,7 +204,7 @@ func StaticWithConfig(config StaticConfig) echo.MiddlewareFunc {
 				}
 
 				var he *echo.HTTPError
-				if !(errors.As(err, &he) && config.HTML5 && he.Code == http.StatusNotFound) {
+				if !(errors.As(err, &he) && config.HTML5 && he.Code == http.StatusNotFound && isRouterNotFoundError(c, err)) {
 					return err
 				}
 
@@ -243,6 +243,18 @@ func StaticWithConfig(config StaticConfig) echo.MiddlewareFunc {
 
 			return serveFile(c, file, info)
 		}
+	}
+}
+
+func isRouterNotFoundError(c echo.Context, err error) bool {
+	if errors.Is(err, echo.ErrNotFound) {
+		return true
+	}
+	switch c.Path() {
+	case "", "/*":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/middleware/static_test.go
+++ b/middleware/static_test.go
@@ -454,3 +454,39 @@ func TestStatic_CustomFS(t *testing.T) {
 		})
 	}
 }
+
+func TestStaticHTML5DoesNotOverrideHandler404(t *testing.T) {
+	t.Parallel()
+
+	e := echo.New()
+	e.Use(StaticWithConfig(StaticConfig{
+		Root:  "../_fixture",
+		HTML5: true,
+	}))
+
+	e.GET("/api/test/:id", func(c echo.Context) error {
+		if c.Param("id") == "3" {
+			return echo.NewHTTPError(http.StatusNotFound, "not found")
+		}
+		return c.String(http.StatusOK, "ID: "+c.Param("id"))
+	})
+
+	t.Run("handler 404 is preserved", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/test/3", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+		assert.Contains(t, rec.Body.String(), "not found")
+		assert.NotContains(t, rec.Body.String(), "<title>Echo</title>")
+	})
+
+	t.Run("router 404 serves SPA index", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/client-route", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, rec.Body.String(), "<title>Echo</title>")
+	})
+}


### PR DESCRIPTION
## Summary

- Restrict Static middleware HTML5 SPA fallback to router-level 404 responses
- Skip index.html fallback when a matched handler returns its own `404` (e.g. API resource not found)
- Add regression test covering `/api/test/3` JSON 404 vs `/client-route` SPA index fallback

## Test plan

- [x] `go test ./middleware/...`
- [x] `TestStaticHTML5DoesNotOverrideHandler404`

Fixes #2775