### PR TITLE
docs(middleware): align RequestID header spelling with HeaderXRequestID

### DIFF
--- a/middleware/request_id.go
+++ b/middleware/request_id.go
@@ -24,7 +24,7 @@ type RequestIDConfig struct {
 	TargetHeader string
 }
 
-// RequestID returns a middleware that reads RequestIDConfig.TargetHeader (`X-Request-ID`) header value or when
+// RequestID returns a middleware that reads RequestIDConfig.TargetHeader (`X-Request-Id`) header value or when
 // the header value is empty, generates that value and sets request ID to response
 // as RequestIDConfig.TargetHeader (`X-Request-Id`) value.
 func RequestID() echo.MiddlewareFunc {
@@ -32,7 +32,7 @@ func RequestID() echo.MiddlewareFunc {
 }
 
 // RequestIDWithConfig returns a middleware with given valid config or panics on invalid configuration.
-// The middleware reads RequestIDConfig.TargetHeader (`X-Request-ID`) header value or when the header value is empty,
+// The middleware reads RequestIDConfig.TargetHeader (`X-Request-Id`) header value or when the header value is empty,
 // generates that value and sets request ID to response as RequestIDConfig.TargetHeader (`X-Request-Id`) value.
 func RequestIDWithConfig(config RequestIDConfig) echo.MiddlewareFunc {
 	return toMiddlewareOrPanic(config)

--- a/middleware/request_logger.go
+++ b/middleware/request_logger.go
@@ -154,7 +154,7 @@ type RequestLoggerConfig struct {
 	LogURIPath bool
 	// LogRoutePath instructs logger to extract route path part to which request was matched to (i.e. `/user/:id`)
 	LogRoutePath bool
-	// LogRequestID instructs logger to extract request ID from request `X-Request-ID` header or response if request did not have value.
+	// LogRequestID instructs logger to extract request ID from request `X-Request-Id` header or response if request did not have value.
 	LogRequestID bool
 	// LogReferer instructs logger to extract request referer values.
 	LogReferer bool
@@ -205,7 +205,7 @@ type RequestLoggerValues struct {
 	URIPath string
 	// RoutePath is route path part to which request was matched to (i.e. `/user/:id`)
 	RoutePath string
-	// RequestID is request ID from request `X-Request-ID` header or response if request did not have value.
+	// RequestID is request ID from request `X-Request-Id` header or response if request did not have value.
 	RequestID string
 	// Referer is request referer values.
 	Referer string


### PR DESCRIPTION
## Summary
RequestID middleware godoc mixed `X-Request-ID` and `X-Request-Id`. HTTP header names are case-insensitive, but docs should match `echo.HeaderXRequestID` (`X-Request-Id`).

## Test plan
- docs only