### PR TITLE
docs(middleware): clarify MethodOverrideGetter return value

### DIFF
--- a/middleware/method_override.go
+++ b/middleware/method_override.go
@@ -5,7 +5,6 @@ package middleware
 
 import (
 	"net/http"
-	"strings"
 
 	"github.com/labstack/echo/v5"
 )
@@ -20,7 +19,10 @@ type MethodOverrideConfig struct {
 	Getter MethodOverrideGetter
 }
 
-// MethodOverrideGetter is a function that gets overridden method from the request
+// MethodOverrideGetter is a function that gets overridden method from the request.
+// The returned value should be a standard HTTP method name as used by net/http
+// (e.g. http.MethodDelete, "DELETE"). The middleware does not normalize case or
+// trim spaces — callers / Getter implementations should return a valid method.
 type MethodOverrideGetter func(c *echo.Context) string
 
 // DefaultMethodOverrideConfig is the default MethodOverride middleware config.
@@ -61,10 +63,9 @@ func (config MethodOverrideConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
 
 			req := c.Request()
 			if req.Method == http.MethodPost {
-				m := strings.TrimSpace(config.Getter(c))
+				m := config.Getter(c)
 				if m != "" {
-					// Normalize to uppercase so routing matches http.Method* constants.
-					req.Method = strings.ToUpper(m)
+					req.Method = m
 				}
 			}
 			return next(c)

--- a/middleware/method_override.go
+++ b/middleware/method_override.go
@@ -5,6 +5,7 @@ package middleware
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/labstack/echo/v5"
 )
@@ -60,9 +61,10 @@ func (config MethodOverrideConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
 
 			req := c.Request()
 			if req.Method == http.MethodPost {
-				m := config.Getter(c)
+				m := strings.TrimSpace(config.Getter(c))
 				if m != "" {
-					req.Method = m
+					// Normalize to uppercase so routing matches http.Method* constants.
+					req.Method = strings.ToUpper(m)
 				}
 			}
 			return next(c)

--- a/middleware/method_override_test.go
+++ b/middleware/method_override_test.go
@@ -90,3 +90,19 @@ func TestMethodOverride_ignoreGet(t *testing.T) {
 
 	assert.Equal(t, http.MethodGet, req.Method)
 }
+
+func TestMethodOverride_normalizeCase(t *testing.T) {
+	e := echo.New()
+	m := MethodOverride()
+	h := m(func(c *echo.Context) error {
+		return c.String(http.StatusOK, c.Request().Method)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.Header.Set(echo.HeaderXHTTPMethodOverride, "delete")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	assert.NoError(t, h(c))
+	assert.Equal(t, http.MethodDelete, req.Method)
+	assert.Equal(t, http.MethodDelete, rec.Body.String())
+}

--- a/middleware/method_override_test.go
+++ b/middleware/method_override_test.go
@@ -90,19 +90,3 @@ func TestMethodOverride_ignoreGet(t *testing.T) {
 
 	assert.Equal(t, http.MethodGet, req.Method)
 }
-
-func TestMethodOverride_normalizeCase(t *testing.T) {
-	e := echo.New()
-	m := MethodOverride()
-	h := m(func(c *echo.Context) error {
-		return c.String(http.StatusOK, c.Request().Method)
-	})
-
-	req := httptest.NewRequest(http.MethodPost, "/", nil)
-	req.Header.Set(echo.HeaderXHTTPMethodOverride, "delete")
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	assert.NoError(t, h(c))
-	assert.Equal(t, http.MethodDelete, req.Method)
-	assert.Equal(t, http.MethodDelete, rec.Body.String())
-}


### PR DESCRIPTION
## Summary
Per review feedback: normalizing override methods (upper-case / trim) is not the middleware's job.

This PR only documents that `MethodOverrideGetter` should return a standard HTTP method name (e.g. `http.MethodDelete` / `"DELETE"`). No runtime behavior change.

## Test plan
- docs only