### PR TITLE
docs: correct `Any` godoc to reflect true arbitrary-method matching

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -578,11 +578,11 @@ func (e *Echo) RouteNotFound(path string, h HandlerFunc, m ...MiddlewareFunc) Ro
 	return e.Add(RouteNotFound, path, h, m...)
 }
 
-// Any registers a new route for all HTTP methods (supported by Echo) and path with matching handler
-// in the router with optional route-level middleware.
+// Any registers a new route for a path with matching handler in the router with optional
+// route-level middleware. Panics on error. The route matches any HTTP method in the request,
+// including methods not known to Echo, by registering a single RouteAny route.
 //
-// Note: this method only adds specific set of supported HTTP methods as handler and is not true
-// "catch-any-arbitrary-method" way of matching requests.
+// A method-specific route registered for the same path takes precedence over the Any route.
 func (e *Echo) Any(path string, handler HandlerFunc, middleware ...MiddlewareFunc) RouteInfo {
 	return e.Add(RouteAny, path, handler, middleware...)
 }

--- a/echo_test.go
+++ b/echo_test.go
@@ -942,6 +942,20 @@ func TestEcho_Any(t *testing.T) {
 	assert.Equal(t, `OK from ANY`, body)
 }
 
+func TestEcho_Any_matchesArbitraryMethod(t *testing.T) {
+	e := New()
+
+	e.Any("/activate", func(c *Context) error {
+		return c.String(http.StatusTeapot, "OK from ANY")
+	})
+
+	// ARBITRARY-METHOD is not one of Echo's known HTTP methods; the RouteAny
+	// fallback must still match it.
+	status, body := request("ARBITRARY-METHOD", "/activate", e)
+	assert.Equal(t, http.StatusTeapot, status)
+	assert.Equal(t, `OK from ANY`, body)
+}
+
 func TestEcho_Any_hasLowerPriority(t *testing.T) {
 	e := New()
 

--- a/router.go
+++ b/router.go
@@ -485,7 +485,7 @@ func (r *DefaultRouter) Remove(method string, path string) error {
 }
 
 // AddRouteError is error returned by Router.Add containing information what actual route adding failed. Useful for
-// mass adding (i.e. Any() routes)
+// mass adding (i.e. Match() routes)
 type AddRouteError struct {
 	Err    error
 	Method string


### PR DESCRIPTION
## Summary

Fixes #3044.

The godoc for `Echo.Any()` said it only matches a specific set of known HTTP methods and is "not a true catch-any-arbitrary-method" way of matching. That's wrong — `Any()` registers a single `RouteAny` route that matches any HTTP method, including ones not known to Echo.

This PR fixes the docs to match the real behavior.

## Changes

- `echo.go`: Rewrite the `Any()` godoc; note that a method-specific route takes precedence.
- `router.go`: Fix the `AddRouteError` comment to use `Match()` as the example.
- `echo_test.go`: Add a test that an arbitrary method still matches the `RouteAny` fallback.

## Notes

Docs and test only — no runtime behavior changes.