### PR TITLE
Changelog for v4.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v4.15.3 - 2026-06-14
+
+**Security**
+
+* fix(static): reject encoded path separators that bypass route-level middleware by @vishr in https://github.com/labstack/echo/pull/3011
+
+Fixes [GHSA-vfp3-v2gw-7wfq](https://github.com/labstack/echo/security/advisories/GHSA-vfp3-v2gw-7wfq): an encoded path separator (`%2F` or `%5C`) in a static file URL could bypass route-level middleware (e.g. authentication on a sibling route) and disclose static files. Both `StaticDirectoryHandler` (used by `Static`/`StaticFS`) and the `Static` middleware are affected. Backport of the v5 fix (#3009). Thanks to @a-tt-om and @oran-gugu for reporting.
+
+
 ## v4.15.2 - 2026-05-01
 
 **Security**

--- a/echo.go
+++ b/echo.go
@@ -267,7 +267,7 @@ const (
 
 const (
 	// Version of Echo
-	Version = "4.15.2"
+	Version = "4.15.3"
 	website = "https://echo.labstack.com"
 	// http://patorjk.com/software/taag/#p=display&f=Small%20Slant&t=Echo
 	banner = `


### PR DESCRIPTION
Release prep for **v4.15.3** (v4 LTS).

- Bumps `Version` in echo.go 4.15.2 → 4.15.3.
- Adds the v4.15.3 `CHANGELOG.md` entry.

Headline: fixes **GHSA-vfp3-v2gw-7wfq** — the encoded path separator static bypass (v4 backport of #3009, merged in #3011). After merge, tag `v4.15.3`, publish the release, and amend the advisory to add the v4 affected product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)