### PR TITLE
fix(binder): include field name in bind conversion errors (#2629)

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -7,6 +7,7 @@ import (
 	"encoding"
 	"encoding/xml"
 	"errors"
+	"fmt"
 	"mime/multipart"
 	"net/http"
 	"reflect"
@@ -249,7 +250,7 @@ func bindData(destination any, data map[string][]string, tag string, dataFiles m
 		// try unmarshalling first, in case we're dealing with an alias to an array type
 		if ok, err := unmarshalInputsToField(typeField.Type.Kind(), inputValue, structField); ok {
 			if err != nil {
-				return err
+				return fmt.Errorf("%s: %w", inputFieldName, err)
 			}
 			continue
 		}
@@ -257,7 +258,7 @@ func bindData(destination any, data map[string][]string, tag string, dataFiles m
 		formatTag := typeField.Tag.Get("format")
 		if ok, err := unmarshalInputToField(typeField.Type.Kind(), inputValue[0], structField, formatTag); ok {
 			if err != nil {
-				return err
+				return fmt.Errorf("%s: %w", inputFieldName, err)
 			}
 			continue
 		}
@@ -275,7 +276,7 @@ func bindData(destination any, data map[string][]string, tag string, dataFiles m
 			slice := reflect.MakeSlice(structField.Type(), numElems, numElems)
 			for j := range numElems {
 				if err := setWithProperType(sliceOf, inputValue[j], slice.Index(j)); err != nil {
-					return err
+					return fmt.Errorf("%s: %w", inputFieldName, err)
 				}
 			}
 			structField.Set(slice)
@@ -283,7 +284,7 @@ func bindData(destination any, data map[string][]string, tag string, dataFiles m
 		}
 
 		if err := setWithProperType(structFieldKind, inputValue[0], structField); err != nil {
-			return err
+			return fmt.Errorf("%s: %w", inputFieldName, err)
 		}
 	}
 	return nil

--- a/bind_field_error_test.go
+++ b/bind_field_error_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2015 LabStack LLC and Echo contributors
+
+package echo
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Regression test for #2629: when binding form data fails a type conversion, the
+// returned error must identify which field failed (so applications can render a
+// useful message), instead of a bare strconv error with no field context.
+func TestBind_formConversionErrorIncludesFieldName(t *testing.T) {
+	e := New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("number=10a"))
+	req.Header.Set(HeaderContentType, MIMEApplicationForm)
+	c := e.NewContext(req, httptest.NewRecorder())
+
+	type DTO struct {
+		Number int `form:"number"`
+	}
+	var dto DTO
+	err := c.Bind(&dto)
+
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "number", "bind error must identify the failing field")
+}

--- a/bind_test.go
+++ b/bind_test.go
@@ -842,7 +842,7 @@ func TestDefaultBinder_BindToStructFromMixedSources(t *testing.T) {
 			givenURL:     "/api/real_node/endpoint?id=nope",
 			givenContent: strings.NewReader(`{"id": 1, "node": "zzz"}`),
 			expect:       &Opts{ID: 0, Node: "node_from_path"}, // path params binding has already modified bind target
-			expectError:  `code=400, message=Bad Request, err=strconv.ParseInt: parsing "nope": invalid syntax`,
+			expectError:  `code=400, message=Bad Request, err=id: strconv.ParseInt: parsing "nope": invalid syntax`,
 		},
 		{
 			name:         "nok, GET body bind failure - trying to bind json array to struct",
@@ -1196,7 +1196,7 @@ func TestBindUnmarshalParamExtras(t *testing.T) {
 		}{}
 		err := testBindURL("/?t=xxxx", &result)
 
-		assert.EqualError(t, err, `code=400, message=Bad Request, err='xxxx' is not an integer`)
+		assert.EqualError(t, err, `code=400, message=Bad Request, err=t: 'xxxx' is not an integer`)
 	})
 
 	t.Run("ok, target is struct", func(t *testing.T) {
@@ -1301,7 +1301,7 @@ func TestBindUnmarshalParams(t *testing.T) {
 		}{}
 		err := testBindURL("/?t=xxxx", &result)
 
-		assert.EqualError(t, err, "code=400, message=Bad Request, err='xxxx' is not an integer")
+		assert.EqualError(t, err, "code=400, message=Bad Request, err=t: 'xxxx' is not an integer")
 	})
 
 	t.Run("ok, target is struct", func(t *testing.T) {
@@ -1368,7 +1368,7 @@ func TestBindInt8(t *testing.T) {
 		}
 		p := target{}
 		err := testBindURL("/?v=x&v=2", &p)
-		assert.EqualError(t, err, `code=400, message=Bad Request, err=strconv.ParseInt: parsing "x": invalid syntax`)
+		assert.EqualError(t, err, `code=400, message=Bad Request, err=v: strconv.ParseInt: parsing "x": invalid syntax`)
 	})
 
 	t.Run("nok, int8 embedded in struct", func(t *testing.T) {


### PR DESCRIPTION
## Problem (#2629)

When `c.Bind()` fails a type conversion on form/struct data, the error gives no indication of *which* field failed:

```
POST /submit  number=10a
→ code=400, message=Bad Request, err=strconv.ParseInt: parsing "10a": invalid syntax
```

This makes it hard to render a useful validation message ("the `number` field must be an integer").

## Fix

`bindData` already has the field name (`inputFieldName`) in scope at each conversion site but returned the bare error. Wrap those returns with the field name using `%w` (so `errors.Is`/`errors.As` still work):

```
→ code=400, message=Bad Request, err=number: strconv.ParseInt: parsing "10a": invalid syntax
```

This is the wrap the reporter proposed in the thread (`fmt.Errorf("%s: %w", inputFieldName, err)`), applied to all four conversion-error sites (unmarshaler, slice element, scalar).

## Test

`TestBind_formConversionErrorIncludesFieldName` (written first; fails on master — error contains no field name). Four existing tests that asserted the bare message are updated to the field-prefixed form. gofmt/vet clean; full root-package suite passes.

Fixes #2629.

🤖 Generated with [Claude Code](https://claude.com/claude-code)