### PR TITLE
docs: warn that predefined errors are no longer *HTTPError in v5

### DIFF
--- a/API_CHANGES_V5.md
+++ b/API_CHANGES_V5.md
@@ -246,6 +246,24 @@ func (he *HTTPError) StatusCode() int      // Implements HTTPStatusCoder
 - Added `HTTPStatusCoder` interface and `StatusCode()` method
 - Added `Wrap(err error)` method for error wrapping
 
+**⚠️ Migration trap:** predefined errors such as `echo.ErrNotFound` and
+`echo.ErrMethodNotAllowed` (returned by the router for unmatched routes) are no
+longer `*echo.HTTPError`. They are immutable sentinels that only implement
+`HTTPStatusCoder`, so a v4-style type assertion in a custom error handler stops
+matching them and turns every 404/405 into a 500:
+
+```go
+// Broken in v5: never matches echo.ErrNotFound
+if he, ok := err.(*echo.HTTPError); ok {
+    code = he.Code
+} else {
+    code = http.StatusInternalServerError
+}
+
+// Correct: works for *HTTPError and the predefined errors
+code := echo.StatusCode(err) // 0 if err carries no status
+```
+
 ---
 
 ### 7. **HTTPErrorHandler Signature Changed**


### PR DESCRIPTION
`API_CHANGES_V5.md` documents the new `HTTPError` shape and the swapped `HTTPErrorHandler` signature, but not that the predefined errors (`echo.ErrNotFound`, `echo.ErrMethodNotAllowed`, ...) are no longer `*echo.HTTPError`.

That gap bit us in production after migrating an app to v5.3.1. A common v4 custom error handler does:

```go
if he, ok := err.(*echo.HTTPError); ok {
    code = he.Code
} else {
    code = http.StatusInternalServerError
}
```

In v5 the router returns unexported sentinels that only implement `HTTPStatusCoder`, so the assertion never matches and every unmatched route renders as a 500 instead of a 404. Nothing fails at compile time or at runtime. We only noticed because scanner traffic showed up in our logs as thousands of 500s.

The sentinel design looks intentional, since it prevents globally mutating `echo.ErrNotFound.Message` the way v4 allowed, so this PR only adds documentation: a warning in the "HTTPError Simplified" section and a short note in migration step 4, both pointing at `echo.StatusCode(err)`.

If you'd take a code change as well, `httpError` could implement `As(any) bool` so that `errors.As(err, &he)` matches again. I can send that separately if there's interest.