### PR TITLE
CI: add Go 1.27 to CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 env:
-  LATEST_GO_VERSION: "1.26"
+  LATEST_GO_VERSION: "1.27"
 
   # https://github.com/actions/checkout/commit/df4cb1c069e1874edd31b4311f1884172cec0e10
   CHECKOUT_ACTION: &checkout_action actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/echo.yml
+++ b/.github/workflows/echo.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 env:
-  LATEST_GO_VERSION: "1.26"
+  LATEST_GO_VERSION: "1.27"
 
   # https://github.com/actions/checkout/commit/df4cb1c069e1874edd31b4311f1884172cec0e10
   CHECKOUT_ACTION: &checkout_action actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -33,7 +33,7 @@ jobs:
         # Echo tests with last four major releases (unless there are pressing vulnerabilities)
         # As we depend on `golang.org/x/` libraries which only support the last 2 Go releases, we could have situations when
         # we derive from the last four major releases promise.
-        go: ["1.25", "1.26"]
+        go: ["1.25", "1.26", "1.27"]
     name: ${{ matrix.os }} @ Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/route_test.go
+++ b/route_test.go
@@ -66,19 +66,6 @@ func TestHandlerName(t *testing.T) {
 	}
 }
 
-func TestHandlerName_differentFuncSameName(t *testing.T) {
-	handlerCreator := func(name string) HandlerFunc {
-		return func(c *Context) error {
-			return c.String(http.StatusTeapot, name)
-		}
-	}
-	h1 := handlerCreator("name1")
-	assert.Equal(t, "github.com/labstack/echo/v5.TestHandlerName_differentFuncSameName.TestHandlerName_differentFuncSameName.func1.func2", HandlerName(h1))
-
-	h2 := handlerCreator("name2")
-	assert.Equal(t, "github.com/labstack/echo/v5.TestHandlerName_differentFuncSameName.TestHandlerName_differentFuncSameName.func1.func3", HandlerName(h2))
-}
-
 func TestRoute_ToRouteInfo(t *testing.T) {
 	var testCases = []struct {
 		expect     RouteInfo


### PR DESCRIPTION
## Summary

- Update `LATEST_GO_VERSION` from Go 1.26 to Go 1.27.
- Add Go 1.27 to the cross-platform test matrix.
- Remove `TestHandlerName_differentFuncSameName`, which depends on compiler-generated closure symbol names.

## Background

Go 1.27 changed how function literals and closures are named by the compiler. A function literal now uses the same symbol name regardless of inlining, and multiple closure instances may share the same code and symbol name.

As a result, the following handlers:

```go
h1 := handlerCreator("name1")
h2 := handlerCreator("name2")
```

previously had different names under older Go versions, but both resolve to the following name with Go 1.27:

```text
github.com/labstack/echo/v5.TestHandlerName_differentFuncSameName.func1.func1
```

This behavior is documented in the [Go 1.27 release notes](https://go.dev/doc/go1.27#compiler). The `reflect.Value.Pointer` documentation also states that a function code pointer is not guaranteed to uniquely identify a function value.

## Test removal

`TestHandlerName_differentFuncSameName` asserted exact compiler-generated names and required two closure instances to have different names. Neither behavior is guaranteed across Go versions, so the test has been removed.

This part may need further discussion. If retaining coverage for closure handlers is preferred, the test could instead verify only version-independent behavior, such as:

- `HandlerName` returns a non-empty value for a closure.
- Repeated calls for the same handler return a stable value.

It should not assert that separate closure instances have either equal or different names.

## Verification

- `go test ./...` with Go 1.27.0
- All packages pass.