### PR TITLE
fix(static): preserve matched handler 404s

### DIFF
--- a/middleware/static.go
+++ b/middleware/static.go
@@ -269,10 +269,12 @@ func (config StaticConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
 				}
 
 				var he echo.HTTPStatusCoder
-				if !errors.As(err, &he) || !config.HTML5 || he.StatusCode() != http.StatusNotFound {
+				if (c.Path() != "" && c.RouteInfo().Method != echo.RouteNotFound) ||
+					!errors.As(err, &he) ||
+					!config.HTML5 || he.StatusCode() != http.StatusNotFound {
 					return err
 				}
-				// is case HTML5 mode is enabled + echo 404 we serve index to the client
+				// In HTML5 mode, serve index for a router-level 404.
 				file, err = currentFS.Open(config.Index)
 				if err != nil {
 					return err

--- a/middleware/static_test.go
+++ b/middleware/static_test.go
@@ -45,33 +45,64 @@ func TestStatic_useCaseForApiAndSPAs(t *testing.T) {
 }
 
 func TestStaticHTML5PreservesMatchedHandlerNotFound(t *testing.T) {
-	e := echo.New()
-	e.Use(StaticWithConfig(StaticConfig{
-		Root:  "testdata/dist/public",
-		HTML5: true,
-	}))
-	e.GET("/api/users/:id", func(c *echo.Context) error {
-		return echo.NewHTTPError(http.StatusNotFound, "user not found")
-	})
+	var testCases = []struct {
+		name           string
+		buildEcho      func() *echo.Echo
+		whenURL        string
+		expectCode     int
+		expectJSONEq   string
+		expectContains string
+	}{
+		{
+			name: "ok, router-matched handler 404 is preserved instead of serving index",
+			buildEcho: func() *echo.Echo {
+				e := echo.New()
+				e.Use(StaticWithConfig(StaticConfig{
+					Root:  "testdata/dist/public",
+					HTML5: true,
+				}))
+				e.GET("/api/users/:id", func(c *echo.Context) error {
+					return echo.NewHTTPError(http.StatusNotFound, "user not found")
+				})
+				return e
+			},
+			whenURL:      "/api/users/42",
+			expectCode:   http.StatusNotFound,
+			expectJSONEq: `{"message":"user not found"}`,
+		},
+		{
+			name: "ok, router-level 404 for group without matched route still serves index",
+			buildEcho: func() *echo.Echo {
+				e := echo.New()
+				e.Group("/app", StaticWithConfig(StaticConfig{
+					Root:  "testdata/dist/public",
+					HTML5: true,
+				}))
+				return e
+			},
+			whenURL:        "/app/dashboard",
+			expectCode:     http.StatusOK,
+			expectContains: "<h1>Hello from index</h1>\n",
+		},
+	}
 
-	req := httptest.NewRequest(http.MethodGet, "/api/users/42", nil)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := tc.buildEcho()
 
-	assert.Equal(t, http.StatusNotFound, rec.Code)
-	assert.JSONEq(t, `{"message":"user not found"}`, rec.Body.String())
+			req := httptest.NewRequest(http.MethodGet, tc.whenURL, nil)
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
 
-	group := echo.New()
-	group.Group("/app", StaticWithConfig(StaticConfig{
-		Root:  "testdata/dist/public",
-		HTML5: true,
-	}))
-	req = httptest.NewRequest(http.MethodGet, "/app/dashboard", nil)
-	rec = httptest.NewRecorder()
-	group.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Contains(t, rec.Body.String(), "<h1>Hello from index</h1>\n")
+			assert.Equal(t, tc.expectCode, rec.Code)
+			if tc.expectJSONEq != "" {
+				assert.JSONEq(t, tc.expectJSONEq, rec.Body.String())
+			}
+			if tc.expectContains != "" {
+				assert.Contains(t, rec.Body.String(), tc.expectContains)
+			}
+		})
+	}
 }
 
 func TestStatic(t *testing.T) {

--- a/middleware/static_test.go
+++ b/middleware/static_test.go
@@ -44,6 +44,36 @@ func TestStatic_useCaseForApiAndSPAs(t *testing.T) {
 
 }
 
+func TestStaticHTML5PreservesMatchedHandlerNotFound(t *testing.T) {
+	e := echo.New()
+	e.Use(StaticWithConfig(StaticConfig{
+		Root:  "testdata/dist/public",
+		HTML5: true,
+	}))
+	e.GET("/api/users/:id", func(c *echo.Context) error {
+		return echo.NewHTTPError(http.StatusNotFound, "user not found")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/users/42", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.JSONEq(t, `{"message":"user not found"}`, rec.Body.String())
+
+	group := echo.New()
+	group.Group("/app", StaticWithConfig(StaticConfig{
+		Root:  "testdata/dist/public",
+		HTML5: true,
+	}))
+	req = httptest.NewRequest(http.MethodGet, "/app/dashboard", nil)
+	rec = httptest.NewRecorder()
+	group.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "<h1>Hello from index</h1>\n")
+}
+
 func TestStatic(t *testing.T) {
 	var testCases = []struct {
 		name                 string


### PR DESCRIPTION
Fixes #2775

Preserves 404 responses from matched handlers when HTML5 static fallback is enabled, while retaining the index fallback for router misses, including group route-not-found handling.

Verification:
- `go test -race ./middleware -run '^TestStaticHTML5PreservesMatchedHandlerNotFound$' -count=1`
- `go test -race ./middleware -run '^TestStatic$/^ok,_when_html5_mode_serve_index_for_any_static_file_that_does_not_exist$' -count=1`
- `go test -race ./middleware`
