### PR TITLE
fix(binder): MustUnixTime docs say time.Time, not time.Duration

### DIFF
--- a/binder.go
+++ b/binder.go
@@ -1239,7 +1239,7 @@ func (b *ValueBinder) UnixTime(sourceParam string, dest *time.Time) *ValueBinder
 	return b.unixTime(sourceParam, dest, false, time.Second)
 }
 
-// MustUnixTime requires parameter value to exist to bind to time.Duration variable (in local time corresponding
+// MustUnixTime requires parameter value to exist to bind to time.Time variable (in local time corresponding
 // to the given Unix time). Returns error when value does not exist.
 //
 // Example: 1609180603 bind to 2020-12-28T18:36:43.000000000+00:00
@@ -1260,7 +1260,7 @@ func (b *ValueBinder) UnixTimeMilli(sourceParam string, dest *time.Time) *ValueB
 	return b.unixTime(sourceParam, dest, false, time.Millisecond)
 }
 
-// MustUnixTimeMilli requires parameter value to exist to bind to time.Duration variable  (in local time corresponding
+// MustUnixTimeMilli requires parameter value to exist to bind to time.Time variable (in local time corresponding
 // to the given Unix time in millisecond precision). Returns error when value does not exist.
 //
 // Example: 1647184410140 bind to 2022-03-13T15:13:30.140000000+00:00
@@ -1284,8 +1284,8 @@ func (b *ValueBinder) UnixTimeNano(sourceParam string, dest *time.Time) *ValueBi
 	return b.unixTime(sourceParam, dest, false, time.Nanosecond)
 }
 
-// MustUnixTimeNano requires parameter value to exist to bind to time.Duration variable  (in local Time corresponding
-// to the given Unix time value in nano second precision). Returns error when value does not exist.
+// MustUnixTimeNano requires parameter value to exist to bind to time.Time variable (in local time corresponding
+// to the given Unix time value in nanosecond precision). Returns error when value does not exist.
 //
 // Example: 1609180603123456789 binds to 2020-12-28T18:36:43.123456789+00:00
 // Example:          1000000000 binds to 1970-01-01T00:00:01.000000000+00:00


### PR DESCRIPTION
Spotted while reading binder.go. The doc comments on `MustUnixTime`, `MustUnixTimeMilli`, `MustUnixTimeNano` all say "bind to time.Duration variable" but the function signature is `dest *time.Time` and the non-Must variants directly above each one correctly say "binds parameter to time.Time variable". Looks like a copy-paste from the actual `MustDuration` doc that never got updated.

While there, dropped a stray double space and changed "nano second" to "nanosecond" on the Nano variant. No code change.