### PR TITLE
fix: propagate root RouteNotFound handler to route groups

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -117,6 +117,11 @@ type Echo struct {
 	// If you are enabling this option, make sure you understand the security implications.
 	// See: https://github.com/labstack/echo/security/advisories/GHSA-vfp3-v2gw-7wfq
 	EnablePathUnescapingStaticFiles bool
+
+	// notFoundHandler is the user-provided RouteNotFound handler set on the root Echo instance.
+	// Groups propagate this handler so that catch-all 404 routes use the user's custom handler
+	// instead of the default NotFoundHandler.
+	notFoundHandler HandlerFunc
 }
 
 // Route contains a handler and information for matching against requests.
@@ -554,6 +559,7 @@ func (e *Echo) TRACE(path string, h HandlerFunc, m ...MiddlewareFunc) *Route {
 //
 // Example: `e.RouteNotFound("/*", func(c echo.Context) error { return c.NoContent(http.StatusNotFound) })`
 func (e *Echo) RouteNotFound(path string, h HandlerFunc, m ...MiddlewareFunc) *Route {
+	e.notFoundHandler = h
 	return e.Add(RouteNotFound, path, h, m...)
 }
 

--- a/group.go
+++ b/group.go
@@ -28,8 +28,13 @@ func (g *Group) Use(middleware ...MiddlewareFunc) {
 	// are only executed if they are added to the Router with route.
 	// So we register catch all route (404 is a safe way to emulate route match) for this group and now during routing the
 	// Router would find route to match our request path and therefore guarantee the middleware(s) will get executed.
-	g.RouteNotFound("", NotFoundHandler)
-	g.RouteNotFound("/*", NotFoundHandler)
+	// Use the root Echo's RouteNotFound handler if one was set, otherwise fall back to the default NotFoundHandler.
+	handler := NotFoundHandler
+	if g.echo.notFoundHandler != nil {
+		handler = g.echo.notFoundHandler
+	}
+	g.RouteNotFound("", handler)
+	g.RouteNotFound("/*", handler)
 }
 
 // CONNECT implements `Echo#CONNECT()` for sub-routes within the Group.

--- a/group_test.go
+++ b/group_test.go
@@ -204,17 +204,17 @@ func TestGroup_RouteNotFoundWithMiddleware(t *testing.T) {
 			expectCode:     http.StatusNotFound,
 		},
 		{
-			name:           "ok, default group 404 handler is called with middleware",
+			name:           "ok, root 404 handler propagates to group with middleware",
 			givenCustom404: false,
 			whenURL:        "/group/test3",
-			expectBody:     "{\"message\":\"Not Found\"}\n",
+			expectBody:     "GET /group/*",
 			expectCode:     http.StatusNotFound,
 		},
 		{
-			name:           "ok, (no slash) default group 404 handler is called with middleware",
+			name:           "ok, (no slash) root 404 handler propagates to group with middleware",
 			givenCustom404: false,
 			whenURL:        "/group",
-			expectBody:     "{\"message\":\"Not Found\"}\n",
+			expectBody:     "GET /group",
 			expectCode:     http.StatusNotFound,
 		},
 	}


### PR DESCRIPTION
## Summary

When a group has middleware, `Group.Use()` registers catch-all routes (`""` and `"/*"`) to guarantee middleware execution. Previously these routes always used the hardcoded `NotFoundHandler`, ignoring any custom `RouteNotFound` handler set on the root `Echo` instance.

## Problem

```go
e := echo.New()
e.RouteNotFound("/*", customHandler) // user's custom 404

v0 := e.Group("/v0", someMiddleware)
v0.POST("/resource", handler)

// Request to /v0/nonexistent uses NotFoundHandler instead of customHandler
```

## Fix

Store the user's custom `RouteNotFound` handler on the `Echo` struct and use it when registering group catch-all routes, falling back to `NotFoundHandler` if none was set.

### Changes
- **echo.go**: Added `notFoundHandler` field to `Echo` struct; set it in `RouteNotFound()`
- **group.go**: `Use()` now uses `g.echo.notFoundHandler` instead of hardcoded `NotFoundHandler`
- **group_test.go**: Updated test expectations to verify root handler propagation

Fixes #2485
