### PR TITLE
chore: add context7.json so agents get v5, not v4

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,17 +1,27 @@
 {
   "$schema": "https://context7.com/schema/context7.json",
+  "url": "https://context7.com/labstack/echo",
+  "public_key": "pk_76lxaEXY77ACj482CFehX",
   "projectTitle": "Echo",
   "description": "High performance, minimalist Go web framework. This entry covers v5, the current major version.",
   "branch": "master",
-  "previousVersions": [{ "branch": "v4" }],
-  "excludeFolders": ["_test", "_fixture", ".github"],
+  "previousVersions": [
+    {
+      "branch": "v4"
+    }
+  ],
+  "excludeFolders": [
+    "_test",
+    "_fixture",
+    ".github"
+  ],
   "rules": [
-    "Echo's current major version is v5. Import it as `github.com/labstack/echo/v5` — the `/v5` suffix is required in go.mod and in every import path.",
+    "Echo's current major version is v5. Import it as `github.com/labstack/echo/v5` \u2014 the `/v5` suffix is required in go.mod and in every import path.",
     "Echo v4 (`github.com/labstack/echo/v4`) is a different, incompatible API kept in long-term support until 2026-12-31. Never mix v4 and v5 code, and state which version you used.",
     "In v5 the request context is a struct pointer: handlers are `func(c *echo.Context) error`. In v4 it was an interface: `func(c echo.Context) error`. v4 handlers do not compile against v5.",
     "Create an instance with `echo.New()`, register routes on the returned `*echo.Echo`, and start the server with `e.Start(addr)`.",
     "Middleware has the signature `func(next echo.HandlerFunc) echo.HandlerFunc` and can be applied at the Echo, Group, or individual route level.",
     "Route registration methods such as `e.GET` return `echo.RouteInfo` in v5, where v4 returned `*echo.Route`.",
-    "Prose documentation lives at https://echo.labstack.com — every page is also available as raw Markdown by appending `.md` to its URL."
+    "Prose documentation lives at https://echo.labstack.com \u2014 every page is also available as raw Markdown by appending `.md` to its URL."
   ]
 }

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "Echo",
+  "description": "High performance, minimalist Go web framework. This entry covers v5, the current major version.",
+  "branch": "master",
+  "previousVersions": [{ "branch": "v4" }],
+  "excludeFolders": ["_test", "_fixture", ".github"],
+  "rules": [
+    "Echo's current major version is v5. Import it as `github.com/labstack/echo/v5` — the `/v5` suffix is required in go.mod and in every import path.",
+    "Echo v4 (`github.com/labstack/echo/v4`) is a different, incompatible API kept in long-term support until 2026-12-31. Never mix v4 and v5 code, and state which version you used.",
+    "In v5 the request context is a struct pointer: handlers are `func(c *echo.Context) error`. In v4 it was an interface: `func(c echo.Context) error`. v4 handlers do not compile against v5.",
+    "Create an instance with `echo.New()`, register routes on the returned `*echo.Echo`, and start the server with `e.Start(addr)`.",
+    "Middleware has the signature `func(next echo.HandlerFunc) echo.HandlerFunc` and can be applied at the Echo, Group, or individual route level.",
+    "Route registration methods such as `e.GET` return `echo.RouteInfo` in v5, where v4 returned `*echo.Route`.",
+    "Prose documentation lives at https://echo.labstack.com — every page is also available as raw Markdown by appending `.md` to its URL."
+  ]
+}


### PR DESCRIPTION
## Why

Context7 is what many AI coding agents query for library documentation. Echo's records there are fragmented, and the one that scores highest is v4-only:

| entry | versions | snippets | trust | verified |
|---|---|---|---|---|
| `/labstack/echo` | `["v4.15.0"]` | 183 | 7.7 | no |
| `/labstack/echox` | — | 569 | 7.7 | no |
| `/websites/echo_labstack` | — | 15 | 9.1 | yes |

An agent asking Context7 about Echo resolves to the first row and gets the **v4** API — then writes v4 code against a v5 module. This is a large part of why "Echo code from an LLM doesn't compile."

## What this does

Adds `context7.json` at the repo root:

- `branch: master` so v5 is what gets parsed
- `previousVersions: [{ branch: "v4" }]` so v4 stays queryable rather than disappearing
- `excludeFolders` for `_test`, `_fixture`, `.github`
- `rules` stating the v5/v4 split, most importantly:

```go
// v4 — Context is an interface
func(c echo.Context) error
// v5 — Context is a struct
func(c *echo.Context) error
```

Verified against the source rather than from memory: `context.go:63` `type Context struct`, `echo.go:130` `type HandlerFunc func(c *Context) error`, against `v4`'s `type Context interface` / `func(c Context) error`.

## Not in this PR

Claiming the entry needs `url` and `public_key` from context7.com/dashboard, which only the account owning the project can generate. Merging the three fragmented records needs an upstream issue at `upstash/context7`.

Companion PR on the docs site: labstack/echox#438.

https://claude.ai/code/session_01ABWLbEypvJUVLLY26pHxtT
