### PR TITLE
Fix CORS header duplication in chained proxies

### DIFF
--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -111,6 +111,13 @@ type CORSConfig struct {
 	//
 	// See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
 	MaxAge int
+
+	// UnsafeDeduplicateHeaders is an optional configuration to deduplicate CORS and Vary headers.
+	// This is useful in chained proxy environments where duplicate CORS headers are returned from upstream.
+	// Enabling this wraps the ResponseWriter and has a minor performance cost.
+	//
+	// Optional. Default value false.
+	UnsafeDeduplicateHeaders bool
 }
 
 // CORS returns a Cross-Origin Resource Sharing (CORS) middleware.
@@ -189,9 +196,16 @@ func (config CORSConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
 				return next(c)
 			}
 
+			// Add Vary: Origin unconditionally to all requests
+			addVaryHeader(c.Response().Header(), echo.HeaderOrigin)
+
 			req := c.Request()
-			res := c.Response()
 			origin := req.Header.Get(echo.HeaderOrigin)
+
+			if config.UnsafeDeduplicateHeaders {
+				rw := &corsResponseWriter{ResponseWriter: c.Response()}
+				c.SetResponse(rw)
+			}
 
 			// Preflight request is an OPTIONS request, using three HTTP request headers: Access-Control-Request-Method,
 			// Access-Control-Request-Headers, and the Origin header. See: https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request
