### PR TITLE
fix(middleware): reset ContentLength after gzip decompression

### DIFF
--- a/middleware/body_limit_test.go
+++ b/middleware/body_limit_test.go
@@ -68,6 +68,31 @@ func TestBodyLimitConfig_ToMiddleware(t *testing.T) {
 	assert.Equal(t, http.StatusRequestEntityTooLarge, he.StatusCode())
 }
 
+func TestBodyLimitAfterDecompressUsesDecodedSize(t *testing.T) {
+	e := echo.New()
+	body := "ok"
+	gz, err := gzipString(body)
+	assert.NoError(t, err)
+	assert.Greater(t, len(gz), len(body))
+
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(gz))
+	req.Header.Set(echo.HeaderContentEncoding, GZIPEncoding)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err = Decompress()(BodyLimit(int64(len(body)))(func(c *echo.Context) error {
+		body, readErr := io.ReadAll(c.Request().Body)
+		if readErr != nil {
+			return readErr
+		}
+		return c.String(http.StatusOK, string(body))
+	}))(c)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, body, rec.Body.String())
+}
+
 func TestBodyLimitReader(t *testing.T) {
 	hw := []byte("Hello, World!")
 

--- a/middleware/decompress.go
+++ b/middleware/decompress.go
@@ -120,6 +120,7 @@ func (config DecompressConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
 				// -1 means explicitly unlimited (not recommended)
 				c.Request().Body = gr
 			}
+			c.Request().ContentLength = -1
 
 			return next(c)
 		}

--- a/middleware/decompress_test.go
+++ b/middleware/decompress_test.go
@@ -215,8 +215,6 @@ func BenchmarkDecompress(b *testing.B) {
 	e := echo.New()
 	body := `{"name": "echo"}`
 	gz, _ := gzipString(body)
-	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(gz)))
-	req.Header.Set(echo.HeaderContentEncoding, GZIPEncoding)
 
 	h := Decompress()(func(c *echo.Context) error {
 		c.Response().Write([]byte(body)) // For Content-Type sniffing
@@ -228,6 +226,8 @@ func BenchmarkDecompress(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		// Decompress
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(gz))
+		req.Header.Set(echo.HeaderContentEncoding, GZIPEncoding)
 		rec := httptest.NewRecorder()
 		c := e.NewContext(req, rec)
 		h(c)


### PR DESCRIPTION
## Summary

Fix `Decompress` so middleware after it does not keep using the compressed request size after the body has been replaced with the decoded gzip stream.

For example:

```go
e.Use(middleware.Decompress())
e.Use(middleware.BodyLimit(4))
```

A gzipped request whose decoded body is `ok` should pass:

```bash
printf "ok" | gzip | curl -X POST \
  -H "Content-Type: text/plain" \
  -H "Content-Encoding: gzip" \
  --data-binary @- \
  http://localhost:8080/
```

Before this change, `Decompress` replaced `req.Body` but left `req.ContentLength` set to the compressed size, so `BodyLimit` could reject the request before reading it:

```text
{"message":"Request Entity Too Large"}
```

With this change, `Decompress` sets `req.ContentLength = -1` after gzip decompression is set up, so downstream middleware enforces limits while reading the decoded body:

```text
ok
```

This intentionally does not change `Content-Encoding`, `GetBody`, or multiple content-coding behavior.

## Test plan

- [x] `go test -count=1 ./...`
- [x] `go test -race -count=1 ./...`
- [x] `go vet ./...`
- [x] `staticcheck ./...`
- [x] Manual curl check with the same handler returned `ok` and HTTP 200
