### PR TITLE
refactor: use range-over-integer loops

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -187,7 +187,7 @@ func bindMetaFor(typ reflect.Type) *bindStructMeta {
 	}
 	n := typ.NumField()
 	meta := &bindStructMeta{fields: make([]bindFieldMeta, n)}
-	for i := 0; i < n; i++ {
+	for i := range n {
 		f := typ.Field(i)
 		meta.fields[i] = bindFieldMeta{
 			index:     i,

--- a/json_test.go
+++ b/json_test.go
@@ -136,7 +136,7 @@ func TestDefaultJSONCodec_Decode_RejectsTrailingData(t *testing.T) {
 // followed by a short one must each decode to exactly their own input.
 func TestDefaultJSONCodec_Decode_PooledBufferReuse(t *testing.T) {
 	e := New()
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		longName := strings.Repeat("x", 1000+i)
 		var long user
 		err := deserializeJSON(e, fmt.Sprintf(`{"id":%d,"name":%q}`, i, longName), &long)
@@ -159,7 +159,7 @@ func TestDefaultJSONCodec_Decode_PooledBufferConcurrent(t *testing.T) {
 	var wg sync.WaitGroup
 	errs := make([]error, n)
 	got := make([]user, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
@@ -168,7 +168,7 @@ func TestDefaultJSONCodec_Decode_PooledBufferConcurrent(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
-	for i := 0; i < n; i++ {
+	for i := range n {
 		assert.NoError(t, errs[i])
 		assert.Equal(t, user{ID: i, Name: strings.Repeat("n", i+1)}, got[i])
 	}

--- a/perf_bench_test.go
+++ b/perf_bench_test.go
@@ -51,7 +51,7 @@ func BenchmarkServeHTTP_Param(b *testing.B) {
 // Exercises the global middleware chain (finding #1). Five pass-through middlewares.
 func BenchmarkServeHTTP_Middleware(b *testing.B) {
 	e := New()
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		e.Use(func(next HandlerFunc) HandlerFunc {
 			return func(c *Context) error { return next(c) }
 		})


### PR DESCRIPTION
Use Go's range-over-integer syntax where the index is either needed directly or not used. This simplifies the loops without changing behavior.