### PR TITLE
[Archeo] Erros em operações de setup devem ser explicitamente verificados e reportados

### DIFF
--- a/router_concurrent_test.go
+++ b/router_concurrent_test.go
@@ -95,8 +95,14 @@ func TestConcurrentRouter_ConcurrentReads(t *testing.T) {
 func TestConcurrentRouter_ConcurrentWrites(t *testing.T) {
 	router := NewConcurrentRouter(NewRouter(RouterConfig{}))
 
-	_, _ = router.Add(Route{Method: http.MethodGet, Path: "/initial1", Handler: handlerFunc})
-	_, _ = router.Add(Route{Method: http.MethodGet, Path: "/initial2", Handler: handlerFunc})
+	_, err := router.Add(Route{Method: http.MethodGet, Path: "/initial1", Handler: handlerFunc})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = router.Add(Route{Method: http.MethodGet, Path: "/initial2", Handler: handlerFunc})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Launch 5 goroutines, each adds 10 unique routes
 	var wg sync.WaitGroup


### PR DESCRIPTION
Correção autônoma para a issue #10803.

Linha 98 descarta erros com `_, _ = router.Add(...)` sem verificação ou logging. Embora seja um teste, erros silenciosos podem mascarar problemas de setup que afetam a validade do teste.