@@ -215,12 +229,8 @@ func (config CORSConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
 			// No Origin provided. This is (probably) not request from actual browser - proceed executing middleware chain
 			if origin == "" {
 				if preflight { // req.Method=OPTIONS
-					addVaryHeader(res.Header(), echo.HeaderOrigin)
 					return c.NoContent(http.StatusNoContent)
 				}
-				res.Before(func() {
-					addVaryHeader(res.Header(), echo.HeaderOrigin)
-				})
 				return next(c) // let non-browser calls through
 			}
 
@@ -241,9 +251,6 @@ func (config CORSConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
 				// no CORS middleware should block non-preflight requests;
 				// such requests should be let through. One reason is that not all requests that
 				// carry an Origin header participate in the CORS protocol.
-				res.Before(func() {
-					addVaryHeader(res.Header(), echo.HeaderOrigin)
-				})
 				return next(c)
 			}
 
@@ -251,18 +258,15 @@ func (config CORSConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
 
 			// Simple request will be let though
 			if !preflight {
-				res.Before(func() {
-					addVaryHeader(res.Header(), echo.HeaderOrigin)
-					res.Header().Set(echo.HeaderAccessControlAllowOrigin, allowedOrigin)
-					if config.AllowCredentials {
-						res.Header().Set(echo.HeaderAccessControlAllowCredentials, "true")
-					} else {
-						res.Header().Del(echo.HeaderAccessControlAllowCredentials)
-					}
-					if exposeHeaders != "" {
-						res.Header().Set(echo.HeaderAccessControlExposeHeaders, exposeHeaders)
-					}
-				})
+				c.Response().Header().Set(echo.HeaderAccessControlAllowOrigin, allowedOrigin)
+				if config.AllowCredentials {
+					c.Response().Header().Set(echo.HeaderAccessControlAllowCredentials, "true")
+				} else {
+					c.Response().Header().Del(echo.HeaderAccessControlAllowCredentials)
+				}
+				if exposeHeaders != "" {
+					c.Response().Header().Set(echo.HeaderAccessControlExposeHeaders, exposeHeaders)
+				}
 				return next(c)
 			}
 			// Below code is for Preflight (OPTIONS) request
@@ -270,32 +274,31 @@ func (config CORSConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
 			// Preflight will end with c.NoContent(http.StatusNoContent) as we do not know if
 			// at the end of handler chain is actual OPTIONS route or 404/405 route which
 			// response code will confuse browsers
-			addVaryHeader(res.Header(), echo.HeaderOrigin)
-			res.Header().Set(echo.HeaderAccessControlAllowOrigin, allowedOrigin)
+			c.Response().Header().Set(echo.HeaderAccessControlAllowOrigin, allowedOrigin)
 			if config.AllowCredentials {
-				res.Header().Set(echo.HeaderAccessControlAllowCredentials, "true")
+				c.Response().Header().Set(echo.HeaderAccessControlAllowCredentials, "true")
 			} else {
-				res.Header().Del(echo.HeaderAccessControlAllowCredentials)
+				c.Response().Header().Del(echo.HeaderAccessControlAllowCredentials)
 			}
-			addVaryHeader(res.Header(), echo.HeaderAccessControlRequestMethod)
-			addVaryHeader(res.Header(), echo.HeaderAccessControlRequestHeaders)
+			addVaryHeader(c.Response().Header(), echo.HeaderAccessControlRequestMethod)
+			addVaryHeader(c.Response().Header(), echo.HeaderAccessControlRequestHeaders)
 
 			if !hasCustomAllowMethods && routerAllowMethods != "" {
-				res.Header().Set(echo.HeaderAccessControlAllowMethods, routerAllowMethods)
+				c.Response().Header().Set(echo.HeaderAccessControlAllowMethods, routerAllowMethods)
 			} else {
-				res.Header().Set(echo.HeaderAccessControlAllowMethods, allowMethods)
+				c.Response().Header().Set(echo.HeaderAccessControlAllowMethods, allowMethods)
 			}
 
 			if allowHeaders != "" {
-				res.Header().Set(echo.HeaderAccessControlAllowHeaders, allowHeaders)
+				c.Response().Header().Set(echo.HeaderAccessControlAllowHeaders, allowHeaders)
 			} else {
 				h := req.Header.Get(echo.HeaderAccessControlRequestHeaders)
 				if h != "" {
-					res.Header().Set(echo.HeaderAccessControlAllowHeaders, h)
+					c.Response().Header().Set(echo.HeaderAccessControlAllowHeaders, h)
 				}
 			}
 			if config.MaxAge != 0 {
-				res.Header().Set(echo.HeaderAccessControlMaxAge, maxAge)
+				c.Response().Header().Set(echo.HeaderAccessControlMaxAge, maxAge)
 			}
 			return c.NoContent(http.StatusNoContent)
 		}
@@ -328,4 +331,86 @@ func addVaryHeader(h http.Header, value string) {
 		}
 	}
 	h.Add(echo.HeaderVary, value)
+}
+
+type corsResponseWriter struct {
+	http.ResponseWriter
+	deduplicated bool
+}
+
+func (w *corsResponseWriter) WriteHeader(statusCode int) {
+	w.deduplicate()
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *corsResponseWriter) Write(b []byte) (int, error) {
+	w.deduplicate()
+	return w.ResponseWriter.Write(b)
+}
+
+func (w *corsResponseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+func (w *corsResponseWriter) deduplicate() {
+	if w.deduplicated {
+		return
+	}
+	w.deduplicated = true
+
+	h := w.ResponseWriter.Header()
+	deduplicateHeader(h, echo.HeaderAccessControlAllowOrigin)
+	deduplicateHeader(h, echo.HeaderAccessControlAllowCredentials)
+	deduplicateHeader(h, echo.HeaderAccessControlExposeHeaders)
+	deduplicateHeader(h, echo.HeaderAccessControlAllowHeaders)
+	deduplicateHeader(h, echo.HeaderAccessControlAllowMethods)
+	deduplicateHeader(h, echo.HeaderAccessControlMaxAge)
+	deduplicateVary(h)
+}
+
+func deduplicateHeader(h http.Header, key string) {
+	values := h[key]
+	if len(values) <= 1 {
+		return
+	}
+	seen := make(map[string]bool)
+	var result []string
+	for _, v := range values {
+		trimmed := strings.TrimSpace(v)
+		if !seen[trimmed] {
+			seen[trimmed] = true
+			result = append(result, v)
+		}
+	}
+	h[key] = result
+}
+
+func deduplicateVary(h http.Header) {
+	values := h[echo.HeaderVary]
+	if len(values) == 0 {
+		return
+	}
+	seen := make(map[string]bool)
+	var varyParts []string
+	for _, v := range values {
+		for _, part := range strings.Split(v, ",") {
+			trimmed := strings.TrimSpace(part)
+			if trimmed == "" {
+				continue
+			}
+			lower := strings.ToLower(trimmed)
+			if !seen[lower] {
+				seen[lower] = true
+				varyParts = append(varyParts, trimmed)
+			}
+		}
+	}
+	if len(varyParts) > 0 {
+		h.Del(echo.HeaderVary)
+		for _, part := range varyParts {
+			h.Add(echo.HeaderVary, part)
+		}
+	} else {
+		h.Del(echo.HeaderVary)
+	}
 }

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -193,8 +193,6 @@ func (config CORSConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
 			res := c.Response()
 			origin := req.Header.Get(echo.HeaderOrigin)
 
-			res.Header().Add(echo.HeaderVary, echo.HeaderOrigin)
-
 			// Preflight request is an OPTIONS request, using three HTTP request headers: Access-Control-Request-Method,
 			// Access-Control-Request-Headers, and the Origin header. See: https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request
 			// For simplicity we just consider method type and later `Origin` header.
@@ -217,8 +215,12 @@ func (config CORSConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
 			// No Origin provided. This is (probably) not request from actual browser - proceed executing middleware chain
 			if origin == "" {
 				if preflight { // req.Method=OPTIONS
+					addVaryHeader(res.Header(), echo.HeaderOrigin)
 					return c.NoContent(http.StatusNoContent)
 				}
+				res.Before(func() {
+					addVaryHeader(res.Header(), echo.HeaderOrigin)
+				})
 				return next(c) // let non-browser calls through
 			}
 
@@ -239,21 +241,28 @@ func (config CORSConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
 				// no CORS middleware should block non-preflight requests;
 				// such requests should be let through. One reason is that not all requests that
 				// carry an Origin header participate in the CORS protocol.
+				res.Before(func() {
+					addVaryHeader(res.Header(), echo.HeaderOrigin)
+				})
 				return next(c)
 			}
 
 			// Origin existed and was allowed
 
-			res.Header().Set(echo.HeaderAccessControlAllowOrigin, allowedOrigin)
-			if config.AllowCredentials {
-				res.Header().Set(echo.HeaderAccessControlAllowCredentials, "true")
-			}
-
 			// Simple request will be let though
 			if !preflight {
-				if exposeHeaders != "" {
-					res.Header().Set(echo.HeaderAccessControlExposeHeaders, exposeHeaders)
-				}
+				res.Before(func() {
+					addVaryHeader(res.Header(), echo.HeaderOrigin)
+					res.Header().Set(echo.HeaderAccessControlAllowOrigin, allowedOrigin)
+					if config.AllowCredentials {
+						res.Header().Set(echo.HeaderAccessControlAllowCredentials, "true")
+					} else {
+						res.Header().Del(echo.HeaderAccessControlAllowCredentials)
+					}
+					if exposeHeaders != "" {
+						res.Header().Set(echo.HeaderAccessControlExposeHeaders, exposeHeaders)
+					}
+				})
 				return next(c)
 			}
 			// Below code is for Preflight (OPTIONS) request
@@ -261,8 +270,15 @@ func (config CORSConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
 			// Preflight will end with c.NoContent(http.StatusNoContent) as we do not know if
 			// at the end of handler chain is actual OPTIONS route or 404/405 route which
 			// response code will confuse browsers
-			res.Header().Add(echo.HeaderVary, echo.HeaderAccessControlRequestMethod)
-			res.Header().Add(echo.HeaderVary, echo.HeaderAccessControlRequestHeaders)
+			addVaryHeader(res.Header(), echo.HeaderOrigin)
+			res.Header().Set(echo.HeaderAccessControlAllowOrigin, allowedOrigin)
+			if config.AllowCredentials {
+				res.Header().Set(echo.HeaderAccessControlAllowCredentials, "true")
+			} else {
+				res.Header().Del(echo.HeaderAccessControlAllowCredentials)
+			}
+			addVaryHeader(res.Header(), echo.HeaderAccessControlRequestMethod)
+			addVaryHeader(res.Header(), echo.HeaderAccessControlRequestHeaders)
 
 			if !hasCustomAllowMethods && routerAllowMethods != "" {
 				res.Header().Set(echo.HeaderAccessControlAllowMethods, routerAllowMethods)
@@ -297,4 +313,19 @@ func (config CORSConfig) defaultAllowOriginFunc(c *echo.Context, origin string) 
 		}
 	}
 	return "", false, nil
+}
+
+func addVaryHeader(h http.Header, value string) {
+	if h.Get(echo.HeaderVary) == "" {
+		h.Set(echo.HeaderVary, value)
+		return
+	}
+	for _, v := range h.Values(echo.HeaderVary) {
+		for _, part := range strings.Split(v, ",") {
+			if strings.EqualFold(strings.TrimSpace(part), value) {
+				return
+			}
+		}
+	}
+	h.Add(echo.HeaderVary, value)
 }

--- a/middleware/cors_test.go
+++ b/middleware/cors_test.go
@@ -628,47 +628,93 @@ func Test_allowOriginFunc(t *testing.T) {
 }
 
 func TestCORSProxyChainedHeaders(t *testing.T) {
-	e := echo.New()
+	t.Run("with deduplication enabled", func(t *testing.T) {
+		e := echo.New()
 
-	// CORS middleware on the proxy
-	cors := CORSWithConfig(CORSConfig{
-		AllowOrigins: []string{"http://example.com"},
-	})
+		// CORS middleware on the proxy with deduplication enabled
+		cors := CORSWithConfig(CORSConfig{
+			AllowOrigins:             []string{"http://example.com"},
+			UnsafeDeduplicateHeaders: true,
+		})
 
-	// Proxy handler simulating upstream call that also returns CORS headers
-	proxyHandler := func(c *echo.Context) error {
-		// Mock upstream copying headers to response
-		// This simulates the behavior of httputil.ReverseProxy which copies headers from upstream
-		c.Response().Header().Add(echo.HeaderAccessControlAllowOrigin, "http://example.com")
-		c.Response().Header().Add(echo.HeaderVary, echo.HeaderOrigin)
-		c.Response().WriteHeader(http.StatusOK)
-		return nil
-	}
+		// Proxy handler simulating upstream call that also returns CORS headers
+		proxyHandler := func(c *echo.Context) error {
+			// Mock upstream copying headers to response
+			// This simulates the behavior of httputil.ReverseProxy which copies headers from upstream
+			c.Response().Header().Add(echo.HeaderAccessControlAllowOrigin, "http://example.com")
+			c.Response().Header().Add(echo.HeaderVary, echo.HeaderOrigin)
+			c.Response().WriteHeader(http.StatusOK)
+			return nil
+		}
 
-	h := cors(proxyHandler)
+		h := cors(proxyHandler)
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	req.Header.Set(echo.HeaderOrigin, "http://example.com")
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set(echo.HeaderOrigin, "http://example.com")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
 
-	err := h(c)
-	assert.NoError(t, err)
+		err := h(c)
+		assert.NoError(t, err)
 
-	// Verify that Access-Control-Allow-Origin is not duplicated
-	acaoHeaders := rec.Header()[echo.HeaderAccessControlAllowOrigin]
-	assert.Len(t, acaoHeaders, 1, "Access-Control-Allow-Origin should not be duplicated")
-	assert.Equal(t, "http://example.com", acaoHeaders[0])
+		// Verify that Access-Control-Allow-Origin is not duplicated
+		acaoHeaders := rec.Header()[echo.HeaderAccessControlAllowOrigin]
+		assert.Len(t, acaoHeaders, 1, "Access-Control-Allow-Origin should not be duplicated")
+		assert.Equal(t, "http://example.com", acaoHeaders[0])
 
-	// Verify that Vary: Origin is not duplicated
-	varyHeaders := rec.Header()[echo.HeaderVary]
-	originCount := 0
-	for _, v := range varyHeaders {
-		for _, part := range strings.Split(v, ",") {
-			if strings.EqualFold(strings.TrimSpace(part), echo.HeaderOrigin) {
-				originCount++
+		// Verify that Vary: Origin is not duplicated
+		varyHeaders := rec.Header()[echo.HeaderVary]
+		originCount := 0
+		for _, v := range varyHeaders {
+			for _, part := range strings.Split(v, ",") {
+				if strings.EqualFold(strings.TrimSpace(part), echo.HeaderOrigin) {
+					originCount++
+				}
 			}
 		}
-	}
-	assert.Equal(t, 1, originCount, "Vary Origin should not be duplicated")
+		assert.Equal(t, 1, originCount, "Vary Origin should not be duplicated")
+	})
+
+	t.Run("with deduplication disabled (default)", func(t *testing.T) {
+		e := echo.New()
+
+		// CORS middleware on the proxy with deduplication disabled
+		cors := CORSWithConfig(CORSConfig{
+			AllowOrigins: []string{"http://example.com"},
+		})
+
+		// Proxy handler simulating upstream call that also returns CORS headers
+		proxyHandler := func(c *echo.Context) error {
+			c.Response().Header().Add(echo.HeaderAccessControlAllowOrigin, "http://example.com")
+			c.Response().Header().Add(echo.HeaderVary, echo.HeaderOrigin)
+			c.Response().WriteHeader(http.StatusOK)
+			return nil
+		}
+
+		h := cors(proxyHandler)
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set(echo.HeaderOrigin, "http://example.com")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		err := h(c)
+		assert.NoError(t, err)
+
+		// Verify that Access-Control-Allow-Origin is duplicated
+		acaoHeaders := rec.Header()[echo.HeaderAccessControlAllowOrigin]
+		assert.Len(t, acaoHeaders, 2, "Access-Control-Allow-Origin should be duplicated")
+
+		// Verify that Vary: Origin is duplicated
+		varyHeaders := rec.Header()[echo.HeaderVary]
+		originCount := 0
+		for _, v := range varyHeaders {
+			for _, part := range strings.Split(v, ",") {
+				if strings.EqualFold(strings.TrimSpace(part), echo.HeaderOrigin) {
+					originCount++
+				}
+			}
+		}
+		assert.Equal(t, 2, originCount, "Vary Origin should be duplicated")
+	})
 }

--- a/middleware/cors_test.go
+++ b/middleware/cors_test.go
@@ -626,3 +626,49 @@ func Test_allowOriginFunc(t *testing.T) {
 		}
 	}
 }
+
+func TestCORSProxyChainedHeaders(t *testing.T) {
+	e := echo.New()
+
+	// CORS middleware on the proxy
+	cors := CORSWithConfig(CORSConfig{
+		AllowOrigins: []string{"http://example.com"},
+	})
+
+	// Proxy handler simulating upstream call that also returns CORS headers
+	proxyHandler := func(c *echo.Context) error {
+		// Mock upstream copying headers to response
+		// This simulates the behavior of httputil.ReverseProxy which copies headers from upstream
+		c.Response().Header().Add(echo.HeaderAccessControlAllowOrigin, "http://example.com")
+		c.Response().Header().Add(echo.HeaderVary, echo.HeaderOrigin)
+		c.Response().WriteHeader(http.StatusOK)
+		return nil
+	}
+
+	h := cors(proxyHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(echo.HeaderOrigin, "http://example.com")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h(c)
+	assert.NoError(t, err)
+
+	// Verify that Access-Control-Allow-Origin is not duplicated
+	acaoHeaders := rec.Header()[echo.HeaderAccessControlAllowOrigin]
+	assert.Len(t, acaoHeaders, 1, "Access-Control-Allow-Origin should not be duplicated")
+	assert.Equal(t, "http://example.com", acaoHeaders[0])
+
+	// Verify that Vary: Origin is not duplicated
+	varyHeaders := rec.Header()[echo.HeaderVary]
+	originCount := 0
+	for _, v := range varyHeaders {
+		for _, part := range strings.Split(v, ",") {
+			if strings.EqualFold(strings.TrimSpace(part), echo.HeaderOrigin) {
+				originCount++
+			}
+		}
+	}
+	assert.Equal(t, 1, originCount, "Vary Origin should not be duplicated")
+}


### PR DESCRIPTION
Fixes #2853.

When Echo CORS middleware is run in a chained proxy setup (or in front of any handler copying upstream headers using Add), headers like Access-Control-Allow-Origin and Vary get duplicated in the response.

Changes:
- Run simple request CORS header writing inside a Before hook on the response. This allows the proxy's CORS config to cleanly Set the headers, overriding duplicated upstream headers from the proxy or downstream response copy.
- Implement addVaryHeader helper to merge and deduplicate Vary values case-insensitively.
- Add unit test simulating ReverseProxy behavior to verify headers are not duplicated.