### PR TITLE
fix(middleware): correct documented KeyAuth KeyLookup default

### DIFF
--- a/middleware/key_auth.go
+++ b/middleware/key_auth.go
@@ -22,7 +22,7 @@ type KeyAuthConfig struct {
 
 	// KeyLookup is a string in the form of "<source>:<name>" or "<source>:<name>,<source>:<name>" that is used
 	// to extract key from the request.
-	// Optional. Default value "header:Authorization".
+	// Optional. Default value "header:Authorization:Bearer ".
 	// Possible values:
 	// - "header:<name>" or "header:<name>:<cut-prefix>"
 	// 			`<cut-prefix>` is argument value to cut/trim prefix of the extracted value. This is useful if header


### PR DESCRIPTION
The `KeyLookup` field comment in `KeyAuthConfig` documents the default as `"header:Authorization"`, but the default applied by `DefaultKeyAuthConfig` is:

```go
KeyLookup: "header:" + echo.HeaderAuthorization + ":Bearer ",
```

which evaluates to `"header:Authorization:Bearer "` (also the value `ToMiddleware` falls back to when `KeyLookup` is empty). The `:Bearer ` cut-prefix trims the scheme from the header value, exactly as the same comment block describes.

The comment was correct in v4, where `AuthScheme: "Bearer"` was a separate field. In v5 `AuthScheme` was folded into `KeyLookup`, but this comment was left showing the old default.

Doc comment only — no behavior change.
