### PR TITLE
fix(static): reject encoded path separator to prevent route-level auth bypass

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -53,11 +53,14 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"path"
 	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
+
+	"github.com/labstack/echo/v5/internal/pathutil"
 )
 
 // Echo is the top-level framework instance.
@@ -589,6 +592,16 @@ func StaticDirectoryHandler(fileSystem fs.FS, disablePathUnescaping bool) Handle
 	return func(c *Context) error {
 		p := c.Param("*")
 		if !disablePathUnescaping { // when router is already unescaping we do not want to do is twice
+			// By default the router matches routes against the raw, still-encoded request path
+			// (unless UseEscapedPathForMatching is enabled), so an encoded path separator is not
+			// treated as a segment boundary during routing. Unescaping it here would let it act as
+			// a separator and resolve a file outside the path the router authorized, bypassing
+			// route-level middleware (e.g. auth on a sibling route). No real filename contains a
+			// separator, so reject it as not found, carrying the reason internally for operators.
+			if pathutil.HasEncodedPathSeparator(p) {
+				return NewHTTPError(http.StatusNotFound, http.StatusText(http.StatusNotFound)).
+					Wrap(fmt.Errorf("rejected encoded path separator in static path %q", p))
+			}
 			tmpPath, err := url.PathUnescape(p)
 			if err != nil {
 				return fmt.Errorf("failed to unescape path variable: %w", err)
@@ -596,8 +609,11 @@ func StaticDirectoryHandler(fileSystem fs.FS, disablePathUnescaping bool) Handle
 			p = tmpPath
 		}
 
-		// fs.FS.Open() already assumes that file names are relative to FS root path and considers name with prefix `/` as invalid
-		name := filepath.ToSlash(filepath.Clean(strings.TrimPrefix(p, "/")))
+		// fs.FS.Open() already assumes that file names are relative to FS root path and considers name with prefix `/` as invalid.
+		// Use path.Clean (not filepath.Clean): fs.FS paths are always forward-slash, so a backslash must stay a literal
+		// character rather than being interpreted as a separator on Windows (which would resolve a file across a boundary
+		// the router never matched on, the same Windows backslash traversal class as GHSA-pgvm-wxw2-hrv9).
+		name := path.Clean(strings.TrimPrefix(p, "/"))
 		fi, err := fs.Stat(fileSystem, name)
 		if err != nil {
 			return ErrNotFound

--- a/echo_test.go
+++ b/echo_test.go
@@ -259,13 +259,16 @@ func TestEcho_StaticFS(t *testing.T) {
 			expectBodyStartsWith: "{\"message\":\"Not Found\"}\n",
 		},
 		{
-			name:                 "open redirect vulnerability",
+			// An encoded slash (%2f) is rejected outright (GHSA-vfp3-v2gw-7wfq): by default the
+			// router matches on the raw path so %2f is not a separator, and unescaping it here
+			// would let it act as one. No redirect is emitted, closing the open-redirect vector.
+			name:                 "encoded slash is rejected, not redirected",
 			givenPrefix:          "/",
 			givenFs:              os.DirFS("_fixture/"),
 			whenURL:              "/open.redirect.hackercom%2f..",
-			expectStatus:         http.StatusMovedPermanently,
-			expectHeaderLocation: "/open.redirect.hackercom/../", // location starting with `//open` would be very bad
-			expectBodyStartsWith: "",
+			expectStatus:         http.StatusNotFound,
+			expectHeaderLocation: "",
+			expectBodyStartsWith: "{\"message\":\"Not Found\"}\n",
 		},
 	}
 

--- a/internal/pathutil/pathutil.go
+++ b/internal/pathutil/pathutil.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2015 LabStack LLC and Echo contributors
+
+// Package pathutil holds internal helpers for safely handling request and file
+// paths. It is internal so it can be shared between the echo package and the
+// middleware package without becoming part of the public API.
+package pathutil
+
+// HasEncodedPathSeparator reports whether s contains a percent-encoded path
+// separator, case-insensitively: %2F/%2f (forward slash) or %5C/%5c (backslash).
+// Backslash is included as defense-in-depth against Windows-style separators even
+// though fs.FS itself only uses forward slashes.
+//
+// Such sequences let an attacker smuggle a separator past the router, which by
+// default matches on the raw encoded path, so they must be rejected before
+// unescaping when resolving static files.
+func HasEncodedPathSeparator(s string) bool {
+	for i := 0; i+2 < len(s); i++ {
+		if s[i] != '%' {
+			continue
+		}
+		switch {
+		case s[i+1] == '2' && (s[i+2] == 'f' || s[i+2] == 'F'): // %2F
+			return true
+		case s[i+1] == '5' && (s[i+2] == 'c' || s[i+2] == 'C'): // %5C
+			return true
+		}
+	}
+	return false
+}

--- a/internal/pathutil/pathutil_test.go
+++ b/internal/pathutil/pathutil_test.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2015 LabStack LLC and Echo contributors
+
+package pathutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasEncodedPathSeparator(t *testing.T) {
+	for s, want := range map[string]bool{
+		"foo/bar.txt": false,
+		"100%25.txt":  false, // encoded percent, not a separator
+		"a%2Fb":       true,
+		"a%2fb":       true,
+		"a%5Cb":       true,
+		"a%5cb":       true,
+		"trailing%2F": true,
+		"%2F":         true,
+		"%2":          false, // truncated, not a full sequence
+		"":            false,
+	} {
+		assert.Equal(t, want, HasEncodedPathSeparator(s), "input=%q", s)
+	}
+}

--- a/middleware/static.go
+++ b/middleware/static.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 
 	"github.com/labstack/echo/v5"
+	"github.com/labstack/echo/v5/internal/pathutil"
 )
 
 // StaticConfig defines the config for Static middleware.
@@ -205,6 +206,14 @@ func (config StaticConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
 				pathUnescape = !config.DisablePathUnescaping // because router could already do PathUnescape
 			}
 			if pathUnescape {
+				// The router matched on the raw, still-encoded path (by default), so an encoded
+				// path separator in the wildcard would only now become a real separator and
+				// resolve a file the matched route never authorized, bypassing route-level
+				// middleware. Reject it before unescaping (see echo.StaticDirectoryHandler).
+				if pathutil.HasEncodedPathSeparator(p) {
+					return echo.NewHTTPError(http.StatusNotFound, http.StatusText(http.StatusNotFound)).
+						Wrap(fmt.Errorf("rejected encoded path separator in static path %q", p))
+				}
 				p, err = url.PathUnescape(p)
 				if err != nil {
 					return err

--- a/middleware/static_test.go
+++ b/middleware/static_test.go
@@ -280,6 +280,35 @@ func TestStatic(t *testing.T) {
 	}
 }
 
+// Regression for GHSA-vfp3-v2gw-7wfq: the static middleware mounted on a group
+// must not let an encoded separator in the wildcard bypass route-level middleware
+// and disclose a file the matched route never authorized.
+func TestStatic_EncodedSeparatorDoesNotBypassRoute(t *testing.T) {
+	fsys := fstest.MapFS{
+		"admin/secret.txt": {Data: []byte("TOP-SECRET")},
+		"index.html":       {Data: []byte("public")},
+	}
+	e := echo.New()
+	g := e.Group("/files", StaticWithConfig(StaticConfig{Filesystem: fsys}))
+	g.GET("/*", func(c *echo.Context) error { return echo.ErrNotFound })
+
+	cases := []struct {
+		target   string
+		wantCode int
+	}{
+		{"/files/index.html", http.StatusOK},
+		{"/files/admin%2Fsecret.txt", http.StatusNotFound},
+		{"/files/admin%5Csecret.txt", http.StatusNotFound},
+	}
+	for _, tc := range cases {
+		req := httptest.NewRequest(http.MethodGet, tc.target, nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		assert.Equal(t, tc.wantCode, rec.Code, "GET %s", tc.target)
+		assert.NotContains(t, rec.Body.String(), "TOP-SECRET", "GET %s leaked protected file", tc.target)
+	}
+}
+
 func TestMustStaticWithConfig_panicsInvalidDirListTemplate(t *testing.T) {
 	assert.Panics(t, func() {
 		StaticWithConfig(StaticConfig{DirectoryListTemplate: `{{}`})

--- a/static_encoded_separator_test.go
+++ b/static_encoded_separator_test.go
@@ -1,0 +1,76 @@
+package echo
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Regression for GHSA-vfp3-v2gw-7wfq: an encoded slash (%2F) must not let a static
+// file request resolve across a path separator and bypass route-level middleware.
+func TestStaticDirectoryHandler_EncodedSeparatorDoesNotBypassRoute(t *testing.T) {
+	fsys := fstest.MapFS{
+		"admin/secret.txt": {Data: []byte("TOP-SECRET")},
+		"index.html":       {Data: []byte("public")},
+	}
+	e := New()
+	g := e.Group("/admin", func(next HandlerFunc) HandlerFunc {
+		return func(c *Context) error { return c.String(http.StatusForbidden, "denied") }
+	})
+	g.GET("/*", func(c *Context) error { return c.String(http.StatusOK, "reached-protected-handler") })
+	e.StaticFS("/", fsys)
+
+	cases := []struct {
+		target   string
+		wantCode int
+		wantBody string
+	}{
+		{"/admin/secret.txt", http.StatusForbidden, "denied"}, // protected route fires
+		{"/admin%2Fsecret.txt", http.StatusNotFound, ""},      // encoded slash rejected, no disclosure
+		{"/admin%2fsecret.txt", http.StatusNotFound, ""},      // lower-case hex variant
+		{"/admin%5Csecret.txt", http.StatusNotFound, ""},      // encoded backslash variant
+		{"/admin%252Fsecret.txt", http.StatusNotFound, ""},    // double-encoded: single unescape -> literal filename, not a separator
+		{"/index.html", http.StatusOK, "public"},              // legitimate static file still served
+	}
+	for _, tc := range cases {
+		req := httptest.NewRequest(http.MethodGet, tc.target, nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		assert.Equal(t, tc.wantCode, rec.Code, "GET %s", tc.target)
+		if tc.wantBody != "" {
+			assert.Equal(t, tc.wantBody, rec.Body.String(), "GET %s", tc.target)
+		}
+		assert.NotContains(t, rec.Body.String(), "TOP-SECRET", "GET %s leaked protected file", tc.target)
+	}
+}
+
+// A Group-mounted StaticFS shares StaticDirectoryHandler, so it must reject the
+// same encoded separators when served under a non-root prefix.
+func TestGroupStaticFS_EncodedSeparatorDoesNotBypassRoute(t *testing.T) {
+	fsys := fstest.MapFS{
+		"admin/secret.txt": {Data: []byte("TOP-SECRET")},
+		"index.html":       {Data: []byte("public")},
+	}
+	e := New()
+	g := e.Group("/files")
+	g.StaticFS("/", fsys)
+
+	cases := []struct {
+		target   string
+		wantCode int
+	}{
+		{"/files/index.html", http.StatusOK},
+		{"/files/admin%2Fsecret.txt", http.StatusNotFound},
+		{"/files/admin%5Csecret.txt", http.StatusNotFound},
+	}
+	for _, tc := range cases {
+		req := httptest.NewRequest(http.MethodGet, tc.target, nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		assert.Equal(t, tc.wantCode, rec.Code, "GET %s", tc.target)
+		assert.NotContains(t, rec.Body.String(), "TOP-SECRET", "GET %s leaked protected file", tc.target)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes an access-control bypass / static file disclosure where an **encoded slash (`%2F`) lets a request skip a protected route group yet still resolve the file on disk** (GHSA-vfp3-v2gw-7wfq, CWE-22).

The router matches routes against the raw, still-encoded request path, so `%2F` is **not** treated as a path separator — `/admin%2Fsecret.txt` is a single segment and never matches a protected `/admin/*` group. The request falls through to the static handler, which then `url.PathUnescape`d `%2F` back to `/` and resolved `admin/secret.txt` from disk. Router and file handler disagreed on what counts as a separator.

### Reproduction (before)
```
GET /admin/secret.txt    -> 403  (protected group fires)
GET /admin%2Fsecret.txt  -> 200  body="TOP-SECRET"   ← bypass + disclosure
```

Common affected pattern:
```go
adminGroup := e.Group("/admin", authMiddleware)
e.StaticFS("/", os.DirFS("public"))
```

## Fix

`StaticDirectoryHandler` now rejects a wildcard containing an encoded path separator (`%2F`/`%2f` or `%5C`/`%5c`) with `404` **before** unescaping, keeping the router and the file handler consistent. No real filename contains a path separator, so legitimate static requests are unaffected.

## Tests
- New `static_encoded_separator_test.go`: regression test for the bypass + unit test for the `%2F`/`%5C` detector (incl. lower-case hex and a benign `%25` case).
- Updated the existing `TestEcho_StaticFS` "open redirect" case: `…%2f..` now returns `404` with **no redirect emitted at all** (was a sanitized `301`), which closes that vector harder.
- `go test ./ ./middleware/` and `go vet ./` pass.

## Scope / notes
- This addresses the **static-disclosure** vector. The related report GHSA-xr3h-5475-xgqr (percent-encoded routing bypassing protected middleware on *non-static* routes) is a broader router-level decision and is intentionally **not** included here.
- Reported by @a-tt-om and @oran-gugu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)