### PR TITLE
fix: parse comma-separated X-Forwarded-Proto in Scheme

### DIFF
--- a/context.go
+++ b/context.go
@@ -208,6 +208,18 @@ func isValidProto(proto string) bool {
 	return false
 }
 
+// firstValidProto returns the left-most valid scheme token from a possibly
+// comma-separated header value (e.g. "https, http" from multi-proxy hops).
+func firstValidProto(header string) string {
+	for _, part := range strings.Split(header, ",") {
+		p := strings.TrimSpace(part)
+		if isValidProto(p) {
+			return p
+		}
+	}
+	return ""
+}
+
 // Scheme returns the HTTP protocol scheme, `http` or `https`.
 func (c *Context) Scheme() string {
 	// Can't use `r.Request.URL.Scheme`
@@ -215,16 +227,16 @@ func (c *Context) Scheme() string {
 	if c.IsTLS() {
 		return "https"
 	}
-	if scheme := c.request.Header.Get(HeaderXForwardedProto); isValidProto(scheme) {
+	if scheme := firstValidProto(c.request.Header.Get(HeaderXForwardedProto)); scheme != "" {
 		return scheme
 	}
-	if scheme := c.request.Header.Get(HeaderXForwardedProtocol); isValidProto(scheme) {
+	if scheme := firstValidProto(c.request.Header.Get(HeaderXForwardedProtocol)); scheme != "" {
 		return scheme
 	}
 	if ssl := c.request.Header.Get(HeaderXForwardedSsl); ssl == "on" {
 		return "https"
 	}
-	if scheme := c.request.Header.Get(HeaderXUrlScheme); isValidProto(scheme) {
+	if scheme := firstValidProto(c.request.Header.Get(HeaderXUrlScheme)); scheme != "" {
 		return scheme
 	}
 	return "http"

--- a/context_test.go
+++ b/context_test.go
@@ -1141,6 +1141,22 @@ func TestContext_Scheme(t *testing.T) {
 			expect: "HTTPS",
 		},
 		{
+			name:       "uses left-most token from comma-separated X-Forwarded-Proto",
+			givenIsTLS: false,
+			givenHeaders: http.Header{
+				HeaderXForwardedProto: []string{"https, http"},
+			},
+			expect: "https",
+		},
+		{
+			name:       "skips invalid tokens in comma-separated X-Forwarded-Proto",
+			givenIsTLS: false,
+			givenHeaders: http.Header{
+				HeaderXForwardedProto: []string{"ftp, https"},
+			},
+			expect: "https",
+		},
+		{
 			name:       "uses X-Forwarded-Proto ws",
 			givenIsTLS: false,
 			givenHeaders: http.Header{


### PR DESCRIPTION
## Summary
`Context.Scheme()` treated the entire `X-Forwarded-Proto` header as one token. Multi-proxy values like `https, http` failed validation and were ignored.

## Change
- Introduce `firstValidProto` to take the left-most valid scheme token.
- Apply to `X-Forwarded-Proto`, `X-Forwarded-Protocol`, and `X-Url-Scheme`.
- Add unit tests for comma-separated headers.

## Test plan
- [x] `go test . -run TestContext_Scheme`