### PR TITLE
docs: liveness signals in README + public ROADMAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Latest release](https://img.shields.io/github/v/release/labstack/echo?style=flat-square&label=release&color=00afd1)](https://github.com/labstack/echo/releases)
+[![Last commit](https://img.shields.io/github/last-commit/labstack/echo/master?style=flat-square)](https://github.com/labstack/echo/commits/master)
 [![Sourcegraph](https://sourcegraph.com/github.com/labstack/echo/-/badge.svg?style=flat-square)](https://sourcegraph.com/github.com/labstack/echo?badge)
 [![GoDoc](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](https://pkg.go.dev/github.com/labstack/echo/v5)
 [![Go Report Card](https://goreportcard.com/badge/github.com/labstack/echo?style=flat-square)](https://goreportcard.com/report/github.com/labstack/echo)
@@ -10,6 +12,8 @@
 ## Echo
 
 High performance, extensible, minimalist Go web framework.
+
+Echo is built on Go's standard `net/http` — handlers stay `http.Handler`-compatible — and adds the parts the standard library leaves to you: a fast radix-tree router, request binding and validation, a deep middleware ecosystem, and centralized error handling. Actively maintained, with `v5` as the current release line (see badges above for the latest version and most recent commit).
 
 * [Official website](https://echo.labstack.com)
 * [Quick start](https://echo.labstack.com/docs/quick-start)
@@ -52,6 +56,8 @@ Click [here](https://github.com/sponsors/labstack) for more information on spons
 - Latest major version of Echo is `v5` as of 2026-01-18.
   - See [API_CHANGES_V5.md](./API_CHANGES_V5.md) for public API changes between `v4` and `v5`, notes on upgrading.
 - Echo `v4` is supported with **security*** updates and **bug** fixes until **2026-12-31**
+
+See [ROADMAP.md](./ROADMAP.md) for where Echo is heading and the version support policy.
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 High performance, extensible, minimalist Go web framework.
 
-Echo is built on Go's standard `net/http` — handlers stay `http.Handler`-compatible — and adds the parts the standard library leaves to you: a fast radix-tree router, request binding and validation, a deep middleware ecosystem, and centralized error handling. Actively maintained, with `v5` as the current release line (see badges above for the latest version and most recent commit).
+Echo is built on Go's standard `net/http` — and interoperates with it via `echo.WrapHandler` / `echo.WrapMiddleware` — adding the parts the standard library leaves to you: a fast radix-tree router, request binding (with a pluggable validator), a deep middleware ecosystem, and centralized error handling. Actively maintained, with `v5` as the current release line (see badges above for the latest version and most recent commit).
 
 * [Official website](https://echo.labstack.com)
 * [Quick start](https://echo.labstack.com/docs/quick-start)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,7 +30,7 @@ Echo supports the **latest four Go major releases** and may work with older vers
 These are frequently-requested items being discussed. Inclusion here is **not** a
 commitment — each still needs design agreement before implementation:
 
-- **Automatic `HEAD` for `GET` routes** (#2944, #2937) — opt-in, likely via an
+- **Automatic `HEAD` for `GET` routes** (#2895; see #2949) — opt-in, likely via an
   `OnAddRoute` hook so users keep control.
 - **Rate limiter response metadata** — expose `Retry-After` / remaining quota
   through the store interface (#2961).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,50 @@
+# Echo Roadmap
+
+> **DRAFT** — this is a starting point for maintainers to edit, not a commitment.
+> Dates and priorities are owned by the Echo team. Open a discussion to propose changes.
+
+This document exists so the community can see where Echo is heading. Echo is
+**actively maintained**. We publish releases regularly across two supported
+lines — see [README](./README.md) badges for the latest version and most recent commit.
+
+## Version policy
+
+| Line | Status | Support |
+|------|--------|---------|
+| `v5` | **Current** (since 2026-01-18) | New features, fixes, and improvements. |
+| `v4` | Maintenance / LTS | **Security and bug fixes until 2026-12-31.** No new features. |
+
+Upgrading from v4? See [API_CHANGES_V5.md](./API_CHANGES_V5.md).
+
+Echo supports the **latest four Go major releases** and may work with older versions.
+
+## Now (in progress)
+
+- Stabilizing the `v5` API surface through point releases.
+- Documentation catch-up for v5 behavior changes (e.g. CORS / `RouteNotFound`
+  behavior on groups — see #2950).
+- Triaging and reducing the open issue / PR backlog.
+
+## Next (under consideration)
+
+These are frequently-requested items being discussed. Inclusion here is **not** a
+commitment — each still needs design agreement before implementation:
+
+- **Automatic `HEAD` for `GET` routes** (#2944, #2937) — opt-in, likely via an
+  `OnAddRoute` hook so users keep control.
+- **Rate limiter response metadata** — expose `Retry-After` / remaining quota
+  through the store interface (#2961).
+- **Real-IP / `Forwarded` header handling** improvements (#2744).
+- **Proxy middleware** authorization-header handling (#2787).
+
+## Later / exploratory
+
+- Continued alignment with the Go standard library (`net/http`, `slog`).
+- Reducing third-party surface where the stdlib now covers the need.
+
+## How to influence the roadmap
+
+- **Discuss before large PRs** — open a [Discussion](https://github.com/labstack/echo/discussions)
+  or issue so we can agree on the design first.
+- 👍 reactions on issues help us gauge demand.
+- See [README → Contribute](./README.md#contribute) for contribution guidelines.


### PR DESCRIPTION
## Why

Echo is actively maintained and shipping (v5.1.1 + v4.15.2 on 2026-05-01, `master` commits within days), but to a casual visitor the repo can read as inactive. This PR adds low-cost, **self-updating** signals that Echo is alive and clarifies its positioning.

## Changes

- **Dynamic badges** for latest release and last commit. These pull live from GitHub, so they can never go stale the way a hand-written "last updated" line does.
- **Positioning line** under the tagline explaining what Echo adds on top of Go's `net/http` — a gentle answer to the "do I still need a framework after Go 1.22 routing?" question.
- **"Actively maintained" note** pointing at the badges.
- **ROADMAP.md (DRAFT)** documenting the version-support policy (v5 current, v4 LTS until 2026-12-31) and a Now/Next/Later view seeded from current issues. Marked DRAFT — maintainers own the final content. Linked from the README.

No code changes. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)