### PR TITLE
pin GitHub Actions to full commit SHAs and rework actions SHAs to own variables

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,21 +10,26 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read #  to fetch code (actions/checkout)
+  contents: read # to fetch code (actions/checkout)
 
 env:
-  # run static analysis only with the latest Go version
   LATEST_GO_VERSION: "1.26"
+
+  # https://github.com/actions/checkout/commit/df4cb1c069e1874edd31b4311f1884172cec0e10
+  CHECKOUT_ACTION: &checkout_action actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+  # https://github.com/actions/setup-go/commit/924ae3a1cded613372ab5595356fb5720e22ba16
+  SETUP_GO_ACTION: &setup_go_action actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
 
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: *checkout_action
 
-      - name: Set up Go ${{ matrix.go }}
-        uses: actions/setup-go@v6
+      - name: Set up Go
+        uses: *setup_go_action
         with:
           go-version: ${{ env.LATEST_GO_VERSION }}
           check-latest: true
@@ -44,4 +49,3 @@ jobs:
           go version
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...
-

--- a/.github/workflows/echo.yml
+++ b/.github/workflows/echo.yml
@@ -10,11 +10,19 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read #  to fetch code (actions/checkout)
+  contents: read # to fetch code (actions/checkout)
 
 env:
-  # run coverage and benchmarks only with the latest Go version
   LATEST_GO_VERSION: "1.26"
+
+  # https://github.com/actions/checkout/commit/df4cb1c069e1874edd31b4311f1884172cec0e10
+  CHECKOUT_ACTION: &checkout_action actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+  # https://github.com/actions/setup-go/commit/924ae3a1cded613372ab5595356fb5720e22ba16
+  SETUP_GO_ACTION: &setup_go_action actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+
+  # https://github.com/codecov/codecov-action/commit/fb8b3582c8e4def4969c97caa2f19720cb33a72f
+  CODECOV_ACTION: &codecov_action codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
 
 jobs:
   test:
@@ -30,10 +38,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: *checkout_action
 
       - name: Set up Go ${{ matrix.go }}
-        uses: actions/setup-go@v6
+        uses: *setup_go_action
         with:
           go-version: ${{ matrix.go }}
 
@@ -42,7 +50,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: success() && matrix.go == env.LATEST_GO_VERSION && matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v6
+        uses: *codecov_action
         with:
           token:
           fail_ci_if_error: false
@@ -53,18 +61,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code (Previous)
-        uses: actions/checkout@v6
+        uses: *checkout_action
         with:
           ref: ${{ github.base_ref }}
           path: previous
 
       - name: Checkout Code (New)
-        uses: actions/checkout@v6
+        uses: *checkout_action
         with:
           path: new
 
-      - name: Set up Go ${{ matrix.go }}
-        uses: actions/setup-go@v6
+      - name: Set up Go
+        uses: *setup_go_action
         with:
           go-version: ${{ env.LATEST_GO_VERSION }}
 


### PR DESCRIPTION
pin GitHub Actions to full commit SHAs and rework actions shas to own variables so SHA/version bumping would be easier.

Improves https://github.com/labstack/echo/pull/3029