### PR TITLE
fix(middleware): prevent BodyLimit bypass via oversized Read

### DIFF
--- a/middleware/body_limit.go
+++ b/middleware/body_limit.go
@@ -24,6 +24,7 @@ type limitedReader struct {
 	BodyLimitConfig
 	reader io.ReadCloser
 	read   int64
+	err    error // sticky; once set, Read returns (0, err)
 }
 
 // BodyLimit returns a BodyLimit middleware.
@@ -81,12 +82,33 @@ func (config BodyLimitConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
 }
 
 func (r *limitedReader) Read(b []byte) (n int, err error) {
-	n, err = r.reader.Read(b)
-	r.read += int64(n)
-	if r.read > r.LimitBytes {
-		return n, echo.ErrStatusRequestEntityTooLarge
+	if r.err != nil {
+		return 0, r.err
 	}
-	return
+	if len(b) == 0 {
+		return 0, nil
+	}
+
+	remaining := r.LimitBytes - r.read
+	if remaining < 0 {
+		remaining = 0
+	}
+	// Cap at remaining+1 so a single Read cannot both exceed the limit and
+	// complete a value. The extra byte only detects overflow and is not returned.
+	if int64(len(b))-1 > remaining {
+		b = b[:remaining+1]
+	}
+
+	n, err = r.reader.Read(b)
+	if int64(n) <= remaining {
+		r.read += int64(n)
+		return n, err
+	}
+
+	n = int(remaining)
+	r.read = r.LimitBytes
+	r.err = echo.ErrStatusRequestEntityTooLarge
+	return n, r.err
 }
 
 func (r *limitedReader) Close() error {
@@ -96,4 +118,5 @@ func (r *limitedReader) Close() error {
 func (r *limitedReader) Reset(reader io.ReadCloser) {
 	r.reader = reader
 	r.read = 0
+	r.err = nil
 }

--- a/middleware/body_limit_test.go
+++ b/middleware/body_limit_test.go
@@ -5,9 +5,12 @@ package middleware
 
 import (
 	"bytes"
+	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/labstack/echo/v5"
@@ -91,6 +94,175 @@ func TestBodyLimitAfterDecompressUsesDecodedSize(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, body, rec.Body.String())
+}
+
+func TestBodyLimitOversizedReadDoesNotBypassLimit(t *testing.T) {
+	// Callers that process n>0 before treating err as fatal, as io.Reader
+	// documents, must still never receive more than LimitBytes.
+	tests := []struct {
+		name    string
+		bufSize int
+	}{
+		{name: "single oversized read", bufSize: 64},
+		{name: "one byte at a time", bufSize: 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			const limit int64 = 5
+			body := bytes.Repeat([]byte("x"), 10*int(limit))
+
+			e := echo.New()
+			var total int
+			var lastErr error
+			e.POST("/", func(c *echo.Context) error {
+				buf := make([]byte, tc.bufSize)
+				for {
+					n, err := c.Request().Body.Read(buf)
+					total += n
+					lastErr = err
+					if n == 0 {
+						break
+					}
+				}
+				return c.NoContent(http.StatusOK)
+			}, BodyLimit(limit))
+
+			req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+			req.ContentLength = -1
+			req.TransferEncoding = []string{"chunked"}
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+
+			assert.Equal(t, int(limit), total)
+			he, ok := lastErr.(echo.HTTPStatusCoder)
+			if assert.True(t, ok) {
+				assert.Equal(t, http.StatusRequestEntityTooLarge, he.StatusCode())
+			}
+		})
+	}
+}
+
+type countingReadCloser struct {
+	io.Reader
+	read  int64
+	calls int
+}
+
+func (c *countingReadCloser) Read(b []byte) (int, error) {
+	c.calls++
+	n, err := c.Reader.Read(b)
+	c.read += int64(n)
+	return n, err
+}
+
+func (c *countingReadCloser) Close() error { return nil }
+
+func TestBodyLimitDoesNotOverdrawTheSource(t *testing.T) {
+	const limit int64 = 5
+	src := &countingReadCloser{Reader: bytes.NewReader(bytes.Repeat([]byte("x"), 1<<20))}
+
+	e := echo.New()
+	var callsAtRefusal int
+	e.POST("/", func(c *echo.Context) error {
+		buf := make([]byte, 64*1024)
+		_, _ = c.Request().Body.Read(buf)
+		callsAtRefusal = src.calls
+		for i := 0; i < 5; i++ {
+			_, _ = c.Request().Body.Read(buf)
+		}
+		return c.NoContent(http.StatusOK)
+	}, BodyLimit(limit))
+
+	req := httptest.NewRequest(http.MethodPost, "/", src)
+	req.ContentLength = -1
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.LessOrEqual(t, src.read, limit+1)
+	assert.Equal(t, callsAtRefusal, src.calls)
+}
+
+func TestBodyLimitReadStaysRefused(t *testing.T) {
+	e := echo.New()
+	e.POST("/", func(c *echo.Context) error {
+		_, err := io.ReadAll(c.Request().Body)
+		he, ok := err.(echo.HTTPStatusCoder)
+		if assert.True(t, ok) {
+			assert.Equal(t, http.StatusRequestEntityTooLarge, he.StatusCode())
+		}
+
+		n, err := c.Request().Body.Read(make([]byte, 8))
+		assert.Equal(t, 0, n)
+		he, ok = err.(echo.HTTPStatusCoder)
+		if assert.True(t, ok) {
+			assert.Equal(t, http.StatusRequestEntityTooLarge, he.StatusCode())
+		}
+		return c.NoContent(http.StatusOK)
+	}, BodyLimit(2))
+
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte("Hello, World!")))
+	req.ContentLength = -1
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestBodyLimitJSONDecoderDoesNotAcceptOversizedBody(t *testing.T) {
+	const limit int64 = 16
+	payload := `{"data":"` + strings.Repeat("x", 1024) + `"}`
+
+	e := echo.New()
+	var decodeErr error
+	var got string
+	e.POST("/", func(c *echo.Context) error {
+		var v struct {
+			Data string `json:"data"`
+		}
+		decodeErr = json.NewDecoder(c.Request().Body).Decode(&v)
+		got = v.Data
+		if decodeErr != nil {
+			return decodeErr
+		}
+		return c.NoContent(http.StatusOK)
+	}, BodyLimit(limit))
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(payload))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	req.ContentLength = -1
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.NotEqual(t, strings.Repeat("x", 1024), got)
+	var he echo.HTTPStatusCoder
+	if assert.True(t, errors.As(decodeErr, &he), "decode error: %v", decodeErr) {
+		assert.Equal(t, http.StatusRequestEntityTooLarge, he.StatusCode())
+	}
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+}
+
+func TestBodyLimitResetAfterOversizeRequest(t *testing.T) {
+	e := echo.New()
+	e.POST("/", func(c *echo.Context) error {
+		b, err := io.ReadAll(c.Request().Body)
+		if err != nil {
+			return err
+		}
+		return c.String(http.StatusOK, string(b))
+	}, BodyLimit(5))
+
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(bytes.Repeat([]byte("x"), 20)))
+	req.ContentLength = -1
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+
+	req = httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte("hello")))
+	req.ContentLength = -1
+	rec = httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "hello", rec.Body.String())
 }
 
 func TestBodyLimitReader(t *testing.T) {


### PR DESCRIPTION
## Summary

`middleware.BodyLimit` could be bypassed when a caller processed `n > 0` bytes before treating the returned error as fatal, which is the documented `io.Reader` contract. `limitedReader.Read` forwarded the caller's buffer unbounded, checked the cumulative count only after the read, and kept returning more real data on later calls once the limit had already been crossed.

A 5-byte limit against a 50-byte body therefore delivered all 50 bytes. The same pattern is used by `encoding/json.Decoder`, so an oversized JSON body could be fully consumed instead of failing with 413.

## Related Issue (Fixes #3071)

Fixes #3071

## Changes Made

`limitedReader.Read` now follows `net/http.MaxBytesReader`:

- Cap each underlying read at `remaining+1` bytes so a single `Read` cannot both exceed the limit and complete a value.
- Do not deliver the overflow byte to the caller; at most `LimitBytes` are ever returned.
- Once the limit is exceeded, subsequent `Read` calls return `(0, echo.ErrStatusRequestEntityTooLarge)` and do not touch the source again.
- Reset the sticky error in `Reset` so pooled readers do not leak a 413 into the next request.

## Testing

- `gofmt` on the changed files
- `go test ./middleware/` (package tests, including `-race`)

New tests go through the shipped `BodyLimit` middleware via `e.POST(..., BodyLimit(...))` and `ServeHTTP`, not by constructing `limitedReader` directly:

- Issue reproduction: process `n > 0` before `err`, with a 64-byte buffer (single oversized `Read`) and a 1-byte buffer (assemble-after-error).
- Source overdraw: a 64 KiB `Read` against a 5-byte limit pulls at most 6 bytes from the wire, and later calls do not touch the source.
- Sticky refusal after `io.ReadAll`.
- `json.NewDecoder` must not accept an oversized JSON body.
- A later in-limit request still succeeds after an oversize one (pool `Reset`).

Existing `BodyLimit` tests are unchanged and pass.

## Notes

The Content-Length fast path is unchanged. These tests force `ContentLength = -1` so they exercise the content-read path used for chunked (or otherwise unknown-length) bodies, matching the report in #3071.