### PR TITLE
fix(middleware): fallback to html5 route file

### DIFF
--- a/middleware/static.go
+++ b/middleware/static.go
@@ -242,6 +242,20 @@ func (config StaticConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
 				if !isIgnorableOpenFileError(err) {
 					return err
 				}
+
+				if config.HTML5 {
+					html5File, html5Err := currentFS.Open(filePath + ".html")
+					if html5Err == nil {
+						defer html5File.Close()
+
+						html5Info, err := html5File.Stat()
+						if err != nil {
+							return err
+						}
+
+						return serveFile(c, html5File, html5Info)
+					}
+				}
 				// file with that path did not exist, so we continue down in middleware/handler chain, hoping that we end up in
 				// handler that is meant to handle this request
 				err = next(c)
@@ -270,6 +284,20 @@ func (config StaticConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
 			if info.IsDir() {
 				index, err := currentFS.Open(path.Join(filePath, config.Index))
 				if err != nil {
+					if config.HTML5 && !config.Browse {
+						html5File, html5Err := currentFS.Open(filePath + ".html")
+						if html5Err == nil {
+							defer html5File.Close()
+
+							info, err = html5File.Stat()
+							if err != nil {
+								return err
+							}
+
+							return serveFile(c, html5File, info)
+						}
+					}
+
 					if config.Browse {
 						return listDir(dirListTemplate, filePath, currentFS, c.Response())
 					}

--- a/middleware/static_test.go
+++ b/middleware/static_test.go
@@ -78,6 +78,16 @@ func TestStatic(t *testing.T) {
 			expectContains: "<h1>Hello from index</h1>",
 		},
 		{
+			name: "ok, when html5 mode serve route html next to a directory",
+			givenConfig: &StaticConfig{
+				Root:  "testdata/dist/public",
+				HTML5: true,
+			},
+			whenURL:        "/camera",
+			expectCode:     http.StatusOK,
+			expectContains: "<h1>Camera page</h1>",
+		},
+		{
 			name: "ok, serve index as directory index listing files directory",
 			givenConfig: &StaticConfig{
 				Root:   "testdata/dist/public/assets",

--- a/middleware/testdata/dist/public/camera.html
+++ b/middleware/testdata/dist/public/camera.html
@@ -1,0 +1,1 @@
+<h1>Camera page</h1>

--- a/middleware/testdata/dist/public/camera/route.txt
+++ b/middleware/testdata/dist/public/camera/route.txt
@@ -1,0 +1,1 @@
+camera route directory


### PR DESCRIPTION
Add an HTML5 fallback to serve `*.html` beside directory paths when `Browse=false`.

Includes a regression test for a directory-backed route produced by SvelteKit-style output.