### PR TITLE
fix(middleware): reject CSRF TokenLookup that produces no extractors

### DIFF
--- a/middleware/csrf.go
+++ b/middleware/csrf.go
@@ -5,6 +5,7 @@ package middleware
 
 import (
 	"crypto/subtle"
+	"errors"
 	"net/http"
 	"slices"
 	"strings"
@@ -159,6 +160,9 @@ func (config CSRFConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
 	extractors, cErr := createExtractors(config.TokenLookup, 1)
 	if cErr != nil {
 		return nil, cErr
+	}
+	if len(extractors) == 0 {
+		return nil, errors.New("echo csrf middleware could not create extractors from TokenLookup string")
 	}
 
 	return func(next echo.HandlerFunc) echo.HandlerFunc {

--- a/middleware/csrf_test.go
+++ b/middleware/csrf_test.go
@@ -159,6 +159,14 @@ func TestCSRF_tokenExtractors(t *testing.T) {
 			givenQueryTokens:        map[string][]string{},
 			expectToMiddlewareError: "extractor source for lookup could not be split into needed parts: q",
 		},
+		{
+			name:                    "nok, TokenLookup with only unknown source yields no extractors",
+			whenTokenLookup:         "nope:nope",
+			givenCSRFCookie:         "token",
+			givenMethod:             http.MethodPut,
+			givenQueryTokens:        map[string][]string{},
+			expectToMiddlewareError: "echo csrf middleware could not create extractors from TokenLookup string",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Problem

If `TokenLookup` uses a source keyword that isn't recognized, CSRF silently
stops checking tokens.

The known sources are `header`, `query`, `param`, `cookie`, `form`. A small typo
like `Header:X-CSRF-Token` (capital H) or `cookies:_csrf` (should be `cookie`)
matches none of them, and there's no `default` case, so it's just dropped. If
every source in the lookup is like that you end up with zero extractors and no
error. CSRF then loops over an empty list, finds nothing to validate, and lets
the request through. So a typo in the config turns CSRF off without any warning.

KeyAuth already guards against this:

    // middleware/key_auth.go
    if len(extractors) == 0 {
        return nil, errors.New("echo key-auth middleware could not create extractors from KeyLookup string")
    }

CSRF just doesn't have the same check, so this PR adds it.

For context on impact: this only happens with a misconfigured `TokenLookup`, and
`Sec-Fetch-Site` still blocks normal cross-site requests. But a security
middleware quietly doing nothing on a typo felt worth turning into an error.

## Change

- `CSRFConfig.ToMiddleware()` now returns an error when `TokenLookup` produces no
  extractors (e.g. `"echo csrf middleware could not create extractors from TokenLookup string"`),
  matching KeyAuth. `CSRFWithConfig` turns that error into a startup panic.
- Added a test case.

Valid configs keep working; only a lookup where all sources are unknown is
rejected.
