### PR TITLE
docs(cors): note reverse-proxy header duplication

### DIFF
--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -125,6 +125,12 @@ type CORSConfig struct {
 // misconfigurations for Bitcoins and bounties] and [Portswigger: Cross-origin
 // resource sharing (CORS)] for more details.
 //
+// Duplicate CORS headers can appear in a chained-proxy setup where this
+// middleware runs on more than one layer and a reverse proxy copies an
+// upstream's CORS headers on top of the ones set here. Prefer enabling CORS
+// only at the edge; if a proxied upstream sets its own CORS headers, strip them
+// before they are copied (e.g. httputil.ReverseProxy.ModifyResponse).
+//
 // [MDN: Cross-Origin Resource Sharing (CORS)]: https://developer.mozilla.org/en/docs/Web/HTTP/Access_control_CORS
 // [Exploiting CORS misconfigurations for Bitcoins and bounties]: https://blog.portswigger.net/2016/10/exploiting-cors-misconfigurations-for.html
 // [Portswigger: Cross-origin resource sharing (CORS)]: https://portswigger.net/web-security/cors


### PR DESCRIPTION
## Summary

Adds a short note to the `CORS` godoc explaining the chained-proxy header duplication reported in #2853, and pointing users to the correct fix.

CORS headers are written **before** the handler runs. When CORS is enabled on every layer of a chained-proxy setup, the reverse proxy copies the upstream's CORS headers on top of the ones the gateway already wrote, producing duplicates like:

```
Access-Control-Allow-Origin: *
Access-Control-Allow-Origin: *
Vary: Origin
Vary: Origin
```

This is a configuration issue, not something the middleware should undo by wrapping the `ResponseWriter` in security-sensitive code. The same conclusion was reached by `rs/cors` (rs/cors#45). The fix belongs at the boundary: own CORS at the edge only, or strip upstream CORS headers via `httputil.ReverseProxy.ModifyResponse`.

This is a comment-only change. Companion docs PR adds the detail (with snippet) to the website CORS page.

Closes #2853.

🤖 Generated with [Claude Code](https://claude.com/claude-code)