### PR TITLE
fix(group): register auto 404 routes only once on Use

### DIFF
--- a/group.go
+++ b/group.go
@@ -29,11 +29,19 @@ type Group struct {
 // `/*` NotFound routes for itself. If this kind of behavior is not needed, then create an Echo instance with the ` noAutoRegisterRoutes `
 // flag set to true. Example `echo.NewWithConfig(echo.Config{NoGroupAutoRegister404Routes: true})`.
 func (g *Group) Use(middleware ...MiddlewareFunc) {
+	// Track whether this is the first non-empty middleware attachment so we only
+	// auto-register 404 catch-alls once. Re-registering on every Use() panics when
+	// AllowOverwritingRoute is false (#3047).
+	hadMiddleware := len(g.middleware) > 0
 	g.middleware = append(g.middleware, middleware...)
 	if len(g.middleware) == 0 {
 		return
 	}
 	if g.noAutoRegisterRoutes {
+		return
+	}
+	if hadMiddleware {
+		// 404 routes already registered by a previous Use()/Group(...middleware).
 		return
 	}
 	// group level middlewares are different from Echo `Pre` and `Use` middlewares (those are global). Group level middlewares

--- a/group_test.go
+++ b/group_test.go
@@ -866,3 +866,36 @@ func TestGroup_RouteNotFoundWithMiddleware(t *testing.T) {
 		})
 	}
 }
+
+
+func TestGroup_UseMultipleTimesDoesNotPanic(t *testing.T) {
+	// Repro for #3047: second Use() used to re-register 404 routes and panic when
+	// AllowOverwritingRoute is false.
+	e := NewWithConfig(Config{
+		Router: NewRouter(RouterConfig{AllowOverwritingRoute: false}),
+	})
+
+	mw := func(next HandlerFunc) HandlerFunc {
+		return func(c *Context) error { return next(c) }
+	}
+
+	// Case 1: sequential Use on empty group
+	g1 := e.Group("/api")
+	assert.NotPanics(t, func() {
+		g1.Use(mw)
+		g1.Use(mw)
+	})
+
+	// Case 2: Group created with middleware, then Use again
+	g2 := e.Group("/v2", mw)
+	assert.NotPanics(t, func() {
+		g2.Use(mw)
+	})
+
+	// Case 3: nested group inherits middleware then Use
+	api := e.Group("/nested", mw)
+	res := api.Group("/resource")
+	assert.NotPanics(t, func() {
+		res.Use(mw)
+	})
+}


### PR DESCRIPTION
## Description

After #2996, `Group.Use` auto-registers `RouteNotFound` catch-alls so group middleware still runs on 404s. It did that on **every** `Use()` call.

With `AllowOverwritingRoute: false` (or whenever duplicate routes are rejected), a second `Use` panics:

```text
panic: echo_route_not_found /api: adding duplicate route (same method+path) is not allowed
```

Repro patterns from #3047:

```go
g := e.Group("/api")
g.Use(mw1)
g.Use(mw2) // panic

g := e.Group("/api", mw1)
g.Use(mw2) // panic
```

## Fix

Only auto-register the 404 routes the **first** time the group gains middleware (`hadMiddleware` was empty before append). Subsequent `Use` calls only append middleware.

## Tests

```bash
go test ./... -count=1
```

Added `TestGroup_UseMultipleTimesDoesNotPanic`.

## Linked Issue

Closes #3047
