### PR TITLE
fix(static): reject encoded path separators that bypass route-level middleware (v4 backport)

### DIFF
--- a/echo_fs.go
+++ b/echo_fs.go
@@ -9,8 +9,11 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/labstack/echo/v4/internal/pathutil"
 )
 
 type filesystem struct {
@@ -58,6 +61,14 @@ func StaticDirectoryHandler(fileSystem fs.FS, disablePathUnescaping bool) Handle
 	return func(c Context) error {
 		p := c.Param("*")
 		if !disablePathUnescaping { // when router is already unescaping we do not want to do is twice
+			// The router matches routes against the raw, still-encoded request path, so an
+			// encoded path separator (%2F or %5C) is not treated as a segment boundary during
+			// routing. Unescaping it here would let it act as a separator and resolve a file
+			// outside the path the router authorized, bypassing route-level middleware (e.g. auth
+			// on a sibling route). No real filename contains a separator, so reject it as not found.
+			if pathutil.HasEncodedPathSeparator(p) {
+				return ErrNotFound
+			}
 			tmpPath, err := url.PathUnescape(p)
 			if err != nil {
 				return fmt.Errorf("failed to unescape path variable: %w", err)
@@ -65,8 +76,11 @@ func StaticDirectoryHandler(fileSystem fs.FS, disablePathUnescaping bool) Handle
 			p = tmpPath
 		}
 
-		// fs.FS.Open() already assumes that file names are relative to FS root path and considers name with prefix `/` as invalid
-		name := filepath.ToSlash(filepath.Clean(strings.TrimPrefix(p, "/")))
+		// fs.FS.Open() already assumes that file names are relative to FS root path and considers name with prefix `/` as invalid.
+		// Use path.Clean (not filepath.Clean): fs.FS paths are always forward-slash, so a backslash must stay a literal
+		// character rather than being interpreted as a separator on Windows (which would resolve a file across a boundary
+		// the router never matched on).
+		name := path.Clean(strings.TrimPrefix(p, "/"))
 		fi, err := fs.Stat(fileSystem, name)
 		if err != nil {
 			return ErrNotFound

--- a/echo_fs_encoded_separator_test.go
+++ b/echo_fs_encoded_separator_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2015 LabStack LLC and Echo contributors
+
+package echo
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Regression for GHSA-vfp3-v2gw-7wfq (v4 backport): an encoded path separator (%2F or %5C)
+// must not let a static file request resolve across a separator and bypass route-level middleware.
+func TestStaticDirectoryHandler_EncodedSeparatorDoesNotBypassRoute(t *testing.T) {
+	fsys := fstest.MapFS{
+		"admin/secret.txt": {Data: []byte("TOP-SECRET")},
+		"index.html":       {Data: []byte("public")},
+	}
+	e := New()
+	g := e.Group("/admin", func(next HandlerFunc) HandlerFunc {
+		return func(c Context) error { return c.String(http.StatusForbidden, "denied") }
+	})
+	g.GET("/*", func(c Context) error { return c.String(http.StatusOK, "reached-protected-handler") })
+	e.StaticFS("/", fsys)
+
+	cases := []struct {
+		target   string
+		wantCode int
+		wantBody string
+	}{
+		{"/admin/secret.txt", http.StatusForbidden, "denied"}, // protected route fires
+		{"/admin%2Fsecret.txt", http.StatusNotFound, ""},      // encoded slash rejected, no disclosure
+		{"/admin%2fsecret.txt", http.StatusNotFound, ""},      // lower-case hex variant
+		{"/admin%5Csecret.txt", http.StatusNotFound, ""},      // encoded backslash (Windows separator) neutralized by path.Clean
+		{"/admin%252Fsecret.txt", http.StatusNotFound, ""},    // double-encoded: single unescape -> literal filename, not a separator
+		{"/index.html", http.StatusOK, "public"},              // legitimate static file still served
+	}
+	for _, tc := range cases {
+		req := httptest.NewRequest(http.MethodGet, tc.target, nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		assert.Equal(t, tc.wantCode, rec.Code, "GET %s", tc.target)
+		if tc.wantBody != "" {
+			assert.Equal(t, tc.wantBody, rec.Body.String(), "GET %s", tc.target)
+		}
+		assert.NotContains(t, rec.Body.String(), "TOP-SECRET", "GET %s leaked protected file", tc.target)
+	}
+}
+
+// A Group-mounted StaticFS shares StaticDirectoryHandler, so it must reject the
+// same encoded separators when served under a non-root prefix.
+func TestGroupStaticFS_EncodedSeparatorDoesNotBypassRoute(t *testing.T) {
+	fsys := fstest.MapFS{
+		"admin/secret.txt": {Data: []byte("TOP-SECRET")},
+		"index.html":       {Data: []byte("public")},
+	}
+	e := New()
+	g := e.Group("/files")
+	g.StaticFS("/", fsys)
+
+	cases := []struct {
+		target   string
+		wantCode int
+	}{
+		{"/files/index.html", http.StatusOK},
+		{"/files/admin%2Fsecret.txt", http.StatusNotFound},
+		{"/files/admin%5Csecret.txt", http.StatusNotFound},
+	}
+	for _, tc := range cases {
+		req := httptest.NewRequest(http.MethodGet, tc.target, nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		assert.Equal(t, tc.wantCode, rec.Code, "GET %s", tc.target)
+		assert.NotContains(t, rec.Body.String(), "TOP-SECRET", "GET %s leaked protected file", tc.target)
+	}
+}

--- a/echo_fs_test.go
+++ b/echo_fs_test.go
@@ -140,13 +140,16 @@ func TestEcho_StaticFS(t *testing.T) {
 			expectBodyStartsWith: "{\"message\":\"Not Found\"}\n",
 		},
 		{
-			name:                 "open redirect vulnerability",
+			// An encoded slash (%2f) is rejected outright (GHSA-vfp3-v2gw-7wfq): the router matches
+			// on the raw path so %2f is not a separator, and unescaping it here would let it act as
+			// one. No redirect is emitted, closing the open-redirect vector.
+			name:                 "encoded slash is rejected, not redirected",
 			givenPrefix:          "/",
 			givenFs:              os.DirFS("_fixture/"),
 			whenURL:              "/open.redirect.hackercom%2f..",
-			expectStatus:         http.StatusMovedPermanently,
-			expectHeaderLocation: "/open.redirect.hackercom/../", // location starting with `//open` would be very bad
-			expectBodyStartsWith: "",
+			expectStatus:         http.StatusNotFound,
+			expectHeaderLocation: "",
+			expectBodyStartsWith: "{\"message\":\"Not Found\"}\n",
 		},
 	}
 

--- a/internal/pathutil/pathutil.go
+++ b/internal/pathutil/pathutil.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2015 LabStack LLC and Echo contributors
+
+// Package pathutil holds internal helpers for safely handling request and file
+// paths. It is internal so it can be shared between the echo package and the
+// middleware package without becoming part of the public API.
+package pathutil
+
+// HasEncodedPathSeparator reports whether s contains a percent-encoded path
+// separator, case-insensitively: %2F/%2f (forward slash) or %5C/%5c (backslash).
+// Backslash is included as defense-in-depth against Windows-style separators even
+// though fs.FS itself only uses forward slashes.
+//
+// Such sequences let an attacker smuggle a separator past the router, which
+// matches on the raw encoded path, so they must be rejected before unescaping
+// when resolving static files.
+func HasEncodedPathSeparator(s string) bool {
+	for i := 0; i+2 < len(s); i++ {
+		if s[i] != '%' {
+			continue
+		}
+		switch {
+		case s[i+1] == '2' && (s[i+2] == 'f' || s[i+2] == 'F'): // %2F
+			return true
+		case s[i+1] == '5' && (s[i+2] == 'c' || s[i+2] == 'C'): // %5C
+			return true
+		}
+	}
+	return false
+}

--- a/internal/pathutil/pathutil_test.go
+++ b/internal/pathutil/pathutil_test.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2015 LabStack LLC and Echo contributors
+
+package pathutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasEncodedPathSeparator(t *testing.T) {
+	for s, want := range map[string]bool{
+		"foo/bar.txt": false,
+		"100%25.txt":  false, // encoded percent, not a separator
+		"a%2Fb":       true,
+		"a%2fb":       true,
+		"a%5Cb":       true,
+		"a%5cb":       true,
+		"trailing%2F": true,
+		"%2F":         true,
+		"%2":          false, // truncated, not a full sequence
+		"":            false,
+	} {
+		assert.Equal(t, want, HasEncodedPathSeparator(s), "input=%q", s)
+	}
+}

--- a/middleware/static.go
+++ b/middleware/static.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/internal/pathutil"
 	"github.com/labstack/gommon/bytes"
 )
 
@@ -169,6 +170,13 @@ func StaticWithConfig(config StaticConfig) echo.MiddlewareFunc {
 			p := c.Request().URL.Path
 			if strings.HasSuffix(c.Path(), "*") { // When serving from a group, e.g. `/static*`.
 				p = c.Param("*")
+			}
+			// The router matched on the raw, still-encoded path, so an encoded path separator in
+			// the wildcard would only now become a real separator and resolve a file the matched
+			// route never authorized, bypassing route-level middleware. Reject it before unescaping
+			// (see echo.StaticDirectoryHandler).
+			if pathutil.HasEncodedPathSeparator(p) {
+				return echo.ErrNotFound
 			}
 			p, err = url.PathUnescape(p)
 			if err != nil {

--- a/middleware/static_encoded_separator_test.go
+++ b/middleware/static_encoded_separator_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2015 LabStack LLC and Echo contributors
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+// Regression for GHSA-vfp3-v2gw-7wfq (v4 backport): the static middleware mounted on a
+// group must not let an encoded separator in the wildcard bypass route-level middleware
+// and disclose a file the matched route never authorized.
+func TestStatic_EncodedSeparatorDoesNotBypassRoute(t *testing.T) {
+	root := t.TempDir()
+	assert.NoError(t, os.MkdirAll(filepath.Join(root, "admin"), 0o755))
+	assert.NoError(t, os.WriteFile(filepath.Join(root, "admin", "secret.txt"), []byte("TOP-SECRET"), 0o644))
+	assert.NoError(t, os.WriteFile(filepath.Join(root, "index.html"), []byte("public"), 0o644))
+
+	e := echo.New()
+	g := e.Group("/files", StaticWithConfig(StaticConfig{Root: root}))
+	g.GET("/*", func(c echo.Context) error { return echo.ErrNotFound })
+
+	cases := []struct {
+		target   string
+		wantCode int
+	}{
+		{"/files/index.html", http.StatusOK},
+		{"/files/admin%2Fsecret.txt", http.StatusNotFound},
+		{"/files/admin%2fsecret.txt", http.StatusNotFound},
+	}
+	for _, tc := range cases {
+		req := httptest.NewRequest(http.MethodGet, tc.target, nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		assert.Equal(t, tc.wantCode, rec.Code, "GET %s", tc.target)
+		assert.NotContains(t, rec.Body.String(), "TOP-SECRET", "GET %s leaked protected file", tc.target)
+	}
+}

--- a/middleware/static_test.go
+++ b/middleware/static_test.go
@@ -256,13 +256,15 @@ func TestStatic_GroupWithStatic(t *testing.T) {
 			expectBodyStartsWith: "",
 		},
 		{
-			name:                 "Directory redirect",
+			// %2f (encoded slash) is now rejected before unescaping (GHSA-vfp3-v2gw-7wfq), so it no
+			// longer resolves a directory and emits a redirect — it is a 404 with no Location header.
+			name:                 "Encoded slash is rejected, not redirected",
 			givenPrefix:          "/",
 			givenRoot:            "../_fixture",
 			whenURL:              "/group/folder%2f..",
-			expectStatus:         http.StatusMovedPermanently,
-			expectHeaderLocation: "/group/folder/../",
-			expectBodyStartsWith: "",
+			expectStatus:         http.StatusNotFound,
+			expectHeaderLocation: "",
+			expectBodyStartsWith: "{\"message\":\"Not Found\"}\n",
 		},
 		{
 			name:                 "Prefixed directory 404 (request URL without slash)",


### PR DESCRIPTION
v4 backport of #3009 (released in v5.2.0) for **GHSA-vfp3-v2gw-7wfq**.

## Summary
An encoded path separator (`%2F` or `%5C`) in a static file URL could bypass route-level access control and disclose files. The router matches against the raw, still-encoded path, so `%2F` is not a separator — `/admin%2Fsecret.txt` skips a protected `/admin/*` group, falls through to static serving, which then unescaped `%2F`→`/` and served `admin/secret.txt`.

v4 is affected on **both** static surfaces:
- `echo_fs.go` `StaticDirectoryHandler` (used by `Static`/`StaticFS`) — vulnerable to `%2F` **and** `%5C` (it used OS-specific `filepath.Clean`).
- `middleware/static.go` — vulnerable to `%2F` (it already used `path.Clean`, so not `%5C`).

## Fix
- Both surfaces reject a wildcard containing an encoded separator (`%2F`/`%2f` or `%5C`/`%5c`) with `404` before unescaping, via a shared `internal/pathutil` helper.
- `StaticDirectoryHandler` switched from `filepath.Clean`+`ToSlash` to `path.Clean` (OS-independent; keeps backslash literal on Windows).

## Tests
- New regression tests for `%2F`, `%5C`, double-encoded `%252F`, group `StaticFS`, and the static middleware on a group; unit test for the detector.
- Updated two existing cases (`open redirect vulnerability`, `Directory redirect#01`) that asserted the old `%2f`-unescaped redirect — they now correctly assert `404` + no `Location`.
- `go test -race ./...` and `go vet ./...` pass.

Targets the **v4** branch for a **v4.15.3** release; the advisory will be amended to add the `github.com/labstack/echo` (v4) affected product once tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)