### PR TITLE
docs(csrf): fix godoc typo in Generator default (tp -> to)

### DIFF
--- a/middleware/csrf.go
+++ b/middleware/csrf.go
@@ -58,7 +58,7 @@ type CSRFConfig struct {
 	TokenLookup string `yaml:"token_lookup"`
 
 	// Generator defines a function to generate token.
-	// Optional. Defaults tp randomString(TokenLength).
+	// Optional. Defaults to randomString(TokenLength).
 	Generator func() string
 
 	// Context key to store generated CSRF token into context.


### PR DESCRIPTION
Small godoc typo in the CSRF middleware config. The doc comment on `CSRFConfig.Generator` reads:

```
// Optional. Defaults tp randomString(TokenLength).
```

`tp` should be `to`. This renders on pkg.go.dev, so it's user-visible. One-character fix, no behavior change.
