### PR TITLE
refactor(middleware): clamp remaining tokens with max

### DIFF
--- a/middleware/rate_limiter.go
+++ b/middleware/rate_limiter.go
@@ -288,10 +288,7 @@ func (store *RateLimiterMemoryStore) setRateLimitHeaders(c *echo.Context, limite
 	header := c.Response().Header()
 	header.Set(HeaderXRateLimitLimit, strconv.Itoa(store.burst))
 
-	remaining := int(math.Floor(limiter.Tokens()))
-	if remaining < 0 {
-		remaining = 0
-	}
+	remaining := max(int(math.Floor(limiter.Tokens())), 0)
 	header.Set(HeaderXRateLimitRemaining, strconv.Itoa(remaining))
 
 	if !allowed {


### PR DESCRIPTION
RateLimiterMemoryStore clamps the floored token count before writing X-RateLimit-Remaining. 

Use the built-in max function for the lower bound, preserving the existing zero-floor behavior with less branching.