### PR TITLE
ci: run workflows on the v4 branch, not just master

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - v4
   pull_request:
     branches:
       - master
+      - v4
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/echo.yml
+++ b/.github/workflows/echo.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - v4
   pull_request:
     branches:
       - master
+      - v4
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Problem
The **v4** LTS maintenance branch receives **no CI**. Both `echo.yml` (Run Tests) and `checks.yml` (Run checks) trigger only on `master` — a stale snapshot from when v4 *was* the default branch. As a result, PRs targeting `v4` (e.g. the recent security backport #3011) get zero automated testing and must be dispatched manually.

## Fix
Add `v4` to the `push` and `pull_request` branch filters in both workflows.

## Note on this PR
Because `pull_request` workflows run from the **base** branch's config, this PR itself won't auto-run CI (the base `v4` doesn't have the trigger yet — chicken-and-egg). I've **dispatched both workflows manually on this branch** to validate the YAML and confirm they pass. After merge, all future v4 pushes/PRs will be tested automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)