### PR TITLE
fix(rfc9457): do not mutate a shared ProblemError

### DIFF
--- a/rfc9457.go
+++ b/rfc9457.go
@@ -104,23 +104,27 @@ func ProblemDetailsHTTPErrorHandler(exposeError bool) HTTPErrorHandler {
 			}
 		}
 
-		if pe.Status == 0 {
-			pe.Status = http.StatusInternalServerError
+		// The problem can be a value the application reuses, for example a package
+		// level sentinel error, so the defaults are applied to a copy. Writing them
+		// back would race between requests and would permanently alter the error.
+		problem := *pe
+		if problem.Status == 0 {
+			problem.Status = http.StatusInternalServerError
 		}
-		if pe.Type == "" {
-			pe.Type = "about:blank"
+		if problem.Type == "" {
+			problem.Type = "about:blank"
 		}
-		if pe.Title == "" {
-			pe.Title = http.StatusText(pe.Status)
+		if problem.Title == "" {
+			problem.Title = http.StatusText(problem.Status)
 		}
 
 		c.Response().Header().Set(HeaderContentType, MIMEApplicationProblemJSON)
 
 		var cErr error
 		if c.Request().Method == http.MethodHead { // Issue #608
-			cErr = c.NoContent(pe.Status)
+			cErr = c.NoContent(problem.Status)
 		} else {
-			cErr = c.JSON(pe.Status, pe)
+			cErr = c.JSON(problem.Status, &problem)
 		}
 		if cErr != nil {
 			c.Logger().Error("echo RFC 9457 error handler failed to send error to client", "error", cErr) // truly rare case. ala client already disconnected

--- a/rfc9457_test.go
+++ b/rfc9457_test.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -187,29 +186,19 @@ func TestProblemError_StatusCode(t *testing.T) {
 
 func TestProblemDetailsHTTPErrorHandler_DoesNotMutateSharedProblem(t *testing.T) {
 	// A package level sentinel is the idiomatic way to express a reusable error,
-	// so serving one must neither race nor leave the value altered.
+	// so serving one must not leave the value altered.
 	sentinel := &ProblemError{Status: http.StatusNotFound, Detail: "no such widget"}
+	original := *sentinel
 
 	e := New()
 	e.Logger = slog.New(slog.DiscardHandler)
 	e.Any("/path", func(c *Context) error { return sentinel })
 	e.HTTPErrorHandler = ProblemDetailsHTTPErrorHandler(false)
 
-	var wg sync.WaitGroup
-	for i := 0; i < 50; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			rec := httptest.NewRecorder()
-			e.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/path", nil))
-			assert.Equal(t, http.StatusNotFound, rec.Code)
-			assert.Equal(t, `{"type":"about:blank","title":"Not Found","status":404,"detail":"no such widget"}`+"\n", rec.Body.String())
-		}()
-	}
-	wg.Wait()
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/path", nil))
 
-	assert.Equal(t, "", sentinel.Type)
-	assert.Equal(t, "", sentinel.Title)
-	assert.Equal(t, http.StatusNotFound, sentinel.Status)
-	assert.Equal(t, "no such widget", sentinel.Detail)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Equal(t, `{"type":"about:blank","title":"Not Found","status":404,"detail":"no such widget"}`+"\n", rec.Body.String())
+	assert.Equal(t, original, *sentinel)
 }

--- a/rfc9457_test.go
+++ b/rfc9457_test.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -182,4 +183,33 @@ func TestProblemError_Error(t *testing.T) {
 func TestProblemError_StatusCode(t *testing.T) {
 	pe := &ProblemError{Status: http.StatusTeapot}
 	assert.Equal(t, http.StatusTeapot, pe.StatusCode())
+}
+
+func TestProblemDetailsHTTPErrorHandler_DoesNotMutateSharedProblem(t *testing.T) {
+	// A package level sentinel is the idiomatic way to express a reusable error,
+	// so serving one must neither race nor leave the value altered.
+	sentinel := &ProblemError{Status: http.StatusNotFound, Detail: "no such widget"}
+
+	e := New()
+	e.Logger = slog.New(slog.DiscardHandler)
+	e.Any("/path", func(c *Context) error { return sentinel })
+	e.HTTPErrorHandler = ProblemDetailsHTTPErrorHandler(false)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/path", nil))
+			assert.Equal(t, http.StatusNotFound, rec.Code)
+			assert.Equal(t, `{"type":"about:blank","title":"Not Found","status":404,"detail":"no such widget"}`+"\n", rec.Body.String())
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, "", sentinel.Type)
+	assert.Equal(t, "", sentinel.Title)
+	assert.Equal(t, http.StatusNotFound, sentinel.Status)
+	assert.Equal(t, "no such widget", sentinel.Detail)
 }


### PR DESCRIPTION
## Problem

`ProblemDetailsHTTPErrorHandler` fills in the zero-valued `Type`, `Title` and `Status` fields by writing them back into the `*ProblemError` it was handed:

```go
if pe.Status == 0 {
    pe.Status = http.StatusInternalServerError
}
if pe.Type == "" {
    pe.Type = "about:blank"
}
if pe.Title == "" {
    pe.Title = http.StatusText(pe.Status)
}
```

`pe` comes from `errors.As`, so it points at whatever value the application returned. Returning a package level sentinel is the idiomatic way to express a reusable error, and the same pointer then reaches the handler on every request that returns it:

```go
var ErrWidgetNotFound = &echo.ProblemError{Status: http.StatusNotFound, Detail: "no such widget"}

func handler(c *echo.Context) error {
    return ErrWidgetNotFound
}
```

Two things go wrong. Concurrent requests write to the same struct, which the race detector reports:

```
WARNING: DATA RACE
Write at 0x... by goroutine 10:
Previous read at 0x... by goroutine 33:
```

And the write is permanent. After the first request the sentinel is no longer the value the application declared; `Type` has become `"about:blank"` and `Title` has become `"Not Found"`. An application that later inspects or re-serializes its own error sees fields it never set.

The `ProblemErrorer` path has the same shape whenever `ProblemError()` returns a shared pointer.

## The change

The defaults are applied to a copy, so the response is unchanged and the caller's value is left alone. Nothing else about the handler moves.

## Testing

`TestProblemDetailsHTTPErrorHandler_DoesNotMutateSharedProblem` serves one request that returns a sentinel, checks the response still carries the fully defaulted body, and then compares the sentinel with a copy taken before the request.

Against the current code it fails on the mutation:

```
expected: echo.ProblemError{Type:"", Title:"", Status:404, Detail:"no such widget", Instance:""}
actual  : echo.ProblemError{Type:"about:blank", Title:"Not Found", Status:404, Detail:"no such widget", Instance:""}
```

With this change `go test -race ./...` is clean across all three packages.
